### PR TITLE
Version 3.4.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,9 +2,9 @@
 
 ## Version  3.4.0
 
-* Adding HDR10+ support for x265
+* Adding #83 HDR10+ support for x265 (thanks to SlashX)
 * Adding x265 params hdr10, hdr10-opt, aq-mode and repeat-headers
-* Adding basic splash info for some events
+* Adding basic splash info and waiting cursor for events
 * Changing that autocrop will test two spots if possible (thanks to HannesJo0139)
 * Changing covers generated in their own temp directory
 * Fixing #103 x265-params were being pre-pended with an extra ":" (thanks to Zeid164)

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,9 @@
 
 * Adding HDR10+ support for x265
 * Adding x265 params hdr10, hdr10-opt, aq-mode and repeat-headers
-* Fixing #103 x265-params were being pre-pended with an extra ":"
+* Adding basic splash info for some events
+* Changing that autocrop will test two spots if possible (thanks to HannesJo0139)
+* Fixing #103 x265-params were being pre-pended with an extra ":" (thanks to Zeid164)
 * Fixing #101 FFmpeg status codes now taken into account for errors
 
 ## Version  3.3.1

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 * Adding #83 HDR10+ support for x265 (thanks to SlashX)
 * Adding x265 params hdr10, hdr10-opt, aq-mode and repeat-headers
 * Adding basic splash info and waiting cursor for events
+* Adding button to open config file from setting panel
 * Changing that autocrop will test two spots if possible (thanks to HannesJo0139)
 * Changing covers generated in their own temp directory
 * Fixing #103 x265-params were being pre-pended with an extra ":" (thanks to Zeid164)

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version  3.4.0
+
+* Adding HDR10+ support for x265
+* Adding x265 params hdr10, hdr10-opt, aq-mode and repeat-headers
+* Fixing #103 x265-params were being pre-pended with an extra ":"
+* Fixing #101 FFmpeg status codes now taken into account for errors
+
 ## Version  3.3.1
 
 * Fixing #96 input selection did not support all video formats

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 * Adding x265 params hdr10, hdr10-opt, aq-mode and repeat-headers
 * Adding basic splash info for some events
 * Changing that autocrop will test two spots if possible (thanks to HannesJo0139)
+* Changing covers generated in their own temp directory
 * Fixing #103 x265-params were being pre-pended with an extra ":" (thanks to Zeid164)
 * Fixing #101 FFmpeg status codes now taken into account for errors
 

--- a/fastflix/encoders/common/setting_panel.py
+++ b/fastflix/encoders/common/setting_panel.py
@@ -78,6 +78,30 @@ class SettingPanel(QtWidgets.QWidget):
         layout.addWidget(self.ffmpeg_extras_widget)
         return layout
 
+    def _add_file_select(self, label, widget_name, button_action, connect="default", enabled=True, tooltip=""):
+        layout = QtWidgets.QHBoxLayout()
+        self.labels[widget_name] = QtWidgets.QLabel(label)
+        self.labels[widget_name].setToolTip(tooltip)
+
+        self.widgets[widget_name] = QtWidgets.QLineEdit()
+        self.widgets[widget_name].setDisabled(not enabled)
+
+        if connect:
+            if connect == "default":
+                self.widgets[widget_name].textChanged.connect(lambda: self.main.page_update())
+            elif connect == "self":
+                self.widgets[widget_name].textChanged.connect(lambda: self.page_update())
+            else:
+                self.widgets[widget_name].textChanged.connect(connect)
+
+        button = QtWidgets.QPushButton(icon=self.style().standardIcon(QtWidgets.QStyle.SP_FileDialogContentsView))
+        button.clicked.connect(button_action)
+
+        layout.addWidget(self.labels[widget_name])
+        layout.addWidget(self.widgets[widget_name])
+        layout.addWidget(button)
+        return layout
+
     def _add_remove_hdr(self, connect="default"):
         return self._add_combo_box(
             label="Remove HDR",

--- a/fastflix/encoders/hevc_x265/settings_panel.py
+++ b/fastflix/encoders/hevc_x265/settings_panel.py
@@ -101,7 +101,6 @@ class HEVC(SettingPanel):
                 " Default disabled."
             ),
             checked=True,
-            connect=lambda: self.setting_change(),
         )
 
     def init_hdr10_opt(self):
@@ -113,7 +112,6 @@ class HEVC(SettingPanel):
                 "It is recommended that AQ-mode be enabled along with this feature"
             ),
             checked=False,
-            connect=lambda: self.setting_change(),
         )
 
     def init_repeat_headers(self):
