### PR TITLE
Version  3.4.2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 * Fixing color space details being passed correctly to everything other than x265 as well
 * Fixing HDR10+ details on README
 * Fixing #102 better with taking into account master-display ratios (thanks to leonardyan)
+* Fixing VP9 to accept profiles so HDR10 can be copied properly
 
 ## Version  3.4.1
 

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 * Fixing HDR10+ details on README
 * Fixing #102 better with taking into account master-display ratios (thanks to leonardyan)
 * Fixing VP9 to accept profiles so HDR10 can be copied properly
+* Fixing #108 HEVC can select wrong video track for encoding (thanks to Zeid164)
 
 ## Version  3.4.1
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version  3.4.2
+
+* Fixing color space details being passed correctly to everything other than x265 as well
+* Fixing HDR10+ details on README
+* Fixing #102 better with taking into account master-display ratios (thanks to leonardyan)
+
 ## Version  3.4.1
 
 * Fixing #102 color space and HDR details not parsed from webm correctly (thanks to leonardyan)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ On any 10-bit or higher video output, FastFlix will copy the input HDR colorspac
 
 ## HDR10
 
-FastFlix was created to easily extract / copy HDR10 data, but as of sept 2020, only x265 supports copying that data through FFmpeg, no AV1 library does.
+FastFlix was created to easily extract / copy HDR10 data, but as of sept 2020, only x265 and VP9 support copying that data through FFmpeg, no AV1 library does.
 
 * rav1e -  can set mastering data and CLL via their CLI but [not through ffmpeg](https://github.com/xiph/rav1e/issues/2554).
 * SVT AV1 - accepts a "--enable-hdr" flag that is [not well documented](https://github.com/AOMediaCodec/SVT-AV1/blob/master/Docs/svt-av1_encoder_user_guide.md), not supported through FFmpeg.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ On any 10-bit or higher video output, FastFlix will copy the input HDR colorspac
 
 ## HDR10
 
-FastFlix was created to easily extract / copy HDR10 data, but as of sept 2020, only x265 and VP9 support copying that data through FFmpeg, no AV1 library does.
+FastFlix was created to easily extract / copy HDR10 data, but as of sept 2020, only x265 support copying that data through FFmpeg, no AV1 library does.
+
+VP9 has limited support to copy some existing HDR10 metadata, usually from other VP9 files. Will have the line "Mastering Display Metadata, has_primaries:1 has_luminance:1 ..." when it works.
 
 * rav1e -  can set mastering data and CLL via their CLI but [not through ffmpeg](https://github.com/xiph/rav1e/issues/2554).
 * SVT AV1 - accepts a "--enable-hdr" flag that is [not well documented](https://github.com/AOMediaCodec/SVT-AV1/blob/master/Docs/svt-av1_encoder_user_guide.md), not supported through FFmpeg.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Check out [the FastFlix github wiki](https://github.com/cdgriffith/FastFlix/wiki
 * WEBP (libwebp) &nbsp;&nbsp;&nbsp;<img src="./fastflix/data/encoders/icon_webp.png" height="30" alt="vpg" >
 * GIF (gif) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <img src="./fastflix/data/encoders/icon_gif.png" height="30" alt="gif" >
 
-Most builds do not have all these encoders available by default and may require custom compiling FFmpeg for a specific encoder.
+All of these are currently supported by [BtbN's Windows FFmpeg builds](https://github.com/BtbN/FFmpeg-Builds) which is the default FFmpeg downloaded.
 
-* [Window FFmpeg (and more) auto builder](https://github.com/m-ab-s/media-autobuild_suite)
+Most other builds do not have all these encoders available by default and may require custom compiling FFmpeg for a specific encoder.
+
+* [Windows FFmpeg (and more) auto builder](https://github.com/m-ab-s/media-autobuild_suite)
 * [Windows cross compile FFmpeg (build on linux)](https://github.com/rdp/ffmpeg-windows-build-helpers)
 * [FFmpeg compilation guide](https://trac.ffmpeg.org/wiki/CompilationGuide)
 
@@ -77,7 +79,9 @@ FastFlix was created to easily extract / copy HDR10 data, but as of sept 2020, o
 
 ## HDR10+
 
-FastFlix does not currently support copying HDR10+ metadata, but is a planned feature for x265.
+FastFlix supports using generated or [extracted JSON HDR10+ Metadata](https://github.com/cdgriffith/FastFlix/wiki/HDR10-Plus-Metadata-Extraction) with HEVC encodes via x265. However that is highly
+dependant on a FFmpeg version that has been compiled with x265 that has HDR10+ support. [BtbN's Windows FFmpeg builds](https://github.com/BtbN/FFmpeg-Builds) 
+have this support as of 10/23/2020 and may require a [manual upgrade](https://github.com/cdgriffith/FastFlix/wiki/Updating-FFmpeg).
 
 ## Dolby Vision
 

--- a/fastflix/encoders/av1_aom/command_builder.py
+++ b/fastflix/encoders/av1_aom/command_builder.py
@@ -14,6 +14,8 @@ def build(
     ffmpeg,
     temp_dir,
     output_video,
+    streams,
+    stream_track,
     bitrate=None,
     crf=None,
     audio_tracks=(),
@@ -56,7 +58,9 @@ def build(
 
     if not disable_hdr and pix_fmt in ("yuv420p10le", "yuv420p12le"):
 
-        if side_data and side_data.get("color_primaries") == "bt2020":
+        if streams.video[stream_track].get("color_primaries") == "bt2020" or (
+            side_data and side_data.get("color_primaries") == "bt2020"
+        ):
             beginning += "-color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc"
 
     beginning = re.sub("[ ]+", " ", beginning)

--- a/fastflix/encoders/hevc_x265/command_builder.py
+++ b/fastflix/encoders/hevc_x265/command_builder.py
@@ -70,7 +70,7 @@ def build(
     if not disable_hdr and pix_fmt in ("yuv420p10le", "yuv420p12le"):
         x265_params.append(f"hdr10_opt={'1' if hdr10_opt else '0'}")
 
-        if streams.video[video_track].get("color_primaries") == "bt2020" or (
+        if streams.video[stream_track].get("color_primaries") == "bt2020" or (
             side_data and side_data.get("color_primaries") == "bt2020"
         ):
             x265_params.extend(

--- a/fastflix/encoders/rav1e/command_builder.py
+++ b/fastflix/encoders/rav1e/command_builder.py
@@ -29,6 +29,8 @@ def build(
     ffmpeg,
     temp_dir,
     output_video,
+    streams,
+    stream_track,
     tiles=0,
     tile_columns=0,
     tile_rows=0,
@@ -73,7 +75,9 @@ def build(
 
     if not disable_hdr and pix_fmt in ("yuv420p10le", "yuv420p12le"):
 
-        if side_data and side_data.get("color_primaries") == "bt2020":
+        if streams.video[stream_track].get("color_primaries") == "bt2020" or (
+            side_data and side_data.get("color_primaries") == "bt2020"
+        ):
             beginning += "-color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc"
 
         # Currently unsupported https://github.com/xiph/rav1e/issues/2554

--- a/fastflix/encoders/svt_av1/command_builder.py
+++ b/fastflix/encoders/svt_av1/command_builder.py
@@ -29,6 +29,8 @@ def build(
     ffmpeg,
     temp_dir,
     output_video,
+    streams,
+    stream_track,
     tier="main",
     tile_columns=0,
     tile_rows=0,
@@ -75,7 +77,9 @@ def build(
 
     if not disable_hdr and pix_fmt in ("yuv420p10le", "yuv420p12le"):
 
-        if side_data and side_data.get("color_primaries") == "bt2020":
+        if streams.video[stream_track].get("color_primaries") == "bt2020" or (
+            side_data and side_data.get("color_primaries") == "bt2020"
+        ):
             beginning += "-color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc"
 
     beginning = re.sub("[ ]+", " ", beginning)

--- a/fastflix/encoders/vp9/command_builder.py
+++ b/fastflix/encoders/vp9/command_builder.py
@@ -26,7 +26,7 @@ def build(
     row_mt=0,
     pix_fmt="yuv420p10le",
     attachments="",
-    profile="main",
+    profile=1,
     disable_hdr=False,
     side_data=None,
     **kwargs,
@@ -60,16 +60,15 @@ def build(
 
     beginning = re.sub("[ ]+", " ", beginning)
 
+    details = f"-quality {quality} -speed {speed} -profile {profile}"
+
     if bitrate:
-        command_1 = f"{beginning} -b:v {bitrate} -quality {quality} -speed {speed} -profile {profile} -pass 1 -an -f webm {null}"
-        command_2 = f"{beginning} -b:v {bitrate} -quality {quality} -speed {speed} -profile {profile} -pass 2" + ending
+        command_1 = f"{beginning} -b:v {bitrate} {details} -pass 1 -an -f webm {null}"
+        command_2 = f"{beginning} -b:v {bitrate} {details} -pass 2" + ending
 
     elif crf:
-        command_1 = f"{beginning} -b:v 0 -crf {crf} -quality {quality} -speed {speed} -profile {profile} -pass 1 -an -f webm {null}"
-        command_2 = (
-            f"{beginning} -b:v 0 -crf {crf} -quality {quality} -speed {speed} -profile {profile}  "
-            f'{"-pass 2" if not single_pass else ""}'
-        ) + ending
+        command_1 = f"{beginning} -b:v 0 -crf {crf} {details} -pass 1 -an -f webm {null}"
+        command_2 = (f"{beginning} -b:v 0 -crf {crf} {details} " f'{"-pass 2" if not single_pass else ""}') + ending
 
     else:
         return []

--- a/fastflix/encoders/vp9/command_builder.py
+++ b/fastflix/encoders/vp9/command_builder.py
@@ -14,6 +14,8 @@ def build(
     ffmpeg,
     temp_dir,
     output_video,
+    streams,
+    stream_track,
     bitrate=None,
     crf=None,
     subtitle_tracks=(),
@@ -24,6 +26,7 @@ def build(
     row_mt=0,
     pix_fmt="yuv420p10le",
     attachments="",
+    profile="main",
     disable_hdr=False,
     side_data=None,
     **kwargs,
@@ -50,19 +53,21 @@ def build(
 
     if not disable_hdr and pix_fmt in ("yuv420p10le", "yuv420p12le"):
 
-        if side_data and side_data.get("color_primaries") == "bt2020":
-            beginning += "-color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc"
+        if streams.video[stream_track].get("color_primaries") == "bt2020" or (
+            side_data and side_data.get("color_primaries") == "bt2020"
+        ):
+            beginning += "-color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc -color_range 1"
 
     beginning = re.sub("[ ]+", " ", beginning)
 
     if bitrate:
-        command_1 = f"{beginning} -b:v {bitrate} -quality good -pass 1 -an -f webm {null}"
-        command_2 = f"{beginning} -b:v {bitrate} -quality {quality} -speed {speed} -pass 2" + ending
+        command_1 = f"{beginning} -b:v {bitrate} -quality {quality} -speed {speed} -profile {profile} -pass 1 -an -f webm {null}"
+        command_2 = f"{beginning} -b:v {bitrate} -quality {quality} -speed {speed} -profile {profile} -pass 2" + ending
 
     elif crf:
-        command_1 = f"{beginning} -b:v 0 -crf {crf} -quality good -pass 1 -an -f webm {null}"
+        command_1 = f"{beginning} -b:v 0 -crf {crf} -quality {quality} -speed {speed} -profile {profile} -pass 1 -an -f webm {null}"
         command_2 = (
-            f"{beginning} -b:v 0 -crf {crf} -quality {quality} -speed {speed} "
+            f"{beginning} -b:v 0 -crf {crf} -quality {quality} -speed {speed} -profile {profile}  "
             f'{"-pass 2" if not single_pass else ""}'
         ) + ending
 

--- a/fastflix/encoders/vp9/settings_panel.py
+++ b/fastflix/encoders/vp9/settings_panel.py
@@ -67,7 +67,7 @@ class VP9(SettingPanel):
         grid.addWidget(QtWidgets.QWidget(), 8, 0)
         grid.setRowStretch(8, 1)
         guide_label = QtWidgets.QLabel(
-            f"<a href='https://trac.ffmpeg.org/wiki/Encode/VP9'>FFMPEG VP9 Encoding Guide</a>"
+            "<a href='https://trac.ffmpeg.org/wiki/Encode/VP9'>FFMPEG VP9 Encoding Guide</a> "
             "| <a href='https://developers.google.com/media/vp9/hdr-encoding/'>Google's VP9 HDR Encoding Guide</a>"
         )
         guide_label.setAlignment(QtCore.Qt.AlignBottom)
@@ -88,10 +88,15 @@ class VP9(SettingPanel):
     def init_profile(self):
         return self._add_combo_box(
             label="Profile",
-            tooltip="profile: must be 'main' or 'high' for HDR",
+            tooltip="profile: VP9 coding profile - must match bit depth",
             widget_name="profile",
-            options=["baseline", "main", "high"],
-            default=1,
+            options=[
+                "0: 8-bit | 4:2:0",
+                "1: 8-bit | 4:2:2 or 4:4:4",
+                "2: 10 or 12-bit | 4:2:0",
+                "3: 10 or 12-bit | 4:2:2 or 4:4:4",
+            ],
+            default=2,
         )
 
     def init_quality(self):
@@ -215,7 +220,7 @@ class VP9(SettingPanel):
             pix_fmt=self.widgets.pix_fmt.currentText().split(":")[1].strip(),
             single_pass=self.widgets.single_pass.isChecked(),
             max_mux=self.widgets.max_mux.currentText(),
-            profile=self.widgets.profile.currentText(),
+            profile=self.widgets.profile.currentIndex(),
             extra=self.ffmpeg_extras,
         )
         if self.mode == "CRF":

--- a/fastflix/encoders/vp9/settings_panel.py
+++ b/fastflix/encoders/vp9/settings_panel.py
@@ -61,12 +61,14 @@ class VP9(SettingPanel):
         grid.addLayout(self.init_pix_fmt(), 5, 0, 1, 2)
 
         grid.addLayout(self.init_max_mux(), 6, 0, 1, 2)
+        grid.addLayout(self.init_profile(), 7, 0, 1, 2)
         grid.addLayout(self._add_custom(), 9, 0, 1, 6)
 
         grid.addWidget(QtWidgets.QWidget(), 8, 0)
         grid.setRowStretch(8, 1)
         guide_label = QtWidgets.QLabel(
             f"<a href='https://trac.ffmpeg.org/wiki/Encode/VP9'>FFMPEG VP9 Encoding Guide</a>"
+            "| <a href='https://developers.google.com/media/vp9/hdr-encoding/'>Google's VP9 HDR Encoding Guide</a>"
         )
         guide_label.setAlignment(QtCore.Qt.AlignBottom)
         guide_label.setOpenExternalLinks(True)
@@ -83,59 +85,53 @@ class VP9(SettingPanel):
             default=1,
         )
 
-    def init_quality(self):
-        layout = QtWidgets.QHBoxLayout()
-        quality_level = QtWidgets.QLabel("Quality")
-        quality_level.setToolTip(
-            "good is the default and recommended for most applications <br> "
-            "best is recommended if you have lots of time and want the best compression efficiency."
+    def init_profile(self):
+        return self._add_combo_box(
+            label="Profile",
+            tooltip="profile: must be 'main' or 'high' for HDR",
+            widget_name="profile",
+            options=["baseline", "main", "high"],
+            default=1,
         )
-        layout.addWidget(quality_level)
-        self.widgets.quality = QtWidgets.QComboBox()
-        self.widgets.quality.addItems(["realtime", "good", "best"])
-        self.widgets.quality.setCurrentIndex(1)
-        self.widgets.quality.currentIndexChanged.connect(lambda: self.main.page_update())
-        layout.addWidget(self.widgets.quality)
-        return layout
+
+    def init_quality(self):
+        return self._add_combo_box(
+            label="Quality",
+            tooltip=(
+                "good is the default and recommended for most applications <br> "
+                "best is recommended if you have lots of time and want the best compression efficiency."
+            ),
+            widget_name="quality",
+            options=["realtime", "good", "best"],
+            default=1,
+        )
 
     def init_speed(self):
-        layout = QtWidgets.QHBoxLayout()
-        speed_level = QtWidgets.QLabel("Speed")
-        speed_level.setToolTip(
-            "Using 1 or 2 will increase encoding speed at the expense of having some impact on "
-            "quality and rate control accuracy.<br> 4 or 5 will turn off rate distortion optimization, "
-            "having even more of an impact on quality."
+        return self._add_combo_box(
+            label="Speed",
+            tooltip=(
+                "Using 1 or 2 will increase encoding speed at the expense of having some impact on "
+                "quality and rate control accuracy.<br> 4 or 5 will turn off rate distortion optimization, "
+                "having even more of an impact on quality."
+            ),
+            widget_name="speed",
+            options=[str(x) for x in range(-8, 9)],
+            default=9,
         )
-        layout.addWidget(speed_level)
-        self.widgets.speed = QtWidgets.QComboBox()
-        self.widgets.speed.addItems([str(x) for x in range(6)])
-        self.widgets.speed.setCurrentIndex(0)
-        self.widgets.speed.currentIndexChanged.connect(lambda: self.main.page_update())
-        layout.addWidget(self.widgets.speed)
-        return layout
 
     def init_row_mt(self):
-        layout = QtWidgets.QHBoxLayout()
-        row_mt_label = QtWidgets.QLabel("Row multithreading")
-        row_mt_label.setToolTip(
-            "This improves encoding speed significantly on systems that "
-            "are otherwise underutilised when encoding VP9."
+        return self._add_check_box(
+            label="Row multithreading",
+            tooltip=(
+                "This improves encoding speed significantly on systems that "
+                "are otherwise underutilised when encoding VP9."
+            ),
+            widget_name="row_mt",
+            checked=False,
         )
-        layout.addWidget(row_mt_label)
-        self.widgets.row_mt = QtWidgets.QCheckBox()
-        self.widgets.row_mt.setChecked(False)
-        self.widgets.row_mt.toggled.connect(lambda: self.main.page_update())
-        layout.addWidget(self.widgets.row_mt)
-        return layout
 
     def init_single_pass(self):
-        layout = QtWidgets.QHBoxLayout()
-        layout.addWidget(QtWidgets.QLabel("Single Pass (CRF)"))
-        self.widgets.single_pass = QtWidgets.QCheckBox()
-        self.widgets.single_pass.setChecked(False)
-        self.widgets.single_pass.toggled.connect(lambda: self.main.page_update())
-        layout.addWidget(self.widgets.single_pass)
-        return layout
+        return self._add_check_box(label="Single Pass (CRF)", tooltip="", widget_name="single_pass", checked=False)
 
     def init_max_mux(self):
         return self._add_combo_box(
@@ -219,6 +215,7 @@ class VP9(SettingPanel):
             pix_fmt=self.widgets.pix_fmt.currentText().split(":")[1].strip(),
             single_pass=self.widgets.single_pass.isChecked(),
             max_mux=self.widgets.max_mux.currentText(),
+            profile=self.widgets.profile.currentText(),
             extra=self.ffmpeg_extras,
         )
         if self.mode == "CRF":

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "3.4.1"
+__version__ = "3.4.2"
 __author__ = "Chris Griffith"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastflix"
-version = "3.4.1"
+version = "3.4.2"
 description = "Easy to use video encoder GUI"
 authors = ["Chris Griffith <chris@cdgriffith.com>"]
 license = "MIT"


### PR DESCRIPTION
* Fixing color space details being passed correctly to everything other than x265 as well
* Fixing HDR10+ details on README
* Fixing #102 better with taking into account master-display ratios (thanks to leonardyan)
* Fixing VP9 to accept profiles so HDR10 can be copied properly
* Fixing #108 HEVC can select wrong video track for encoding (thanks to Zeid164)