### PR TITLE
Version 4.1.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 4.1.1
+
+* Fixing #156 Copy was broken due to copy settings being renamed due to library update (thanks to leonardyan)
+* Fixing #172 FastFlix could not set profile setting copy (thanks to Etz)
+* Fixing calling delete on a profile without a source video could crash FastFlix
+
 ## Version 4.1.0
 
 * Adding #118 #126 advanced panel with FFmpeg filters (thanks to Marco Ravich and remlap)

--- a/fastflix/encoders/copy/settings_panel.py
+++ b/fastflix/encoders/copy/settings_panel.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("fastflix")
 
 
 class Copy(SettingPanel):
-    profile_name = "copy"
+    profile_name = "copy_settings"
 
     def __init__(self, parent, main, app: FastFlixApp):
         super().__init__(parent, main, app)

--- a/fastflix/models/config.py
+++ b/fastflix/models/config.py
@@ -3,7 +3,7 @@ import logging
 import shutil
 from distutils.version import StrictVersion
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from appdirs import user_data_dir
 from box import Box, BoxError
@@ -41,6 +41,8 @@ setting_types = {
     "webp": WebPSettings,
     "copy_settings": CopySettings,
 }
+
+outdated_settings = ("copy",)
 
 
 class Profile(BaseModel):
@@ -193,6 +195,8 @@ class Config(BaseModel):
                         continue
                     profile = Profile()
                     for setting_name, setting in v.items():
+                        if setting_name in outdated_settings:
+                            continue
                         if setting_name in setting_types.keys() and setting is not None:
                             try:
                                 setattr(profile, setting_name, setting_types[setting_name](**setting))

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "4.1.0"
+__version__ = "4.1.1b0"
 __author__ = "Chris Griffith"

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "4.1.1b0"
+__version__ = "4.1.1"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/panels/advanced_panel.py
+++ b/fastflix/widgets/panels/advanced_panel.py
@@ -370,7 +370,7 @@ class AdvancedPanel(QtWidgets.QWidget):
     # (800 + 140) - 1080 == -140
 
     def update_settings(self):
-        if self.updating:
+        if self.updating or not self.app.fastflix.current_video:
             return False
         self.updating = True
         self.app.fastflix.current_video.video_settings.video_speed = video_speeds[self.video_speed_widget.currentText()]


### PR DESCRIPTION
* Fixing #156 Copy was broken due to copy settings being renamed due to library update (thanks to leonardyan)
* Fixing #172 FastFlix could not set profile setting copy (thanks to Etz)
* Fixing calling delete on a profile without a source video could crash FastFlix