### PR TITLE
Version 4.4.2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 4.4.2
+
+* Fixing #264 changelog encoding was causing crashes on non utf-8 systems (thanks to lobofoot)
+
 ## Version 4.4.1
 
 * Fixing colorspace details from advanced page not applied to x265 (thanks to Tình Em Là Đại Dương)

--- a/fastflix/shared.py
+++ b/fastflix/shared.py
@@ -210,7 +210,7 @@ def clean_logs(signal, app, **_):
                 logger.debug(f"Deleting {file.name}")
                 file.unlink(missing_ok=True)
         if file.name.startswith("flix_conversion") or file.name.startswith("flix_2"):
-            original = file.read_text(encoding="utf-8")
+            original = file.read_text(encoding="utf-8", errors="ignore")
             try:
                 condensed = "\n".join(
                     (

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "4.4.1"
+__version__ = "4.4.2"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/changes.py
+++ b/fastflix/widgets/changes.py
@@ -27,11 +27,11 @@ class Changes(QtWidgets.QScrollArea):
         lay = QtWidgets.QVBoxLayout(content)
 
         if changes_file.exists():
-            content = changes_file.read_text()
+            content = changes_file.read_text(encoding="utf-8", errors="ignore")
         else:
             if not local_changes_file.exists():
                 raise Exception("Could not locate changlog file")
-            content = local_changes_file.read_text()
+            content = local_changes_file.read_text(encoding="utf-8", errors="ignore")
 
         linked_content = issues.sub(
             " <a href='https://github.com/cdgriffith/FastFlix/issues/\\1' style='color: black' >\\1</a> ", content


### PR DESCRIPTION
* Fixing #264 changelog encoding was causing crashes on non utf-8 systems (thanks to lobofoot)