### PR TITLE
Add time elapsed to enoding status tab

### DIFF
--- a/fastflix/command_runner.py
+++ b/fastflix/command_runner.py
@@ -4,6 +4,7 @@ import logging
 import re
 import secrets
 import shlex
+import datetime
 from pathlib import Path
 from subprocess import PIPE
 from threading import Thread
@@ -29,6 +30,7 @@ class BackgroundRunner:
         self.success_detected = False
         self.error_message = []
         self.success_message = []
+        self.started_at = None
 
     def start_exec(self, command, work_dir: str = None, shell: bool = False, errors=(), successes=()):
         self.clean()
@@ -50,6 +52,8 @@ class BackgroundRunner:
             stdin=PIPE,  # FFmpeg can try to read stdin and wrecks havoc on linux
             encoding="utf-8",
         )
+
+        self.started_at = datetime.datetime.now(datetime.timezone.utc)
 
         Thread(target=self.read_output).start()
 
@@ -82,6 +86,7 @@ class BackgroundRunner:
         )
 
         self.error_detected = False
+        self.started_at = datetime.datetime.now(datetime.timezone.utc)
 
         Thread(target=self.read_output).start()
 
@@ -145,6 +150,7 @@ class BackgroundRunner:
         self.error_detected = False
         self.success_detected = False
         self.killed = False
+        self.started_at = None
 
     def kill(self, log=True):
         if self.process_two:

--- a/fastflix/conversion_worker.py
+++ b/fastflix/conversion_worker.py
@@ -67,11 +67,12 @@ def queue_worker(gui_proc, worker_queue, status_queue, log_queue):
         logger.addHandler(new_file_handler)
         prevent_sleep_mode()
         currently_encoding = True
-        status_queue.put(("running", commands_to_run[0][0], commands_to_run[0][1]))
         runner.start_exec(
             commands_to_run[0][2],
             work_dir=commands_to_run[0][3],
         )
+
+        status_queue.put(("running", commands_to_run[0][0], commands_to_run[0][1], runner.started_at.isoformat()))
 
     while True:
         if currently_encoding and not runner.is_alive():

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -1769,6 +1769,13 @@ Time Left:
   ita: Tempo rimanente
   spa: Tiempo restante
   zho: 剩余时间
+Time Elapsed:
+  deu: Verstrichene Zeit
+  eng: Time elapsed
+  fra: Temps écoulé
+  ita: Tempo trascorso
+  spa: Tiempo transcurrido
+  zho: 时间流逝
 Title:
   deu: Titel
   eng: Title

--- a/fastflix/shared.py
+++ b/fastflix/shared.py
@@ -245,3 +245,14 @@ def clean_logs(signal, app, **_):
         for file in compress:
             file.unlink(missing_ok=True)
     signal.emit(100)
+
+
+def timedelta_to_str(delta):
+    if not isinstance(delta, (timedelta,)):
+        logger.warning(f"Wanted timedelta found but found {type(delta)}")
+        return "N/A"
+
+    output_string = str(delta)
+    output_string = output_string.split(".")[0]  # Remove .XXX microseconds
+
+    return output_string

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -1546,7 +1546,7 @@ class Main(QtWidgets.QWidget):
         self.set_convert_button()
 
         try:
-            video_uuid, command_uuid = data.split(":")
+            video_uuid, command_uuid, *_ = data.split("__")
             cancelled_video = self.find_video(video_uuid)
         except Exception:
             return
@@ -1561,7 +1561,6 @@ class Main(QtWidgets.QWidget):
         sm.exec_()
         if sm.clickedButton().text() == t("Delete"):
             try:
-                video_uuid, command_uuid = data.split(":")
                 cancelled_video = self.find_video(video_uuid)
                 cancelled_video.video_settings.output_path.unlink(missing_ok=True)
             except OSError:
@@ -1595,7 +1594,7 @@ class Main(QtWidgets.QWidget):
     def status_update(self, status):
         logger.debug(f"Updating status from command worker: {status}")
         try:
-            command, video_uuid, command_uuid = status.split(":")
+            command, video_uuid, command_uuid, *_ = status.split("__")
         except ValueError:
             logger.exception(f"Could not process status update from the command worker: {status}")
             return
@@ -1670,11 +1669,11 @@ class Notifier(QtCore.QThread):
             if status[0] == "complete":
                 self.main.completed.emit(0)
             elif status[0] == "error":
-                self.main.status_update_signal.emit(":".join(status))
+                self.main.status_update_signal.emit("__".join(status))
                 self.main.completed.emit(1)
             elif status[0] == "cancelled":
-                self.main.cancelled.emit(":".join(status[1:]))
-                self.main.status_update_signal.emit(":".join(status))
+                self.main.cancelled.emit("__".join(status[1:]))
+                self.main.status_update_signal.emit("__".join(status))
             elif status[0] == "exit":
                 try:
                     self.terminate()
@@ -1682,4 +1681,4 @@ class Notifier(QtCore.QThread):
                     self.main.close_event.emit()
                 return
             else:
-                self.main.status_update_signal.emit(":".join(status))
+                self.main.status_update_signal.emit("__".join(status))

--- a/fastflix/widgets/panels/status_panel.py
+++ b/fastflix/widgets/panels/status_panel.py
@@ -126,8 +126,9 @@ class StatusPanel(QtWidgets.QWidget):
     def set_started_at(self, msg):
         try:
             started_at = datetime.datetime.fromisoformat(msg.split("__")[-1])
-        except Exception as e:
-            logger.warning(f"Unable to parse start time - {str(e)}")
+        except Exception:
+            logger.exception("Unable to parse start time, assuming it was now")
+            self.started_at = datetime.datetime.now(datetime.timezone.utc)
             return
 
         self.started_at = started_at
@@ -141,8 +142,8 @@ class StatusPanel(QtWidgets.QWidget):
 
         try:
             time_elapsed = now - self.started_at
-        except Exception as e:
-            logger.warning(f"Unable to calculate elapsed time - {str(e)}")
+        except Exception:
+            logger.exception("Unable to calculate elapsed time")
             return
 
         self.time_elapsed_label.setText(f"{t('Time Elapsed')}: {timedelta_to_str(time_elapsed)}")


### PR DESCRIPTION
Hi there! Thanks for making this software and all the blog posts. It's super great and has been super helpful to me!

I made this time elapsed label to keep track of how long the current encode command has been running.

Let me know if there are changes you'd like to see before merge 🙂

![recording_2021-01-08-18:14:57](https://user-images.githubusercontent.com/3595094/104054485-811a1000-51ed-11eb-969b-05cba49e3222.gif)

## Summary of changes

* Add `started_at` to `BackgroundRunner`
* Move `status_queue.put(("running",` to *after* `runner.start_exec` because start time of command is recorded in `start_exec`
* Add `timedelta_to_str` method for having a common serialization (it's quite hacky with only a string split to remove microseconds)
* Change separator for status update signals from `:` to `__` because ISO formatted timestamps have `:` in them which made it a little difficult to send it along with the other data
* Add a label for time elapsed to the status panel
* Add `on_status_update` method to status panel for listening to status updates from `main`
* Add a thread for "ticking" the time elapsed separate from when output from ffmpeg is received
* Add translations for "Time elapsed" label (I just opened up Google Translate so I don't really know if the translations make sense..)