### PR TITLE
Fix parsing of output with -psnr on and add 640k audio bitrate

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,9 +2,11 @@
 
 ## Version 4.5.2
 
+* Adding #195 640kbps audio (thanks to ObviousInRetrospect and Harybo)
 * Fixing #272 Codec drop down size fix (thanks to kachijs)
 * Fixing #278 FastFlix occasionally getting stuck on a single video in a queue (thanks to kamild_)
 * Fixing build for 3.10 by updating to PySide6 6.2.2.1 (thanks to Nhunz)
+* Fixing status parser when using -psnr (thanks to ObviousInRetrospect)
 
 ## Version 4.5.1
 

--- a/fastflix/widgets/panels/audio_panel.py
+++ b/fastflix/widgets/panels/audio_panel.py
@@ -176,32 +176,15 @@ class Audio(QtWidgets.QTabWidget):
 
         self.widgets.convert_bitrate = QtWidgets.QComboBox()
         self.widgets.convert_bitrate.setFixedWidth(70)
-
+        br=[]
+        channels=self.channels
+        if not channels:
+            channels=2
+        br=[x for x in range(16 * self.channels, (256 * self.channels) + 1, 16 * self.channels)]
+        br.append(640) #required standard Blu-Ray rate, max for AC-3
+        br.sort()
         self.widgets.convert_bitrate.addItems(
-            [f"{x}k" for x in range(16 * self.channels, (256 * self.channels) + 1, 16 * self.channels)]
-            if self.channels
-            else [
-                "32k",
-                "64k",
-                "96k",
-                "128k",
-                "160k",
-                "192k",
-                "224k",
-                "256k",
-                "320k",
-                "512K",
-                "768k",
-                "896k",
-                "1024k",
-                "1152k",
-                "1280k",
-                "1408k",
-                "1536k",
-                "1664k",
-                "1792k",
-                "1920k",
-            ]
+            [f"{x}k" for x in br]
         )
         self.widgets.convert_bitrate.setCurrentIndex(3)
         self.widgets.convert_bitrate.setDisabled(True)

--- a/fastflix/widgets/panels/audio_panel.py
+++ b/fastflix/widgets/panels/audio_panel.py
@@ -176,16 +176,14 @@ class Audio(QtWidgets.QTabWidget):
 
         self.widgets.convert_bitrate = QtWidgets.QComboBox()
         self.widgets.convert_bitrate.setFixedWidth(70)
-        br=[]
-        channels=self.channels
+        br = []
+        channels = self.channels
         if not channels:
-            channels=2
-        br=[x for x in range(16 * self.channels, (256 * self.channels) + 1, 16 * self.channels)]
-        br.append(640) #required standard Blu-Ray rate, max for AC-3
+            channels = 2
+        br = [x for x in range(16 * self.channels, (256 * self.channels) + 1, 16 * self.channels)]
+        br.append(640)  # required standard Blu-Ray rate, max for AC-3
         br.sort()
-        self.widgets.convert_bitrate.addItems(
-            [f"{x}k" for x in br]
-        )
+        self.widgets.convert_bitrate.addItems([f"{x}k" for x in br])
         self.widgets.convert_bitrate.setCurrentIndex(3)
         self.widgets.convert_bitrate.setDisabled(True)
 

--- a/fastflix/widgets/panels/audio_panel.py
+++ b/fastflix/widgets/panels/audio_panel.py
@@ -176,14 +176,7 @@ class Audio(QtWidgets.QTabWidget):
 
         self.widgets.convert_bitrate = QtWidgets.QComboBox()
         self.widgets.convert_bitrate.setFixedWidth(70)
-        br = []
-        channels = self.channels
-        if not channels:
-            channels = 2
-        br = [x for x in range(16 * self.channels, (256 * self.channels) + 1, 16 * self.channels)]
-        br.append(640)  # required standard Blu-Ray rate, max for AC-3
-        br.sort()
-        self.widgets.convert_bitrate.addItems([f"{x}k" for x in br])
+        self.widgets.convert_bitrate.addItems(self.get_conversion_bitrates())
         self.widgets.convert_bitrate.setCurrentIndex(3)
         self.widgets.convert_bitrate.setDisabled(True)
 