@@ -334,8 +332,8 @@ class HEVC(SettingPanel):
                 self.widgets.hdr10.setDisabled(False)
                 self.widgets.hdr10.setChecked(True)
                 self.widgets.hdr10_opt.setDisabled(False)
-            self.updating_settings = False
             self.main.page_update()
+            self.updating_settings = False
             return
 
         remove_hdr = self.widgets.remove_hdr.currentIndex()

--- a/fastflix/flix.py
+++ b/fastflix/flix.py
@@ -132,18 +132,17 @@ class Flix:
         except TimeoutExpired:
             logger.warning(f"WARNING Timeout while extracting cover file {file_name}")
 
-    def parse(self, file, work_dir=None, extract_covers=False):
+    def parse(self, file, temp_dir=None, extract_covers=False):
         data = self.probe(file)
         if "streams" not in data:
             raise FlixError("Not a video file")
         streams = Box({"video": [], "audio": [], "subtitle": [], "attachment": [], "data": []})
-
         covers = []
         for track in data.streams:
             if track.codec_type == "video" and track.get("disposition", {}).get("attached_pic"):
                 filename = track.get("tags", {}).get("filename", "")
                 if filename.rsplit(".", 1)[0] in ("cover", "small_cover", "cover_land", "small_cover_land"):
-                    covers.append((file, track.index, work_dir, filename))
+                    covers.append((file, track.index, temp_dir, filename))
                 streams.attachment.append(track)
             elif track.codec_type in streams:
                 streams[track.codec_type].append(track)

--- a/fastflix/flix.py
+++ b/fastflix/flix.py
@@ -203,13 +203,11 @@ class Flix:
         for line in output.stderr.decode("utf-8").splitlines():
             if line.startswith("[Parsed_cropdetect"):
                 w, h, x, y = [int(x) for x in line.rsplit("=")[1].split(":")]
-                if not width or (width and w < width):
+                if (not x_crop or (x_crop and x > x_crop)) and (not width or (width and w < width)):
                     width = w
-                if not height or (height and h < height):
-                    height = h
-                if not x_crop or (x_crop and x > x_crop):
                     x_crop = x
-                if not y_crop or (y_crop and y > y_crop):
+                if (not height or (height and h < height)) and (not y_crop or (y_crop and y > y_crop)):
+                    height = h
                     y_crop = y
 
         if None in (width, height, x_crop, y_crop):

--- a/fastflix/gui.py
+++ b/fastflix/gui.py
@@ -115,12 +115,13 @@ def main():
         except Empty:
             if not runner.is_alive() and not sent_response and not queued_requests:
                 ret = runner.process.poll()
-                if ret > 0:
+                if ret > 0 or runner.error_detected:
                     log(f"Error during conversion", logging.WARNING)
+                    status_queue.put("error")
                 else:
                     log("conversion complete")
+                    status_queue.put("complete")
                 reusables.remove_file_handlers(logger)
-                status_queue.put("complete")
                 sent_response = True
 
                 if not gui_proc.is_alive():

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "3.3.1"
+__version__ = "3.4.0"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/command_runner.py
+++ b/fastflix/widgets/command_runner.py
@@ -23,6 +23,7 @@ class BackgroundRunner:
         self.output_file = None
         self.error_output_file = None
         self.log_queue = log_queue
+        self.error_detected = False
 
     def start_exec(self, command, work_dir, shell=False):
         logger.info(f"Running command: {command}")
@@ -38,6 +39,7 @@ class BackgroundRunner:
             stdin=PIPE,  # FFmpeg can try to read stdin and wrecks havoc on linux
             encoding="utf-8",
         )
+        self.error_detected = False
 
         Thread(target=self.read_output).start()
 
@@ -64,6 +66,8 @@ class BackgroundRunner:
                 if err_line:
                     logger.info(err_line)
                     self.log_queue.put(err_line)
+                    if "Conversion failed!" in err_line:
+                        self.error_detected = True
         try:
             self.output_file.unlink()
             self.error_output_file.unlink()

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -599,7 +599,7 @@ class Main(QtWidgets.QWidget):
             self,
             caption="Open Video",
             filter="Video Files (*.mkv *.mp4 *.m4v *.mov *.avi *.divx *.webm *.mpg *.mp2 *.mpeg *.mpe *.mpv *.ogg *.m4p"
