### PR TITLE
Version 4.9.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 ## Version 4.9.1
 
 * Fixing QSV AVC command builder not working (thanks to Marco Ravich)
+* Fixing missing details in readme on how to use additional encoders
 
 ## Version 4.9.0
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 4.9.1
+
+* Fixing QSV AVC command builder not working (thanks to Marco Ravich)
+
 ## Version 4.9.0
 
 * Adding #109 Support for AVC and HEVC QSV encoding with rigaya's QSVEncC (thanks to msaintauret)

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Check out [the FastFlix github wiki](https://github.com/cdgriffith/FastFlix/wiki
 
  FastFlix supports the following encoders if available:
 
-| Encoder   | x265 |  NVENC HEVC | [NVEncC HEVC](https://github.com/rigaya/NVEnc/releases) | [VCEEncC HEVC](https://github.com/rigaya/VCEEnc/releases) | x264 | rav1e | AOM AV1 | SVT AV1 | VP9 | WEBP | GIF |
-| --------- | ---- | ---------- | ----------- | ----------- | ---- | ----- | ------- |-----| --- | ---- | --- |
-| HDR10     |   ✓  |            |      ✓     |      ✓     |     |       |         | ✓   |  ✓* |      |     |
-| HDR10+    |   ✓  |            |      ✓     |            |     |       |         |     |     |      |     |
-| Audio     |   ✓  |      ✓     |      ✓*    |      ✓*    | ✓   |   ✓  |    ✓    | ✓   |  ✓   |      |     |
-| Subtitles |   ✓  |      ✓     |      ✓     |      ✓     | ✓   |   ✓  |    ✓    | ✓   |      |      |     |
-| Covers    |   ✓  |      ✓     |            |            | ✓   |   ✓  |    ✓    | ✓   |      |      |     |
-| bt.2020   |   ✓  |     ✓      |     ✓      |     ✓      |  ✓  |  ✓    |   ✓    | ✓   |  ✓   |      |     |
+| Encoder   | x265 |  NVENC HEVC | [NVEncC HEVC](https://github.com/rigaya/NVEnc/releases) | [VCEEncC HEVC](https://github.com/rigaya/VCEEnc/releases) | [QSVEncC HEVC](https://github.com/rigaya/QSVEnc/releases) | x264 | rav1e | AOM AV1 | SVT AV1 | VP9 | WEBP | GIF |
+| --------- | ---- | ---------- | ----------- | ----------- | ----------- |------| ----- | ------- |-----| --- | ---- | --- |
+| HDR10     |   ✓  |            |      ✓     |      ✓     |      ✓     |      |       |         | ✓   |  ✓* |      |     |
+| HDR10+    |   ✓  |            |      ✓     |            |            |      |       |         |     |     |      |     |
+| Audio     |   ✓  |      ✓     |      ✓*    |      ✓*    |      ✓*    |  ✓   |   ✓  |    ✓    | ✓   |  ✓   |      |     |
+| Subtitles |   ✓  |      ✓     |      ✓     |      ✓     |      ✓     |  ✓   |   ✓  |    ✓    | ✓   |      |      |     |
+| Covers    |   ✓  |      ✓     |            |            |            |  ✓   |   ✓  |    ✓    | ✓   |      |      |     |
+| bt.2020   |   ✓  |     ✓      |     ✓      |     ✓      |     ✓      |   ✓  |  ✓    |   ✓    | ✓   |  ✓   |      |     |
 
 `✓ - Full support   |   ✓* - Limited support`
 
@@ -35,6 +35,15 @@ View the [releases](https://github.com/cdgriffith/FastFlix/releases) for binarie
 
 You will need to have `ffmpeg` and `ffprobe` executables on your PATH and they must be executable. Version 4.3 or greater is required for most usage, latest master build is recommended and required for some features. The one in your package manager system may not support all encoders or options.
 Check out the [FFmpeg download page for static builds](https://ffmpeg.org/download.html) for Linux and Mac.
+
+# Additional Encoders
+
+To use rigaya's [Nvidia NVENC](https://github.com/rigaya/NVEnc/releases), [AMD VCE](https://github.com/rigaya/VCEEnc/releases), and [Intel QSV](https://github.com/rigaya/QSVEnc/releases) encoders, download them and extract them to folder on your hard drive. 
+
+Windows: Go into FastFlix's settings and select the corresponding EXE file for each of the encoders you want to use. 
+
+Linux: Install the rpm or deb and restart FastFlix
+
 
 ## Running from source code
 

--- a/fastflix/encoders/qsvencc_avc/command_builder.py
+++ b/fastflix/encoders/qsvencc_avc/command_builder.py
@@ -15,24 +15,6 @@ def build(fastflix: FastFlix):
     video: Video = fastflix.current_video
     settings: QSVEncCH264Settings = fastflix.current_video.video_settings.video_encoder_settings
 
-    master_display = None
-    if fastflix.current_video.master_display:
-        master_display = (
-            f'--master-display "G{fastflix.current_video.master_display.green}'
-            f"B{fastflix.current_video.master_display.blue}"
-            f"R{fastflix.current_video.master_display.red}"
-            f"WP{fastflix.current_video.master_display.white}"
-            f'L{fastflix.current_video.master_display.luminance}"'
-        )
-
-    max_cll = None
-    if fastflix.current_video.cll:
-        max_cll = f'--max-cll "{fastflix.current_video.cll}"'
-
-    dhdr = None
-    if settings.hdr10plus_metadata:
-        dhdr = f'--dhdr10-info "{settings.hdr10plus_metadata}"'
-
     trim = ""
     try:
         if "/" in video.frame_rate:

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "4.9.0"
+__version__ = "4.9.1"
 __author__ = "Chris Griffith"


### PR DESCRIPTION
* Fixing QSV AVC command builder not working (thanks to Marco Ravich)
* Fixing missing details in readme on how to use additional encoders