@@ -197,6 +190,14 @@ class Audio(QtWidgets.QTabWidget):
 
         return layout
 
+    def get_conversion_bitrates(self, channels=None):
+        if not channels:
+            channels = self.channels or 2
+        bitrates = [x for x in range(16 * channels, (256 * channels) + 1, 16 * channels)]
+        if channels > 1:
+            bitrates.append(640)
+        return [f"{x}k" for x in sorted(set(bitrates))]
+
     def update_enable(self):
         enabled = self.widgets.enable_check.isChecked()
         self.widgets.track_number.setText(f"{self.index}:{self.outdex}" if enabled else "❌")
@@ -209,14 +210,7 @@ class Audio(QtWidgets.QTabWidget):
             else self.channels
         )
         self.widgets.convert_bitrate.clear()
-        if channels > 0:
-            self.widgets.convert_bitrate.addItems(
-                [f"{x}k" for x in range(16 * channels, (256 * channels) + 1, 16 * channels)]
-            )
-        else:
-            self.widgets.convert_bitrate.addItems(
-                [f"{x}k" for x in range(16 * self.channels, (256 * self.channels) + 1, 16 * self.channels)]
-            )
+        self.widgets.convert_bitrate.addItems(self.get_conversion_bitrates(channels))
         self.widgets.convert_bitrate.setCurrentIndex(3)
         self.page_update()
 

--- a/fastflix/widgets/panels/status_panel.py
+++ b/fastflix/widgets/panels/status_panel.py
@@ -186,12 +186,14 @@ class Logs(QtWidgets.QTextBrowser):
             return
         if msg.startswith("frame="):
             try:
-                output = []
-                for i in (x.strip().split() for x in msg.split("=")):
-                    output.extend(i)
-
-                frame = dict(zip(output[0::2], output[1::2]))
-
+                frame={}
+                output=[i for i in (x.strip().split() for x in msg.split("="))]
+                output[-1].append([]) #no final value
+                for i in range(0,len(output)-1):
+                    frame[output[i][-1]]=output[i+1][:-1]
+                for k in frame:
+                    if len(frame[k])==1:
+                        frame[k]=frame[k][0]
                 self.status_panel.speed.emit(f"{frame.get('time', '')}|{frame.get('speed', '').rstrip('x')}")
                 self.status_panel.bitrate.emit(frame.get("bitrate", ""))
             except Exception:

--- a/fastflix/widgets/panels/status_panel.py
+++ b/fastflix/widgets/panels/status_panel.py
@@ -186,14 +186,14 @@ class Logs(QtWidgets.QTextBrowser):
             return
         if msg.startswith("frame="):
             try:
-                frame={}
-                output=[i for i in (x.strip().split() for x in msg.split("="))]
-                output[-1].append([]) #no final value
-                for i in range(0,len(output)-1):
-                    frame[output[i][-1]]=output[i+1][:-1]
+                frame = {}
+                output = [i for i in (x.strip().split() for x in msg.split("="))]
+                output[-1].append([])  # no final value
+                for i in range(0, len(output) - 1):
+                    frame[output[i][-1]] = output[i + 1][:-1]
                 for k in frame:
-                    if len(frame[k])==1:
-                        frame[k]=frame[k][0]
+                    if len(frame[k]) == 1:
+                        frame[k] = frame[k][0]
                 self.status_panel.speed.emit(f"{frame.get('time', '')}|{frame.get('speed', '').rstrip('x')}")
                 self.status_panel.bitrate.emit(frame.get("bitrate", ""))
             except Exception:


### PR DESCRIPTION
-psnr causes output of PSNR=Y:nan U:nan V:nan *:nan which breaks the current parser. Treat the = split differently.

Also 640k is a very standard and well supported audio bitrate. It is the max for AC3 and is a required bitrate for bluray. Add it and simplify the  channels not specified case (the old list was the same increment as channels=2).