-            " *.wmv *.mov *.qt *.flv *.hevc *.gif *.vob *.ogv *.ts *.mts *.m2ts *.yuv *.rm *.svi *.3gp *.3g2)",
+            " *.wmv *.mov *.qt *.flv *.hevc *.gif *.webp *.vob *.ogv *.ts *.mts *.m2ts *.yuv *.rm *.svi *.3gp *.3g2)",
         )
         if not filename or not filename[0]:
             return
@@ -1268,6 +1268,8 @@ class Notifier(QtCore.QThread):
             status = self.status_queue.get()
             if status == "complete":
                 self.app.completed.emit(0)
+            if status == "error":
+                self.app.completed.emit(1)
             elif status == "cancelled":
                 self.app.cancelled.emit()
             elif status == "exit":

--- a/fastflix/widgets/panels/cover_panel.py
+++ b/fastflix/widgets/panels/cover_panel.py
@@ -185,7 +185,7 @@ class CoverPanel(QtWidgets.QWidget):
         if attr:
             cover_image = attr.text()
         if getattr(self, f"{filename}_passthrough_checkbox").isChecked():
-            cover_image = str(Path(self.main.path.work) / self.attachments[filename].name)
+            cover_image = str(Path(self.main.path.temp_dir) / self.attachments[filename].name)
         if cover_image:
             mime_type, ext_type = self.image_type(cover_image)
             return (
@@ -213,7 +213,7 @@ class CoverPanel(QtWidgets.QWidget):
         if checked:
             self.cover_path.setDisabled(True)
             self.cover_button.setDisabled(True)
-            pixmap = QtGui.QPixmap(str(Path(self.main.path.work) / self.attachments.cover.name))
+            pixmap = QtGui.QPixmap(str(Path(self.main.path.temp_dir) / self.attachments.cover.name))
             pixmap = pixmap.scaled(230, 230, QtCore.Qt.KeepAspectRatio)
             self.poster.setPixmap(pixmap)
         else:
@@ -236,7 +236,7 @@ class CoverPanel(QtWidgets.QWidget):
         if checked:
             self.cover_land.setDisabled(True)
             self.landscape_button.setDisabled(True)
-            pixmap = QtGui.QPixmap(str(Path(self.main.path.work) / self.attachments.cover_land.name))
+            pixmap = QtGui.QPixmap(str(Path(self.main.path.temp_dir) / self.attachments.cover_land.name))
             pixmap = pixmap.scaled(230, 230, QtCore.Qt.KeepAspectRatio)
             self.landscape.setPixmap(pixmap)
         else:
@@ -285,7 +285,7 @@ class CoverPanel(QtWidgets.QWidget):
         for attachment in attachments:
             filename = attachment.get("tags", {}).get("filename", "")
             base_name = filename.rsplit(".", 1)[0]
-            file_path = Path(self.main.path.work) / filename
+            file_path = Path(self.main.path.temp_dir) / filename
             if base_name == "cover" and file_path.exists():
                 self.cover_passthrough_checkbox.setChecked(True)
                 self.cover_passthrough_checkbox.setDisabled(False)

--- a/fastflix/widgets/settings.py
+++ b/fastflix/widgets/settings.py
@@ -48,6 +48,12 @@ class Settings(QtWidgets.QWidget):
         layout.addWidget(QtWidgets.QLabel("Config File"), 4, 0)
         layout.addWidget(QtWidgets.QLabel(str(self.config_file)), 4, 1)
 
+        config_button = QtWidgets.QPushButton(icon=self.style().standardIcon(QtWidgets.QStyle.SP_FileIcon))
+        config_button.pressed.connect(
+            lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl.fromLocalFile(str(self.config_file)))
+        )
+        layout.addWidget(config_button, 4, 2)
+
         save = QtWidgets.QPushButton(icon=self.style().standardIcon(QtWidgets.QStyle.SP_DialogApplyButton), text="Save")
         save.clicked.connect(lambda: self.save())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastflix"
-version = "3.3.1"
+version = "3.4.0"
 description = "Easy to use video encoder GUI"
 authors = ["Chris Griffith <chris@cdgriffith.com>"]
 license = "MIT"


### PR DESCRIPTION
* Adding #83 HDR10+ support for x265 (thanks to SlashX)
* Adding x265 params hdr10, hdr10-opt, aq-mode and repeat-headers
* Adding basic splash info and waiting cursor for events
* Adding button to open config file from setting panel
* Changing that autocrop will test two spots if possible (thanks to HannesJo0139)
* Changing covers generated in their own temp directory
* Fixing #103 x265-params were being pre-pended with an extra ":" (thanks to Zeid164)
* Fixing #101 FFmpeg status codes now taken into account for errors