### PR TITLE
Cannot load NVENC profiles because RC Lookahead is stored as int

### DIFF
--- a/fastflix/encoders/common/setting_panel.py
+++ b/fastflix/encoders/common/setting_panel.py
@@ -400,7 +400,7 @@ class SettingPanel(QtWidgets.QWidget):
                 data = self.app.fastflix.config.encoder_opt(self.profile_name, opt)
                 if widget_name == "x265_params":
                     data = ":".join(data)
-                self.widgets[widget_name].setText(data or "")
+                self.widgets[widget_name].setText(str(data) or "")
         try:
             bitrate = self.app.fastflix.config.encoder_opt(self.profile_name, "bitrate")
         except AttributeError:


### PR DESCRIPTION
I've run into this bug when testing the NVENC encoder the other day. The RC Lookahead is stored as int in yaml but the Qt widget expects a string.