### PR TITLE
Version 4.10.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload standalone executable artifact
         uses: actions/upload-artifact@v2
         with:
-          name: FastFlix_${{ env.VERSION }}_linux_x86_64
+          name: FastFlix_${{ env.VERSION }}_ubuntu_22_x86_64
           path: |
             dist/FastFlix
             dist/LICENSE
@@ -115,7 +115,7 @@ jobs:
     - name: Upload standalone executable artifact
       uses: actions/upload-artifact@v2
       with:
-        name: FastFlix_${{ env.VERSION }}_linux_x86_64
+        name: FastFlix_${{ env.VERSION }}_ubuntu_20_x86_64
         path: |
           dist/FastFlix
           dist/LICENSE

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -307,3 +307,55 @@ jobs:
         path: |
           dist/FastFlix
           dist/LICENSE
+
+  build-macos-12:
+
+    runs-on: macOS-12
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Gather build version
+      run: |
+        mkdir dist
+        echo "::set-env name=VERSION::$(python scripts/get_version.py)"
+        echo "Building branch ${{env.GITHUB_REF}} - version ${{env.VERSION}}"
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+    - uses: syphar/restore-pip-download-cache@v1
+
+    - name: Insatll requirements
+      run: |
+        python -m pip install --upgrade pip setuptools --ignore-installed
+        python -m pip install --upgrade wheel typing_extensions pyinstaller
+        python -m pip install --upgrade -r requirements.txt
+
+    - name: Grab iso-639 lists
+      run: |
+        cp $(python -c "import iso639; print(iso639.mapping.TABLE_PATH)") iso-639-3.tab
+        cp $(python -c "import iso639; print(iso639.mapping.MAPPING_PATH)") iso-639-3.json
+
+    - name: Build executable
+      run: pyinstaller FastFlix_Nix_OneFile.spec
+
+    - name: Copy license to dist
+      run: |
+        cp docs/build-licenses.txt dist/LICENSE
+
+    - name: Test executable
+      run: |
+        chmod +x dist/FastFlix
+        dist/FastFlix --version
+        dist/FastFlix --test
+
+    - name: Upload standalone executable artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: FastFlix_${{ env.VERSION }}_macos12
+        path: |
+          dist/FastFlix
+          dist/LICENSE

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,63 @@ on:
     branches: [ master, develop ]
 
 jobs:
+  build-ubuntu22:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+
+      - name: Gather build version
+        run: |
+          mkdir dist
+          echo "::set-env name=VERSION::$(python scripts/get_version.py)"
+          echo "Building branch ${{env.GITHUB_REF}} - version ${{env.VERSION}}"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+      - name: Install PySide2 apt requirements
+        run: |
+          sudo apt update
+          sudo apt install libopengl0 freeglut3 freeglut3-dev libxcb-icccm4 libxkbcommon-x11-0 libxcb-xkb1 libxcb-render-util0 libxcb-randr0 libxcb-keysyms1 libxcb-image0 -y
+
+      - uses: syphar/restore-pip-download-cache@v1
+
+      - name: Install pip requirements
+        run: |
+          python -m pip install --upgrade pip setuptools --ignore-installed
+          python -m pip install --upgrade wheel typing_extensions pyinstaller
+          python -m pip install --upgrade -r requirements.txt
+
+      - name: Grab iso-639 lists
+        run: |
+          cp $(python -c "import iso639; print(iso639.mapping.TABLE_PATH)") iso-639-3.tab
+          cp $(python -c "import iso639; print(iso639.mapping.MAPPING_PATH)") iso-639-3.json
+
+      - name: Build single executable
+        run: pyinstaller FastFlix_Nix_OneFile.spec
+
+      - name: Copy license to dist
+        run: |
+          cp docs/build-licenses.txt dist/LICENSE
+
+      - name: Test executable
+        run: |
+          chmod +x dist/FastFlix
+          dist/FastFlix --version
+          dist/FastFlix --test
+
+      - name: Upload standalone executable artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: FastFlix_${{ env.VERSION }}_linux_x86_64
+          path: |
+            dist/FastFlix
+            dist/LICENSE
+
   build-linux:
     runs-on: ubuntu-20.04
 

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 
 * Adding AVIF support using libsvtav1
 * Adding #352 default output directory to settings panel
+* Adding support for audio profiles with pattern matching for rigaya's hardware encoders
 
 ## Version 4.9.4
 

--- a/CHANGES
+++ b/CHANGES
@@ -9,12 +9,14 @@
 * Adding #325 build for Ubuntu 22.04 (thanks to mrjayviper)
 * Adding build for MacOS 12
 * Adding #322 warning if profile audio match doesn't match anything (thanks to wynterca)
+* Adding presumption that 4.x branch is last to support Windows 7 and 8 for update checks
 * Fixing #319 no longer disables built in tracks for profile matching (thanks to Owen Quinlan)
 * Fixing #218 and #308 subtitle scaling with rigaya's hardware encoders needs to be scaled for 4K content (thanks to wynterca)
 * Fixing #350 subtitle burn in quoting (thanks to Maddie Davis)
 * Fixing #346 preserve the order of audio tracks when editing a queued job (thanks to Patrick Bassner)
 * Fixing #187 closing the main app while a progress bar is active will now stop that task (thanks to Todd Wilkinson)
 * Fixing Chinese translations (thanks to leonardyan)
+* Fixing new version check not launching at startup
 
 ## Version 4.9.4
 

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@
 * Fixing #319 no longer disables built in tracks for profile matching (thanks to Owen Quinlan)
 * Fixing #218 and #308 subtitle scaling with rigaya's hardware encoders needs to be scaled for 4K content (thanks to wynterca)
 * Fixing #350 subtitle burn in quoting (thanks to Maddie Davis)
+* Fixing #346 preserve the order of audio tracks when editing a queued job (thanks to Patrick Bassner)
 * Fixing Chinese translations (thanks to leonardyan)
 
 ## Version 4.9.4

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 4.10.0
+
+* Adding AVIF support using libsvtav1
+* Adding #352 default output directory to settings panel
+
 ## Version 4.9.4
 
 * Fixing Apple videotoolbox were not being listed as options (thanks to sublimal)

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
 * Adding #322 warning if profile audio match doesn't match anything (thanks to wynterca)
 * Fixing #319 no longer disables built in tracks for profile matching (thanks to Owen Quinlan)
 * Fixing #218 and #308 subtitle scaling with rigaya's hardware encoders needs to be scaled for 4K content (thanks to wynterca)
+* Fixing #350 subtitle burn in quoting (thanks to Maddie Davis)
 * Fixing Chinese translations (thanks to leonardyan)
 
 ## Version 4.9.4

--- a/CHANGES
+++ b/CHANGES
@@ -4,8 +4,12 @@
 
 * Adding AVIF support using libsvtav1
 * Adding #352 default output directory to settings panel (thanks to Maddie Davis)
-* Adding support for audio profiles with pattern matching for rigaya's hardware encoders
+* Adding #306 support for audio profiles with pattern matching for rigaya's hardware encoders
 * Adding Select All feature for subtitles (thanks to ProFire)
+* Adding #325 builds for Ubuntu 22.04 (thanks to mrjayviper)
+* Adding #322 warning if profile audio match doesn't match anything (thanks to wynterca)
+* Fixing #319 no longer disables built in tracks for profile matching (thanks to Owen Quinlan)
+* Fixing #218 and #308 subtitle scaling with rigaya's hardware encoders needs to be scaled for 4K content (thanks to wynterca)
 * Fixing Chinese translations (thanks to leonardyan)
 
 ## Version 4.9.4

--- a/CHANGES
+++ b/CHANGES
@@ -3,8 +3,10 @@
 ## Version 4.10.0
 
 * Adding AVIF support using libsvtav1
-* Adding #352 default output directory to settings panel
+* Adding #352 default output directory to settings panel (thanks to Maddie Davis)
 * Adding support for audio profiles with pattern matching for rigaya's hardware encoders
+* Adding Select All feature for subtitles (thanks to ProFire)
+* Fixing Chinese translations (thanks to leonardyan)
 
 ## Version 4.9.4
 

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,8 @@
 * Adding #352 default output directory to settings panel (thanks to Maddie Davis)
 * Adding #306 support for audio profiles with pattern matching for rigaya's hardware encoders
 * Adding Select All feature for subtitles (thanks to ProFire)
-* Adding #325 builds for Ubuntu 22.04 (thanks to mrjayviper)
+* Adding #325 build for Ubuntu 22.04 (thanks to mrjayviper)
+* Adding build for MacOS 12
 * Adding #322 warning if profile audio match doesn't match anything (thanks to wynterca)
 * Fixing #319 no longer disables built in tracks for profile matching (thanks to Owen Quinlan)
 * Fixing #218 and #308 subtitle scaling with rigaya's hardware encoders needs to be scaled for 4K content (thanks to wynterca)

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@
 * Adding AVIF support using libsvtav1
 * Adding #352 default output directory to settings panel (thanks to Maddie Davis)
 * Adding #306 support for audio profiles with pattern matching for rigaya's hardware encoders
-* Adding Select All feature for subtitles (thanks to ProFire)
+* Adding #301 Select All feature for subtitles (thanks to ProFire and Genine-Collin)
 * Adding #325 build for Ubuntu 22.04 (thanks to mrjayviper)
 * Adding build for MacOS 12
 * Adding #322 warning if profile audio match doesn't match anything (thanks to wynterca)
@@ -13,6 +13,7 @@
 * Fixing #218 and #308 subtitle scaling with rigaya's hardware encoders needs to be scaled for 4K content (thanks to wynterca)
 * Fixing #350 subtitle burn in quoting (thanks to Maddie Davis)
 * Fixing #346 preserve the order of audio tracks when editing a queued job (thanks to Patrick Bassner)
+* Fixing #187 closing the main app while a progress bar is active will now stop that task (thanks to Todd Wilkinson)
 * Fixing Chinese translations (thanks to leonardyan)
 
 ## Version 4.9.4

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2019-2021 Chris Griffith
+Copyright (c) 2019-2022 Chris Griffith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ FastFlix is a simple and friendly GUI for encoding videos.
 
 FastFlix keeps HDR10 metadata for x265, NVEncC HEVC, and VCEEncC HEVC, which will also be expanded to AV1 libraries when available.
 
-It needs `FFmpeg` (version 4.3 or greater) under the hood for the heavy lifting, and can work with a variety of encoders.
+It needs `FFmpeg` (version 4.3 or greater required, 5.0+ recommended) under the hood for the heavy lifting, and can work with a variety of encoders.
 
 Join us on [discord](https://discord.gg/GUBFP6f)!
 
@@ -18,14 +18,14 @@ Check out [the FastFlix github wiki](https://github.com/cdgriffith/FastFlix/wiki
 
  FastFlix supports the following encoders if available:
 
-| Encoder   | x265 |  NVENC HEVC | [NVEncC HEVC](https://github.com/rigaya/NVEnc/releases) | [VCEEncC HEVC](https://github.com/rigaya/VCEEnc/releases) | [QSVEncC HEVC](https://github.com/rigaya/QSVEnc/releases) | x264 | rav1e | AOM AV1 | SVT AV1 | VP9 | WEBP | GIF |
-| --------- | ---- | ---------- | ----------- | ----------- | ----------- |------| ----- | ------- |-----| --- | ---- | --- |
-| HDR10     |   ✓  |            |      ✓     |      ✓     |      ✓     |      |       |         | ✓   |  ✓* |      |     |
-| HDR10+    |   ✓  |            |      ✓     |            |            |      |       |         |     |     |      |     |
-| Audio     |   ✓  |      ✓     |      ✓*    |      ✓*    |      ✓*    |  ✓   |   ✓  |    ✓    | ✓   |  ✓   |      |     |
-| Subtitles |   ✓  |      ✓     |      ✓     |      ✓     |      ✓     |  ✓   |   ✓  |    ✓    | ✓   |      |      |     |
-| Covers    |   ✓  |      ✓     |            |            |            |  ✓   |   ✓  |    ✓    | ✓   |      |      |     |
-| bt.2020   |   ✓  |     ✓      |     ✓      |     ✓      |     ✓      |   ✓  |  ✓    |   ✓    | ✓   |  ✓   |      |     |
+| Encoder   | x265 |  NVENC HEVC | [NVEncC HEVC](https://github.com/rigaya/NVEnc/releases) | [VCEEncC HEVC](https://github.com/rigaya/VCEEnc/releases) | [QSVEncC HEVC](https://github.com/rigaya/QSVEnc/releases) | x264 | rav1e | AOM AV1 | SVT AV1 | VP9 |
+| --------- | ---- | ---------- | ----------- | ----------- | ----------- |------| ----- | ------- |-----| --- |
+| HDR10     |   ✓  |            |      ✓     |      ✓     |      ✓     |      |       |         | ✓   |  ✓* |
+| HDR10+    |   ✓  |            |      ✓     |            |            |      |       |         |     |     |
+| Audio     |   ✓  |      ✓     |      ✓*    |      ✓*    |      ✓*    |  ✓   |   ✓  |    ✓    | ✓   |  ✓   |
+| Subtitles |   ✓  |      ✓     |      ✓     |      ✓     |      ✓     |  ✓   |   ✓  |    ✓    | ✓   |      |
+| Covers    |   ✓  |      ✓     |            |            |            |  ✓   |   ✓  |    ✓    | ✓   |      |
+| bt.2020   |   ✓  |     ✓      |     ✓      |     ✓      |     ✓      |   ✓  |  ✓    |   ✓    | ✓   |  ✓   |
 
 `✓ - Full support   |   ✓* - Limited support`
 
@@ -98,7 +98,7 @@ Check out the different ways you can help [support FastFlix](https://github.com/
 
 # License
 
-Copyright (C) 2019-2021 Chris Griffith
+Copyright (C) 2019-2022 Chris Griffith
 
 The code itself is licensed under the MIT which you can read in the `LICENSE` file. <br>
 Read more about the release licensing in the [docs](docs/README.md) folder. <br>

--- a/docs/build-licenses.txt
+++ b/docs/build-licenses.txt
@@ -24,7 +24,7 @@ FastFlix's is MIT licenced.
 
 The MIT License
 
-Copyright (c) 2019-2021 Chris Griffith
+Copyright (c) 2019-2022 Chris Griffith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fastflix/application.py
+++ b/fastflix/application.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
-import os
 import sys
 
 import coloredlogs
 import reusables
 from PySide2 import QtGui, QtWidgets, QtCore
-from PySide2.QtGui import QPalette, QColor
-from PySide2.QtCore import Qt
 
 from fastflix.flix import ffmpeg_audio_encoders, ffmpeg_configuration, ffprobe_configuration, ffmpeg_opencl_support
 from fastflix.language import t

--- a/fastflix/application.py
+++ b/fastflix/application.py
@@ -68,6 +68,7 @@ def init_encoders(app: FastFlixApp, **_):
     from fastflix.encoders.vceencc_avc import main as vceencc_avc_plugin
     from fastflix.encoders.hevc_videotoolbox import main as hevc_videotoolbox_plugin
     from fastflix.encoders.h264_videotoolbox import main as h264_videotoolbox_plugin
+    from fastflix.encoders.svt_av1_avif import main as svt_av1_avif_plugin
 
     encoders = [
         hevc_plugin,
@@ -77,6 +78,7 @@ def init_encoders(app: FastFlixApp, **_):
         av1_plugin,
         rav1e_plugin,
         svt_av1_plugin,
+        svt_av1_avif_plugin,
         avc_plugin,
         vp9_plugin,
         gif_plugin,

--- a/fastflix/application.py
+++ b/fastflix/application.py
@@ -6,6 +6,8 @@ import sys
 import coloredlogs
 import reusables
 from PySide2 import QtGui, QtWidgets, QtCore
+from PySide2.QtGui import QPalette, QColor
+from PySide2.QtCore import Qt
 
 from fastflix.flix import ffmpeg_audio_encoders, ffmpeg_configuration, ffprobe_configuration, ffmpeg_opencl_support
 from fastflix.language import t
@@ -14,7 +16,7 @@ from fastflix.models.fastflix import FastFlix
 from fastflix.models.fastflix_app import FastFlixApp
 from fastflix.program_downloads import ask_for_ffmpeg, latest_ffmpeg
 from fastflix.resources import main_icon, breeze_styles_path, get_bool_env
-from fastflix.shared import file_date, message
+from fastflix.shared import file_date, message, latest_fastflix
 from fastflix.version import __version__
 from fastflix.widgets.container import Container
 from fastflix.widgets.progress_bar import ProgressBar, Task
@@ -195,6 +197,9 @@ def start_app(worker_queue, status_queue, log_queue, queue_list, queue_lock):
 
     container = Container(app)
     container.show()
+
+    if not app.fastflix.config.disable_version_check:
+        latest_fastflix(app=app, show_new_dialog=False)
 
     try:
         app.exec_()

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -6801,3 +6801,65 @@ There are more than 100 files, skipping pre-processing.:
   por: Existem mais de 100 ficheiros, saltando o pré-processamento.
   swe: Det finns mer än 100 filer, och du kan hoppa över förbehandlingen.
   pol: Istnieje ponad 100 plików, z pominięciem przetwarzania wstępnego.
+No audio tracks matched for this profile, enable first track?:
+  eng: No audio tracks matched for this profile, enable first track?
+  deu: Keine Audiospuren für dieses Profil gefunden, erste Spur aktivieren?
+  fra: Aucune piste audio ne correspond à ce profil, activez la première piste ?
+  ita: Non ci sono tracce audio corrispondenti per questo profilo, attivare la prima
+    traccia?
+  spa: No hay pistas de audio que coincidan con este perfil, habilitar la primera
+    pista?
+  zho: 此配置文件没有匹配的音轨，启用第一个音轨？
+  jpn: このプロファイルに一致するオーディオトラックがありません、最初のトラックを有効にしますか？
+  rus: Для этого профиля не подобраны звуковые дорожки, включить первую дорожку?
+  por: Não há faixas de áudio correspondentes a este perfil, permitir a primeira faixa?
+  swe: Inga ljudspår har matchats för den här profilen, aktivera det första spåret?
+  pol: Brak dopasowanych ścieżek audio dla tego profilu, włączyć pierwszą ścieżkę?
+No Audio Match:
+  eng: No Audio Match
+  deu: Keine Audioübereinstimmung
+  fra: Pas de correspondance audio
+  ita: Nessuna corrispondenza audio
+  spa: No hay coincidencia de audio
+  zho: 没有音频匹配
+  jpn: オーディオマッチングなし
+  rus: Нет звукового соответствия
+  por: Sem Audio Match
+  swe: Ingen ljudmatchning
+  pol: Brak dopasowania audio
+Unselect All:
+  eng: Unselect All
+  deu: Alle abwählen
+  fra: Désélectionner tout
+  ita: Deselezionare tutti
+  spa: Deseleccionar todo
+  zho: 取消选择所有
+  jpn: すべて選択解除
+  rus: Не выбирать все
+  por: Desseleccionar todos
+  swe: Avmarkera alla
+  pol: Nie wybieraj wszystkich
+Preserve All:
+  eng: Preserve All
+  deu: Alles bewahren
+  fra: Préserver tout
+  ita: Conservare tutto
+  spa: Conservar todo
+  zho: 保存所有
+  jpn: プリザーブオール
+  rus: Сохранить все
+  por: Preservar tudo
+  swe: Bevara allt
+  pol: Zachować wszystko
+Rigaya's encoders will only match one encoding per track:
+  eng: Rigaya's encoders will only match one encoding per track
+  deu: Rigayas Encoder passen nur eine Kodierung pro Spur an
+  fra: Les encodeurs de Rigaya ne correspondent qu'à un seul encodage par piste.
+  ita: I codificatori di Rigaya corrispondono solo a una codifica per traccia.
+  spa: Los codificadores de Rigaya sólo coincidirán con una codificación por pista
+  zho: Rigaya的编码器在每条轨道上只能匹配一个编码
+  jpn: Rigayaのエンコーダーは1トラックにつき1つのエンコーディングにしかマッチしません
+  rus: Кодировщики Rigaya будут соответствовать только одной кодировке на дорожку
+  por: Os codificadores de Rigaya corresponderão apenas a uma codificação por pista
+  swe: Rigayas kodare matchar endast en kodning per spår.
+  pol: Kodery Rigaya dopasują tylko jedno kodowanie na ścieżkę.

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -6863,3 +6863,39 @@ Rigaya's encoders will only match one encoding per track:
   por: Os codificadores de Rigaya corresponderão apenas a uma codificação por pista
   swe: Rigayas kodare matchar endast en kodning per spår.
   pol: Kodery Rigaya dopasują tylko jedno kodowanie na ścieżkę.
+Default Output Folder:
+  eng: Default Output Folder
+  deu: Standard-Ausgabeordner
+  fra: Dossier de sortie par défaut
+  ita: Cartella di output predefinita
+  spa: Carpeta de salida por defecto
+  zho: 默认输出文件夹
+  jpn: デフォルトの出力先フォルダ
+  rus: Папка вывода по умолчанию
+  por: Pasta de saída por defeito
+  swe: Standardmapp för utdata
+  pol: Domyślny folder wyjściowy
+Use same output directory as source file:
+  eng: Use same output directory as source file
+  deu: Gleiches Ausgabeverzeichnis wie Quelldatei verwenden
+  fra: Utiliser le même répertoire de sortie que le fichier source
+  ita: Usa la stessa directory di output del file sorgente
+  spa: Utilizar el mismo directorio de salida que el archivo de origen
+  zho: 使用与源文件相同的输出目录
+  jpn: ソースファイルと同じ出力ディレクトリを使用する
+  rus: Использовать тот же выходной каталог, что и исходный файл
+  por: Usar o mesmo directório de saída que o ficheiro fonte
+  swe: Använd samma utskriftskatalog som källfilen
+  pol: Użyj tego samego katalogu wyjściowego co plik źródłowy
+Please consider supporting FastFlix with a one time contribution!:
+  eng: Please consider supporting FastFlix with a one time contribution!
+  deu: Bitte unterstützen Sie FastFlix mit einer einmaligen Spende!
+  fra: Merci d'envisager de soutenir FastFlix par une contribution unique!
+  ita: Considerate di sostenere FastFlix con un contributo una tantum!
+  spa: Por favor, considere apoyar a FastFlix con una contribución única.
+  zho: 请考虑用一次性捐款支持FastFlix!
+  jpn: FastFlixへの1回限りの寄付をご検討ください。
+  rus: Пожалуйста, рассмотрите возможность поддержать FastFlix единовременным взносом!
+  por: Por favor, considere apoiar FastFlix com uma contribuição única!
+  swe: Överväg att stödja FastFlix med ett engångsbidrag!
+  pol: Proszę rozważyć wsparcie FastFlix jednorazową wpłatą!

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -5607,7 +5607,7 @@ Not all items in the queue were completed:
   fra: Tous les articles dans la file d'attente n'ont pas été complétés
   ita: Non tutti gli elementi in coda sono stati completati
   spa: No se han completado todos los elementos de la cola
-  zho: 并非队列中的所有项目都已完成
+  zho: 队列中有未完成的项目
   jpn: キュー内のすべてのアイテムが完了していない
   rus: Не все пункты в очереди были завершены
   por: Nem todos os itens da fila foram completados
@@ -5679,7 +5679,7 @@ FastFlix Wiki:
   fra: FastFlix Wiki
   ita: FastFlix Wiki
   spa: FastFlix Wiki
-  zho: FastFlix 维基百科
+  zho: FastFlix Wiki
   jpn: FastFlix Wiki
   rus: FastFlix Wiki
   por: FastFlix Wiki
@@ -5848,7 +5848,7 @@ Concatenation Builder:
   fra: Créateur de concaténation
   ita: Costruttore di concatenazioni
   spa: Constructor de Concatenación
-  zho: 串联生成器
+  zho: 创建合并序列
   jpn: コンカチネーションビルダー
   rus: Конструктор конкатенации
   por: Construtor de Concatenação
@@ -5932,7 +5932,7 @@ Base Folder:
   fra: Dossier de base
   ita: Cartella base
   spa: Carpeta base
-  zho: 基本文件夹
+  zho: 当前文件夹
   jpn: ベースフォルダー
   rus: Базовая папка
   por: Pasta de base
@@ -5956,7 +5956,7 @@ Load:
   fra: Charger
   ita: Carica
   spa: Cargar
-  zho: 装载
+  zho: 载入
   jpn: ロード
   rus: Нагрузка
   por: Carga
@@ -5971,7 +5971,7 @@ Drag and Drop to reorder - All items need to be same dimensions:
   ita: Drag and Drop per riordinare - Tutti gli elementi devono avere le stesse dimensioni
   spa: Arrastrar y soltar para reordenar - Todos los elementos deben tener las mismas
     dimensiones
-  zho: 拖放来重新排序 - 所有项目都需要相同的尺寸
+  zho: 拖放来重新排序 - 所有项目的尺寸都需要相同
   jpn: ドラッグ＆ドロップで再注文 - すべてのアイテムが同じ寸法である必要があります。
   rus: Перетаскивание для изменения порядка - все предметы должны иметь одинаковые
     размеры
@@ -6055,7 +6055,7 @@ does not support concatenating files together:
   fra: ne supporte pas la concaténation de fichiers ensemble
   ita: non supporta la concatenazione di file
   spa: no admite la concatenación de archivos
-  zho: 不支持将文件串联起来
+  zho: 不支持将文件合并起来
   jpn: は、ファイルの連結をサポートしていません。
   rus: не поддерживает конкатенацию файлов вместе
   por: não suporta a concatenação de ficheiros em conjunto
@@ -6299,7 +6299,7 @@ Extra svt av1 params in opt=1:opt2=0 format:
   fra: Paramètres supplémentaires de svt av1 au format opt=1:opt2=0
   ita: Parametri extra svt av1 nel formato opt=1:opt2=0
   spa: Parámetros extra svt av1 en formato opt=1:opt2=0
-  zho: 额外的svt av1参数为opt=1:opt2=0格式
+  zho: 额外的svt av1参数，格式为opt=1:opt2=0
   jpn: opt=1:opt2=0のフォーマットでの余分なsvt av1パラメータ
   rus: Дополнительные параметры svt av1 в формате opt=1:opt2=0
   por: Parâmetros av1 extra svt no formato opt=1:opt2=0
@@ -6335,7 +6335,7 @@ Equalizer:
   fra: Égaliseur
   ita: Equalizzatore
   spa: Ecualizador
-  zho: 平衡器
+  zho: 均衡器
   jpn: イコライザー
   rus: Эквалайзер
   por: Equalizador
@@ -6347,7 +6347,7 @@ Method:
   fra: Méthode
   ita: Metodo
   spa: Método
-  zho: 方法
+  zho: 方式
   jpn: 方法
   rus: Метод
   por: Método
@@ -6359,7 +6359,7 @@ Color Formats:
   fra: Formats de couleur
   ita: Formati di colore
   spa: Formatos de color
-  zho: 彩色格式
+  zho: 色彩格式
   jpn: カラーフォーマット
   rus: Форматы цветов
   por: Formatos de cores
@@ -6486,7 +6486,7 @@ AVC coding profile:
   fra: Profil de codage AVC
   ita: Profilo di codifica AVC
   spa: Perfil de codificación AVC
-  zho: AVC编码简介
+  zho: AVC编码规格
   jpn: AVC符号化プロファイル
   rus: Профиль кодирования AVC
   por: Perfil de codificação AVC
@@ -6566,7 +6566,7 @@ Other frames will come before the frames in this session. This helps smooth conc
     aiuta a smussare i problemi di concatenazione.
   spa: Los demás fotogramas vendrán antes que los fotogramas de esta sesión. Esto
     ayuda a suavizar los problemas de concatenación.
-  zho: 其他的帧会在这个会话中的帧之前出现。这有助于平滑串联问题。
+  zho: 其他的帧会在这个会话中的帧之前出现。这有助于缓解合并中的问题。
   jpn: 他のフレームは、このセッションのフレームより前に来ます。これは、連結の問題をスムーズにするのに役立ちます。
   rus: Другие кадры будут идти перед кадрами в этой сессии. Это помогает сгладить
     проблемы конкатенации.
@@ -6599,7 +6599,7 @@ Other frames will come after the frames in this session. This helps smooth conca
     aiuta a smussare i problemi di concatenazione.
   spa: Otros marcos vendrán después de los marcos de esta sesión. Esto ayuda a suavizar
     los problemas de concatenación.
-  zho: 其他的帧将在这个会话中的帧之后出现。这有助于平滑连接问题。
+  zho: 其他的帧将在这个会话中的帧之后出现。这有助于缓解合并中的问题。
   jpn: 他のフレームは、このセッションのフレームの後に来ます。これは、連結の問題をスムーズにするのに役立ちます。
   rus: Другие кадры будут идти после кадров этой сессии. Это помогает сгладить проблемы
     с конкатенацией.
@@ -6615,7 +6615,7 @@ HEVC coding profile - must match bit depth:
   fra: Profil de codage HEVC - doit correspondre à la profondeur de bit
   ita: Profilo di codifica HEVC - deve corrispondere alla profondità di bit
   spa: 'Perfil de codificación HEVC: debe coincidir con la profundidad de bits'
-  zho: HEVC编码配置文件 - 必须与比特深度相匹配
+  zho: HEVC编码配置文件 - 必须与位深度相匹配
   jpn: HEVCコーディングプロファイル - ビット深度との一致が必要
   rus: Профиль кодирования HEVC - должен соответствовать битовой глубине
   por: Perfil de codificação HEVC - deve corresponder à profundidade do bit
@@ -6639,7 +6639,7 @@ Custom QSVEncC options:
   fra: Options personnalisées de QSVEncC
   ita: Opzioni QSVEncC personalizzate
   spa: Opciones personalizadas de QSVEncC
-  zho: 定制QSVEncC选项
+  zho: 自定义QSVEncC选项
   jpn: QSVEncCのカスタムオプション
   rus: Пользовательские опции QSVEncC
   por: Opções personalizadas de QSVEncC
@@ -6723,7 +6723,7 @@ Are you sure you want to proceed?:
   fra: Vous êtes sûr de vouloir continuer ?
   ita: Sei sicuro di voler procedere?
   spa: ¿Estás seguro de que quieres continuar?
-  zho: 你确定你要继续吗？
+  zho: 确定要继续吗？
   jpn: 本当に進めていいんですか？
   rus: Вы уверены, что хотите продолжить?
   por: Você tem certeza de que quer prosseguir?
@@ -6795,7 +6795,7 @@ There are more than 100 files, skipping pre-processing.:
   fra: Il y a plus de 100 fichiers, en sautant le prétraitement.
   ita: Ci sono più di 100 file, saltando la pre-elaborazione.
   spa: Hay más de 100 archivos, omitiendo el preprocesamiento.
-  zho: 有100多个文件，跳过预处理。
+  zho: 文件多于100个，跳过预处理。
   jpn: 前処理を省いて100ファイル以上あります。
   rus: Имеется более 100 файлов, пропуская предварительную обработку.
   por: Existem mais de 100 ficheiros, saltando o pré-processamento.

--- a/fastflix/encoders/common/encc_helpers.py
+++ b/fastflix/encoders/common/encc_helpers.py
@@ -52,7 +52,7 @@ def build_subtitle(subtitle_tracks: List[SubtitleTrack], subtitle_streams, video
     copies = []
     stream_ids = get_stream_pos(subtitle_streams)
 
-    scale = ",scale=2.0" if video_height > 1800 else {}
+    scale = ",scale=2.0" if video_height > 1800 else ""
 
     for track in sorted(subtitle_tracks, key=lambda x: x.outdex):
         sub_id = stream_ids[track.index]

--- a/fastflix/encoders/common/encc_helpers.py
+++ b/fastflix/encoders/common/encc_helpers.py
@@ -47,15 +47,17 @@ def build_audio(audio_tracks: List[AudioTrack], audio_streams):
     return f" --audio-copy {','.join(copies)} {' '.join(command_list)}" if copies else f" {' '.join(command_list)}"
 
 
-def build_subtitle(subtitle_tracks: List[SubtitleTrack], subtitle_streams) -> str:
+def build_subtitle(subtitle_tracks: List[SubtitleTrack], subtitle_streams, video_height: int) -> str:
     command_list = []
     copies = []
     stream_ids = get_stream_pos(subtitle_streams)
 
+    scale = ",scale=2.0" if video_height > 1800 else {}
+
     for track in sorted(subtitle_tracks, key=lambda x: x.outdex):
         sub_id = stream_ids[track.index]
         if track.burn_in:
-            command_list.append(f"--vpp-subburn track={sub_id}")
+            command_list.append(f"--vpp-subburn track={sub_id}{scale}")
         else:
             copies.append(str(sub_id))
             if track.disposition:

--- a/fastflix/encoders/common/helpers.py
+++ b/fastflix/encoders/common/helpers.py
@@ -10,7 +10,7 @@ from fastflix.encoders.common.attachments import build_attachments
 from fastflix.encoders.common.audio import build_audio
 from fastflix.encoders.common.subtitles import build_subtitle
 from fastflix.models.fastflix import FastFlix
-from fastflix.shared import clean_file_string, sanitize
+from fastflix.shared import clean_file_string, sanitize, quoted_path
 
 null = "/dev/null"
 if reusables.win_based:
@@ -193,7 +193,7 @@ def generate_filters(
             else:
                 filter_complex = f"[0:{selected_track}][0:{burn_in_subtitle_track}]overlay[v]"
         else:
-            filter_complex = f"[0:{selected_track}]{f'{filters},' if filters else ''}subtitles='{clean_file_string(source)}':si={burn_in_subtitle_track}[v]"
+            filter_complex = f"[0:{selected_track}]{f'{filters},' if filters else ''}subtitles={quoted_path(clean_file_string(source))}:si={burn_in_subtitle_track}[v]"
     elif filters:
         filter_complex = f"[0:{selected_track}]{filters}[v]"
     else:

--- a/fastflix/encoders/nvencc_avc/command_builder.py
+++ b/fastflix/encoders/nvencc_avc/command_builder.py
@@ -145,7 +145,7 @@ def build(fastflix: FastFlix):
         remove_hdr,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.video_settings.audio_tracks, video.streams.audio),
-        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle),
+        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle, video_height=video.height),
         settings.extra,
         "-o",
         f'"{clean_file_string(video.video_settings.output_path)}"',

--- a/fastflix/encoders/nvencc_avc/main.py
+++ b/fastflix/encoders/nvencc_avc/main.py
@@ -15,6 +15,7 @@ icon = str(Path(pkg_resources.resource_filename(__name__, f"../../data/encoders/
 enable_subtitles = True
 enable_audio = True
 enable_attachments = False
+original_audio_tracks_only = True
 
 # Taken from NVEncC64.exe --check-encoders
 audio_formats = [

--- a/fastflix/encoders/nvencc_hevc/command_builder.py
+++ b/fastflix/encoders/nvencc_hevc/command_builder.py
@@ -176,7 +176,7 @@ def build(fastflix: FastFlix):
         remove_hdr,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.video_settings.audio_tracks, video.streams.audio),
-        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle),
+        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle, video_height=video.height),
         settings.extra,
         "-o",
         f'"{clean_file_string(video.video_settings.output_path)}"',

--- a/fastflix/encoders/nvencc_hevc/main.py
+++ b/fastflix/encoders/nvencc_hevc/main.py
@@ -14,6 +14,7 @@ icon = str(Path(pkg_resources.resource_filename(__name__, f"../../data/encoders/
 enable_subtitles = True
 enable_audio = True
 enable_attachments = False
+original_audio_tracks_only = True
 
 # Taken from NVEncC64.exe --check-encoders
 audio_formats = [

--- a/fastflix/encoders/qsvencc_avc/command_builder.py
+++ b/fastflix/encoders/qsvencc_avc/command_builder.py
@@ -137,7 +137,7 @@ def build(fastflix: FastFlix):
         remove_hdr,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.video_settings.audio_tracks, video.streams.audio),
-        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle),
+        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle, video_height=video.height),
         settings.extra,
         "-o",
         f'"{clean_file_string(video.video_settings.output_path)}"',

--- a/fastflix/encoders/qsvencc_avc/main.py
+++ b/fastflix/encoders/qsvencc_avc/main.py
@@ -14,6 +14,7 @@ icon = str(Path(pkg_resources.resource_filename(__name__, f"../../data/encoders/
 enable_subtitles = True
 enable_audio = True
 enable_attachments = False
+original_audio_tracks_only = True
 
 # Taken from NVEncC64.exe --check-encoders
 audio_formats = [

--- a/fastflix/encoders/qsvencc_hevc/command_builder.py
+++ b/fastflix/encoders/qsvencc_hevc/command_builder.py
@@ -156,7 +156,7 @@ def build(fastflix: FastFlix):
         remove_hdr,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.video_settings.audio_tracks, video.streams.audio),
-        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle),
+        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle, video_height=video.height),
         settings.extra,
         "-o",
         f'"{clean_file_string(video.video_settings.output_path)}"',

--- a/fastflix/encoders/qsvencc_hevc/main.py
+++ b/fastflix/encoders/qsvencc_hevc/main.py
@@ -14,6 +14,7 @@ icon = str(Path(pkg_resources.resource_filename(__name__, f"../../data/encoders/
 enable_subtitles = True
 enable_audio = True
 enable_attachments = False
+original_audio_tracks_only = True
 
 # Taken from NVEncC64.exe --check-encoders
 audio_formats = [

--- a/fastflix/encoders/svt_av1_avif/command_builder.py
+++ b/fastflix/encoders/svt_av1_avif/command_builder.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+import re
+import secrets
+
+import reusables
+
+from fastflix.encoders.common.helpers import Command, generate_all, generate_color_details, null
+from fastflix.models.encode import SVTAV1Settings
+from fastflix.models.fastflix import FastFlix
+
+logger = logging.getLogger("fastflix")
+
+
+@reusables.log_exception("fastflix", show_traceback=True)
+def build(fastflix: FastFlix):
+    settings: SVTAV1Settings = fastflix.current_video.video_settings.video_encoder_settings
+    beginning, ending = generate_all(fastflix, "libsvtav1", audio=False, subs=False)
+
+    beginning += f"-strict experimental " f"-preset {settings.speed} " f"{generate_color_details(fastflix)} "
+
+    svtav1_params = settings.svtav1_params.copy()
+
+    if not fastflix.current_video.video_settings.remove_hdr:
+
+        if (
+            fastflix.current_video.video_settings.color_primaries == "bt2020"
+            or fastflix.current_video.color_primaries == "bt2020"
+        ):
+            svtav1_params.append(f"color-primaries=9")
+
+        if (
+            fastflix.current_video.video_settings.color_transfer == "smpte2084"
+            or fastflix.current_video.color_transfer == "smpte2084"
+        ):
+            svtav1_params.append(f"transfer-characteristics=16")
+
+        if (
+            fastflix.current_video.video_settings.color_space
+            and "bt2020" in fastflix.current_video.video_settings.color_space
+        ) or (fastflix.current_video.color_space and "bt2020" in fastflix.current_video.color_space):
+            svtav1_params.append(f"matrix-coefficients=9")
+
+        enable_hdr = False
+        if settings.pix_fmt in ("yuv420p10le", "yuv420p12le"):
+
+            def convert_me(two_numbers, conversion_rate=50_000) -> str:
+                num_one, num_two = map(int, two_numbers.strip("()").split(","))
+                return f"{num_one / conversion_rate:0.4f},{num_two / conversion_rate:0.4f}"
+
+            if fastflix.current_video.master_display:
+                svtav1_params.append(
+                    "mastering-display="
+                    f"G({convert_me(fastflix.current_video.master_display.green)})"
+                    f"B({convert_me(fastflix.current_video.master_display.blue)})"
+                    f"R({convert_me(fastflix.current_video.master_display.red)})"
+                    f"WP({convert_me(fastflix.current_video.master_display.white)})"
+                    f"L({convert_me(fastflix.current_video.master_display.luminance, 10_000)})"
+                )
+                enable_hdr = True
+
+            if fastflix.current_video.cll:
+                svtav1_params.append(f"content-light={fastflix.current_video.cll}")
+                enable_hdr = True
+
+            if enable_hdr:
+                svtav1_params.append("enable-hdr=1")
+
+    if svtav1_params:
+        beginning += f" -svtav1-params \"{':'.join(svtav1_params)}\" "
+
+    pass_type = "bitrate" if settings.bitrate else "QP"
+
+    if settings.bitrate:
+        command_1 = f"{beginning} -b:v {settings.bitrate} {settings.extra} {ending}"
+
+    elif settings.qp is not None:
+        command_1 = f"{beginning} -{settings.qp_mode} {settings.qp} {settings.extra} {ending}"
+    else:
+        return []
+    return [Command(command=command_1, name=f"{pass_type}", exe="ffmpeg")]

--- a/fastflix/encoders/svt_av1_avif/command_builder.py
+++ b/fastflix/encoders/svt_av1_avif/command_builder.py
@@ -8,7 +8,7 @@ import secrets
 import reusables
 
 from fastflix.encoders.common.helpers import Command, generate_all, generate_color_details, null
-from fastflix.models.encode import SVTAV1Settings
+from fastflix.models.encode import SVTAVIFSettings
 from fastflix.models.fastflix import FastFlix
 
 logger = logging.getLogger("fastflix")
@@ -16,7 +16,7 @@ logger = logging.getLogger("fastflix")
 
 @reusables.log_exception("fastflix", show_traceback=True)
 def build(fastflix: FastFlix):
-    settings: SVTAV1Settings = fastflix.current_video.video_settings.video_encoder_settings
+    settings: SVTAVIFSettings = fastflix.current_video.video_settings.video_encoder_settings
     beginning, ending = generate_all(fastflix, "libsvtav1", audio=False, subs=False)
 
     beginning += f"-strict experimental " f"-preset {settings.speed} " f"{generate_color_details(fastflix)} "

--- a/fastflix/encoders/svt_av1_avif/main.py
+++ b/fastflix/encoders/svt_av1_avif/main.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+__author__ = "Chris Griffith"
+from pathlib import Path
+
+import pkg_resources
+
+name = "AVIF (SVT AV1)"
+requires = "libsvtav1"
+
+video_extension = "avif"
+video_dimension_divisor = 8
+icon = str(Path(pkg_resources.resource_filename(__name__, f"../../data/encoders/icon_svt_av1.png")).resolve())
+
+enable_subtitles = False
+enable_audio = False
+enable_attachments = False
+enable_concat = True
+
+from fastflix.encoders.svt_av1_avif.command_builder import build
+from fastflix.encoders.svt_av1_avif.settings_panel import SVT_AV1_AVIF as settings_panel

--- a/fastflix/encoders/svt_av1_avif/settings_panel.py
+++ b/fastflix/encoders/svt_av1_avif/settings_panel.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import logging
+
+from box import Box
+from PySide2 import QtCore, QtWidgets
+
+from fastflix.encoders.common.setting_panel import SettingPanel
+from fastflix.language import t
+from fastflix.models.encode import SVTAVIFSettings
+from fastflix.models.fastflix_app import FastFlixApp
+from fastflix.shared import link
+
+logger = logging.getLogger("fastflix")
+
+recommended_bitrates = [
+    "150k   (320x240p @ 30fps)",
+    "276k   (640x360p @ 30fps)",
+    "512k   (640x480p @ 30fps)",
+    "1024k  (1280x720p @ 30fps)",
+    "1800k (1280x720p @ 60fps)",
+    "1800k (1920x1080p @ 30fps)",
+    "3000k (1920x1080p @ 60fps)",
+    "6000k (2560x1440p @ 30fps)",
+    "9000k (2560x1440p @ 60fps)",
+    "12000k (3840x2160p @ 30fps)",
+    "18000k (3840x2160p @ 60fps)",
+    "Custom",
+]
+
+recommended_qp = [
+    "14",
+    "15",
+    "16",
+    "17",
+    "18",
+    "19",
+    "20",
+    "21",
+    "22",
+    "23",
+    "24 - recommended",
+    "25",
+    "26",
+    "27",
+    "28",
+    "29",
+    "30 - standard",
+    "31",
+    "32",
+    "33",
+    "34",
+    "35",
+    "36",
+    '50 - "I\'m just testing to see if this works"',
+    "Custom",
+]
+pix_fmts = ["8-bit: yuv420p", "10-bit: yuv420p10le"]
+
+
+class SVT_AV1_AVIF(SettingPanel):
+    profile_name = "svt_av1_avif"
+
+    def __init__(self, parent, main, app: FastFlixApp):
+        super().__init__(parent, main, app)
+        self.main = main
+        self.app = app
+
+        grid = QtWidgets.QGridLayout()
+
+        self.widgets = Box(fps=None, mode=None, segment_size=None)
+
+        self.mode = "QP"
+
+        grid.addLayout(self.init_preset(), 0, 0, 1, 2)
+        grid.addLayout(self.init_pix_fmt(), 1, 0, 1, 2)
+        grid.addLayout(self.init_qp_or_crf(), 5, 0, 1, 2)
+        grid.addLayout(self.init_modes(), 0, 2, 5, 4)
+        grid.addLayout(self.init_svtav1_params(), 5, 2, 1, 4)
+
+        grid.setRowStretch(8, 1)
+        guide_label = QtWidgets.QLabel(
+            link(
+                "https://github.com/AOMediaCodec/SVT-AV1/blob/master/Docs/svt-av1_encoder_user_guide.md",
+                t("SVT-AV1 Encoding Guide"),
+                app.fastflix.config.theme,
+            )
+        )
+        guide_label.setAlignment(QtCore.Qt.AlignBottom)
+        guide_label.setOpenExternalLinks(True)
+        grid.addLayout(self._add_custom(), 10, 0, 1, 6)
+        grid.addWidget(guide_label, 11, 0, -1, 1)
+        self.setLayout(grid)
+        self.hide()
+
+    def init_pix_fmt(self):
+        return self._add_combo_box(
+            label="Bit Depth",
+            tooltip="Pixel Format (requires at least 10-bit for HDR)",
+            widget_name="pix_fmt",
+            options=pix_fmts,
+            opt="pix_fmt",
+        )
+
+    def init_preset(self):
+        return self._add_combo_box(
+            label="Preset",
+            widget_name="speed",
+            options=[str(x) for x in range(14)],
+            tooltip="Quality/Speed ratio modifier",
+            opt="speed",
+        )
+
+    def init_qp_or_crf(self):
+        return self._add_combo_box(
+            label="Quantization Mode",
+            widget_name="qp_mode",
+            options=["qp", "crf"],
+            tooltip="Use CRF or QP",
+            opt="qp_mode",
+        )
+
+    def init_svtav1_params(self):
+        layout = QtWidgets.QHBoxLayout()
+        self.labels.svtav1_params = QtWidgets.QLabel(t("Additional svt av1 params"))
+        self.labels.svtav1_params.setFixedWidth(200)
+        tool_tip = f"{t('Extra svt av1 params in opt=1:opt2=0 format')},\n" f"{t('cannot modify generated settings')}"
+        self.labels.svtav1_params.setToolTip(tool_tip)
+        layout.addWidget(self.labels.svtav1_params)
+        self.widgets.svtav1_params = QtWidgets.QLineEdit()
+        self.widgets.svtav1_params.setToolTip(tool_tip)
+        self.widgets.svtav1_params.setText(
+            ":".join(self.app.fastflix.config.encoder_opt(self.profile_name, "svtav1_params"))
+        )
+        self.opts["svtav1_params"] = "svtav1_params"
+        self.widgets.svtav1_params.textChanged.connect(lambda: self.main.page_update())
+        layout.addWidget(self.widgets.svtav1_params)
+        return layout
+
+    def init_modes(self):
+        return self._add_modes(recommended_bitrates, recommended_qp, qp_name="qp")
+
+    def mode_update(self):
+        self.widgets.custom_qp.setDisabled(self.widgets.qp.currentText() != "Custom")
+        self.widgets.custom_bitrate.setDisabled(self.widgets.bitrate.currentText() != "Custom")
+        self.main.build_commands()
+
+    def update_video_encoder_settings(self):
+        svtav1_params_text = self.widgets.svtav1_params.text().strip()
+
+        settings = SVTAVIFSettings(
+            speed=self.widgets.speed.currentText(),
+            qp_mode=self.widgets.qp_mode.currentText(),
+            pix_fmt=self.widgets.pix_fmt.currentText().split(":")[1].strip(),
+            extra=self.ffmpeg_extras,
+            svtav1_params=svtav1_params_text.split(":") if svtav1_params_text else [],
+        )
+        encode_type, q_value = self.get_mode_settings()
+        settings.qp = q_value if encode_type == "qp" else None
+        settings.bitrate = q_value if encode_type == "bitrate" else None
+        self.app.fastflix.current_video.video_settings.video_encoder_settings = settings
+
+    def set_mode(self, x):
+        self.mode = x.text()
+        self.main.build_commands()

--- a/fastflix/encoders/vceencc_avc/command_builder.py
+++ b/fastflix/encoders/vceencc_avc/command_builder.py
@@ -129,7 +129,7 @@ def build(fastflix: FastFlix):
         remove_hdr,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.video_settings.audio_tracks, video.streams.audio),
-        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle),
+        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle, video_height=video.height),
         settings.extra,
         "-o",
         f'"{clean_file_string(video.video_settings.output_path)}"',

--- a/fastflix/encoders/vceencc_avc/main.py
+++ b/fastflix/encoders/vceencc_avc/main.py
@@ -15,6 +15,7 @@ icon = str(Path(pkg_resources.resource_filename(__name__, f"../../data/encoders/
 enable_subtitles = True
 enable_audio = True
 enable_attachments = False
+original_audio_tracks_only = True
 
 # Taken from VCEEncC64.exe --check-encoders
 audio_formats = [

--- a/fastflix/encoders/vceencc_hevc/command_builder.py
+++ b/fastflix/encoders/vceencc_hevc/command_builder.py
@@ -148,7 +148,7 @@ def build(fastflix: FastFlix):
         remove_hdr,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.video_settings.audio_tracks, video.streams.audio),
-        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle),
+        build_subtitle(video.video_settings.subtitle_tracks, video.streams.subtitle, video_height=video.height),
         settings.extra,
         "-o",
         f'"{clean_file_string(video.video_settings.output_path)}"',

--- a/fastflix/encoders/vceencc_hevc/main.py
+++ b/fastflix/encoders/vceencc_hevc/main.py
@@ -14,6 +14,7 @@ icon = str(Path(pkg_resources.resource_filename(__name__, f"../../data/encoders/
 enable_subtitles = True
 enable_audio = True
 enable_attachments = False
+original_audio_tracks_only = True
 
 # Taken from VCEEncC64.exe --check-encoders
 audio_formats = [

--- a/fastflix/models/config.py
+++ b/fastflix/models/config.py
@@ -111,7 +111,7 @@ class Config(BaseModel):
     selected_profile: str = "Standard Profile"
     theme: str = "onyx"
     disable_version_check: bool = False
-    disable_update_check: bool = False
+    disable_update_check: bool = False  # old name
     disable_automatic_subtitle_burn_in: bool = False
     custom_after_run_scripts: Dict = Field(default_factory=dict)
     profiles: Dict[str, Profile] = Field(default_factory=get_preset_defaults)
@@ -287,6 +287,8 @@ class Config(BaseModel):
                 self.ffmpeg = Path(data.ffprobe)
             self.disable_automatic_subtitle_burn_in = data.get("disable_automatic_subtitle_burn_in")
             self.disable_update_check = data.get("disable_update_check")
+            self.disable_version_check = data.get("disable_update_check", self.disable_update_check)
+            self.disable_version_check = data.get("disable_version_check", self.disable_version_check)
             self.use_sane_audio = data.get("use_sane_audio")
             for audio_type in data.get("sane_audio_selection", []):
                 if audio_type not in self.sane_audio_selection:

--- a/fastflix/models/encode.py
+++ b/fastflix/models/encode.py
@@ -267,6 +267,16 @@ class SVTAV1Settings(EncoderSettings):
     svtav1_params: List[str] = Field(default_factory=list)
 
 
+class SVTAVIFSettings(EncoderSettings):
+    name = "AVIF (SVT AV1)"
+    single_pass: bool = True
+    speed: str = "7"  # Renamed preset in svtav1 encoder
+    qp: Optional[Union[int, float]] = 24
+    qp_mode: str = "qp"
+    bitrate: Optional[str] = None
+    svtav1_params: List[str] = Field(default_factory=list)
+
+
 class VP9Settings(EncoderSettings):
     name = "VP9"
     profile: int = 2
@@ -357,4 +367,5 @@ setting_types = {
     "vceencc_avc": VCEEncCAVCSettings,
     "hevc_videotoolbox": HEVCVideoToolboxSettings,
     "h264_videotoolbox": H264VideoToolboxSettings,
+    "svt_av1_avif": SVTAVIFSettings,
 }

--- a/fastflix/models/fastflix.py
+++ b/fastflix/models/fastflix.py
@@ -34,3 +34,6 @@ class FastFlix(BaseModel):
     conversion_list: List[Video] = Field(default_factory=list)
     current_video_encode_index = 0
     current_command_encode_index = 0
+
+    # State
+    shutting_down: bool = False

--- a/fastflix/models/profiles.py
+++ b/fastflix/models/profiles.py
@@ -26,6 +26,7 @@ from fastflix.models.encode import (
     VCEEncCSettings,
     HEVCVideoToolboxSettings,
     H264VideoToolboxSettings,
+    SVTAVIFSettings,
 )
 
 from fastflix.encoders.common.audio import channel_list
@@ -146,6 +147,7 @@ class Profile(BaseModel):
     x264: Optional[x264Settings] = None
     rav1e: Optional[rav1eSettings] = None
     svt_av1: Optional[SVTAV1Settings] = None
+    svt_av1_avif: Optional[SVTAVIFSettings] = None
     vp9: Optional[VP9Settings] = None
     aom_av1: Optional[AOMAV1Settings] = None
     gif: Optional[GIFSettings] = None

--- a/fastflix/models/video.py
+++ b/fastflix/models/video.py
@@ -28,6 +28,7 @@ from fastflix.models.encode import (
     VCEEncCAVCSettings,
     HEVCVideoToolboxSettings,
     H264VideoToolboxSettings,
+    SVTAVIFSettings,
 )
 
 __all__ = ["VideoSettings", "Status", "Video", "Crop", "Status"]
@@ -114,6 +115,7 @@ class VideoSettings(BaseModel):
         VCEEncCAVCSettings,
         HEVCVideoToolboxSettings,
         H264VideoToolboxSettings,
+        SVTAVIFSettings,
     ] = None
     audio_tracks: List[AudioTrack] = Field(default_factory=list)
     subtitle_tracks: List[SubtitleTrack] = Field(default_factory=list)

--- a/fastflix/shared.py
+++ b/fastflix/shared.py
@@ -260,6 +260,10 @@ def clean_file_string(source):
     return str(source).strip().strip("'\"")
 
 
+def quoted_path(source):
+    return str(source).strip().replace("\\", "\\\\\\\\").replace(":", "\\\\:").replace(" ", "\\ ").replace(",", "\\,")
+
+
 def sanitize(source):
     return str(sanitize_filepath(source, platform="Windows" if reusables.win_based else "Linux"))
     # return str().replace("\\", "/")

--- a/fastflix/shared.py
+++ b/fastflix/shared.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from distutils.version import StrictVersion
 from pathlib import Path
 from subprocess import run
+import platform
 
 from appdirs import user_data_dir
 import pkg_resources
@@ -110,21 +111,55 @@ def yes_no_message(msg, title=None, yes_text=t("Yes"), no_text=t("No"), yes_acti
     return None
 
 
-def latest_fastflix(no_new_dialog=False):
+def latest_fastflix(app, show_new_dialog=False):
     from fastflix.version import __version__
 
-    url = "https://api.github.com/repos/cdgriffith/FastFlix/releases/latest"
+    url = "https://api.github.com/repos/cdgriffith/FastFlix/releases"
+    contrib = link(
+        url="https://github.com/sponsors/cdgriffith?frequency=one-time&sponsor=cdgriffith",
+        text=t("Please consider supporting FastFlix with a one time contribution!"),
+        theme=app.fastflix.config.theme,
+    )
+
+    logger.debug("Checking for newer versions of FastFlix")
+
     try:
-        data = requests.get(url, timeout=15 if no_new_dialog else 3).json()
+        data = requests.get(url, timeout=15 if not show_new_dialog else 3).json()
     except Exception:
         logger.warning(t("Could not connect to github to check for newer versions"))
-        if no_new_dialog:
+        if show_new_dialog:
             message(t("Could not connect to github to check for newer versions"))
         return
 
-    if data["tag_name"] != __version__ and StrictVersion(data["tag_name"]) > StrictVersion(__version__):
+    versions = sorted(
+        (tuple(int(y) for y in x["tag_name"].split(".")) for x in data if not x["prerelease"] and not x["draft"]),
+        reverse=True,
+    )
+
+    use_version = ".".join(str(x) for x in versions[0])
+    if reusables.win_based:
+
+        try:
+            win_ver = int(platform.platform().lower().split("-")[1])
+        except Exception:
+            logger.warning(f"Could not extract Windows version from {platform.platform()}, please report this message")
+            win_ver = 0
+
+        if win_ver < 10:
+            logger.debug(f"Detected legacy Windows version {win_ver}, looking for 4.x builds only")
+            for version in versions:
+                if version[0] == 4:
+                    use_version = ".".join(str(x) for x in version)
+                    break
+            else:
+                logger.warning("No 4.x Versions found for legacy Windows")
+                return
+
+    release = [x for x in data if x["tag_name"] == use_version][0]
+
+    if use_version != __version__ and StrictVersion(use_version) > StrictVersion(__version__):
         portable, installer = None, None
-        for asset in data["assets"]:
+        for asset in release["assets"]:
             if asset["name"].endswith("win64.zip"):
                 portable = asset["browser_download_url"]
             if asset["name"].endswith("installer.exe"):
@@ -132,21 +167,33 @@ def latest_fastflix(no_new_dialog=False):
 
         download_link = ""
         if installer:
-            download_link += (
-                f"<a href='{installer}'>{t('Download')} FastFlix {t('installer')} {data['tag_name']}</a><br>"
+            download_link += link(
+                url=installer,
+                text=f"{t('Download')} FastFlix {t('installer')} {use_version}",
+                theme=app.fastflix.config.theme,
             )
+            download_link += "<br><br>"
         if portable:
-            download_link += f"<a href='{portable}'>{t('Download')} FastFlix {t('portable')} {data['tag_name']}</a><br>"
+            download_link += link(
+                url=portable,
+                text=f"{t('Download')} FastFlix {t('portable')} {use_version}",
+                theme=app.fastflix.config.theme,
+            )
+            download_link += "<br><br>"
         if (not portable and not installer) or not reusables.win_based:
-            html_link = data["html_url"]
-            download_link = f"<a href='{html_link}'>{t('View')} FastFlix {data['tag_name']} now</a>"
+            html_link = release["html_url"]
+            download_link = link(
+                url=html_link, text=f"{t('View')} FastFlix {use_version}", theme=app.fastflix.config.theme
+            )
+        logger.debug(f"Newer version found: {use_version}")
         message(
-            f"{t('There is a newer version of FastFlix available!')} <br> {download_link}",
+            f"{t('There is a newer version of FastFlix available!')} <br><br> {download_link} <br><br> {contrib} 💓<br>",
             title=t("New Version"),
         )
         return
-    if no_new_dialog:
-        message(t("You are using the latest version of FastFlix"))
+    logger.debug("FastFlix is up tp date")
+    if show_new_dialog:
+        message(t(f"You are using the latest version of FastFlix") + f" <br><br> {contrib} 💓 <br>")
 
 
 def file_date():

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "4.9.4"
+__version__ = "4.10.0"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/about.py
+++ b/fastflix/widgets/about.py
@@ -46,9 +46,11 @@ class About(QtWidgets.QWidget):
         bundle_label = QtWidgets.QLabel(
             f"Conversion suites: {link('https://www.ffmpeg.org/download.html', 'FFmpeg', app.fastflix.config.theme)} ({t('Various')}), "
             f"{link('https://github.com/rigaya/NVEnc', 'NVEncC', app.fastflix.config.theme)} (MIT) "
+            f"{link('https://github.com/rigaya/QSVEnc', 'QSVEnc', app.fastflix.config.theme)} (MIT) "
             f"{link('https://github.com/rigaya/VCEEnc', 'VCEEnc', app.fastflix.config.theme)} (MIT)<br><br>"
             f"Encoders: <br> {link('https://github.com/rigaya/NVEnc', 'NVEncC', app.fastflix.config.theme)} (MIT), "
             f"{link('https://github.com/rigaya/VCEEnc', 'VCEEnc', app.fastflix.config.theme)} (MIT), "
+            f"{link('https://github.com/rigaya/QSVEnc', 'QSVEnc', app.fastflix.config.theme)} (MIT), "
             f"SVT AV1 (MIT), rav1e (MIT), aom (MIT), x265 (GPL), x264 (GPL), libvpx (BSD)"
         )
         bundle_label.setAlignment(QtCore.Qt.AlignCenter)

--- a/fastflix/widgets/container.py
+++ b/fastflix/widgets/container.py
@@ -86,6 +86,7 @@ class Container(QtWidgets.QMainWindow):
     #     self.setCursor(QtCore.Qt.ArrowCursor)
 
     def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
+        self.app.fastflix.shutting_down = True
         if self.pb:
             try:
                 self.pb.stop_signal.emit()

--- a/fastflix/widgets/container.py
+++ b/fastflix/widgets/container.py
@@ -185,7 +185,7 @@ class Container(QtWidgets.QMainWindow):
         version_action = QAction(
             self.si(QtWidgets.QStyle.SP_BrowserReload), t("Check for Newer Version of FastFlix"), self
         )
-        version_action.triggered.connect(lambda: latest_fastflix(no_new_dialog=True))
+        version_action.triggered.connect(lambda: latest_fastflix(show_new_dialog=True, app=self.app))
 
         ffmpeg_update_action = QAction(self.si(QtWidgets.QStyle.SP_ArrowDown), t("Download Newest FFmpeg"), self)
         ffmpeg_update_action.triggered.connect(self.download_ffmpeg)

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -1716,6 +1716,7 @@ class Main(QtWidgets.QWidget):
             self.generate_thumbnail()
 
     def close(self, no_cleanup=False, from_container=False):
+        self.app.fastflix.shutting_down = True
         if not no_cleanup:
             try:
                 shutil.rmtree(self.temp_dir, ignore_errors=True)

--- a/fastflix/widgets/panels/audio_panel.py
+++ b/fastflix/widgets/panels/audio_panel.py
@@ -14,7 +14,7 @@ from fastflix.models.encode import AudioTrack
 from fastflix.models.profiles import Profile, MatchType, MatchItem
 from fastflix.models.fastflix_app import FastFlixApp
 from fastflix.resources import get_icon
-from fastflix.shared import no_border, error_message
+from fastflix.shared import no_border, error_message, yes_no_message
 from fastflix.widgets.panels.abstract_list import FlixList
 
 language_list = sorted((k for k, v in Lang._data["name"].items() if v["pt2B"] and v["pt1"]), key=lambda x: x.lower())
@@ -541,6 +541,14 @@ class AudioList(FlixList):
             for num, tt in enumerate(self.tracks):
                 if tt.index == idx:
                     return num
+
+        if self.tracks and not tracks:
+            enable = yes_no_message(
+                t("No audio tracks matched for this profile, enable first track?"), title="No Audio Match"
+            )
+            if enable:
+                self.tracks[0].widgets.enable_check.setChecked(True)
+            return super()._new_source(self.tracks)
 
         current_id = -1
         skip_tracks = []

--- a/fastflix/widgets/panels/audio_panel.py
+++ b/fastflix/widgets/panels/audio_panel.py
@@ -281,7 +281,7 @@ class Audio(QtWidgets.QTabWidget):
         return self.widgets.enable_check.isChecked()
 
     @property
-    def conversion(self) -> dict[str, str]:
+    def conversion(self):
         if self.widgets.convert_to.currentIndex() == 0:
             return {"codec": "", "bitrate": ""}
         return {"codec": self.widgets.convert_to.currentText(), "bitrate": self.widgets.convert_bitrate.currentText()}

--- a/fastflix/widgets/panels/audio_panel.py
+++ b/fastflix/widgets/panels/audio_panel.py
@@ -219,9 +219,10 @@ class Audio(QtWidgets.QTabWidget):
             if self.widgets.downmix.currentIndex() > 0
             else self.channels
         )
-        self.widgets.convert_bitrate.clear()
-        self.widgets.convert_bitrate.addItems(self.get_conversion_bitrates(channels))
-        self.widgets.convert_bitrate.setCurrentIndex(3)
+        if self.conversion["codec"] not in lossless:
+            self.widgets.convert_bitrate.clear()
+            self.widgets.convert_bitrate.addItems(self.get_conversion_bitrates(channels))
+            self.widgets.convert_bitrate.setCurrentIndex(3)
         self.page_update()
 
     def update_conversion(self):
@@ -236,10 +237,20 @@ class Audio(QtWidgets.QTabWidget):
             self.widgets.convert_bitrate.show()
             self.widgets.bitrate_label.show()
             self.widgets.downmix.show()
-            if self.widgets.convert_to.currentText() in lossless:
+            if self.conversion["codec"] in lossless:
                 self.widgets.convert_bitrate.setDisabled(True)
+                self.widgets.convert_bitrate.addItem("lossless")
+                self.widgets.convert_bitrate.setCurrentText("lossless")
             else:
                 self.widgets.convert_bitrate.setDisabled(False)
+                self.widgets.convert_bitrate.clear()
+                channels = (
+                    channel_list[self.widgets.downmix.currentText()]
+                    if self.widgets.downmix.currentIndex() > 0
+                    else self.channels
+                )
+                self.widgets.convert_bitrate.addItems(self.get_conversion_bitrates(channels))
+                self.widgets.convert_bitrate.setCurrentIndex(3)
         self.page_update()
 
     def page_update(self):
@@ -270,7 +281,7 @@ class Audio(QtWidgets.QTabWidget):
         return self.widgets.enable_check.isChecked()
 
     @property
-    def conversion(self):
+    def conversion(self) -> dict[str, str]:
         if self.widgets.convert_to.currentIndex() == 0:
             return {"codec": "", "bitrate": ""}
         return {"codec": self.widgets.convert_to.currentText(), "bitrate": self.widgets.convert_bitrate.currentText()}
@@ -406,7 +417,9 @@ class AudioList(FlixList):
         for track in self.tracks:
             track.update_codecs(allowed_formats or set())
 
-    def apply_profile_settings(self, profile: Profile, original_tracks: List[Box], audio_formats):
+    def apply_profile_settings(
+        self, profile: Profile, original_tracks: List[Box], audio_formats, og_only: bool = False
+    ):
         if profile.audio_filters:
             self.disable_all()
         else:
@@ -415,6 +428,25 @@ class AudioList(FlixList):
 
         disable_dups = "nvencc" in self.main.convert_to.lower() or "vcenc" in self.main.convert_to.lower()
         self.tracks = []
+
+        def update_track(new_track, downmix=None, conversion=None, bitrate=None):
+            if conversion:
+                new_track.widgets.convert_to.setCurrentText(conversion)
+                # Downmix must come first
+                if downmix:
+                    new_track.widgets.downmix.setCurrentText(downmix)
+                if conversion in lossless:
+                    new_track.widgets.convert_bitrate.setDisabled(True)
+                    new_track.widgets.convert_bitrate.addItem("lossless")
+                    new_track.widgets.convert_bitrate.setCurrentText("lossless")
+                else:
+                    if bitrate not in [
+                        new_track.widgets.convert_bitrate.itemText(i)
+                        for i in range(new_track.widgets.convert_bitrate.count())
+                    ]:
+                        new_track.widgets.convert_bitrate.addItem(bitrate)
+                    new_track.widgets.convert_bitrate.setCurrentText(bitrate)
+                    new_track.widgets.convert_bitrate.setDisabled(False)
 
         def gen_track(
             parent, audio_track, outdex, og=False, enabled=True, downmix=None, conversion=None, bitrate=None
@@ -438,20 +470,8 @@ class AudioList(FlixList):
                 disable_dup=disable_dups,
             )
 
-            if conversion:
-                new_track.widgets.convert_to.setCurrentText(conversion)
-                # Downmix must come first
-                if downmix:
-                    new_track.widgets.downmix.setCurrentText(downmix)
-                if conversion in lossless:
-                    new_track.widgets.convert_bitrate.setDisabled(True)
-                else:
-                    if bitrate not in [
-                        new_track.widgets.convert_bitrate.itemText(i)
-                        for i in range(new_track.widgets.convert_bitrate.count())
-                    ]:
-                        new_track.widgets.convert_bitrate.addItem(bitrate)
-                    new_track.widgets.convert_bitrate.setCurrentText(bitrate)
+            update_track(new_track=new_track, downmix=downmix, conversion=conversion, bitrate=bitrate)
+
             return new_track
 
         # First populate all original tracks and disable them
@@ -517,19 +537,45 @@ class AudioList(FlixList):
                     else:
                         tracks.extend(subset_tracks)
 
-        self.tracks.extend(
-            gen_track(
-                self,
-                track[0],
-                i,
-                enabled=True,
-                og=False,
-                conversion=track[1].conversion,
-                bitrate=track[1].bitrate,
-                downmix=track[1].downmix,
-            )
-            for i, track in enumerate(tracks, start=len(self.tracks) + 1)
-        )
+        def find_track_num(idx):
+            for num, tt in enumerate(self.tracks):
+                if tt.index == idx:
+                    return num
+
+        current_id = -1
+        skip_tracks = []
+        for idx, track in enumerate(tracks):
+            if track[0].index > current_id:
+                current_id = track[0].index
+                track_num = find_track_num(track[0].index)
+                self.tracks[track_num].widgets.enable_check.setChecked(True)
+                update_track(
+                    self.tracks[track_num],
+                    downmix=track[1].downmix,
+                    conversion=track[1].conversion,
+                    bitrate=track[1].bitrate,
+                )
+                skip_tracks.append(idx)
+
+        if not og_only:
+            additional_tracks = []
+            for i, track in enumerate(tracks, start=len(self.tracks) + 1):
+                if i not in skip_tracks:
+                    additional_tracks.append(
+                        gen_track(
+                            self,
+                            track[0],
+                            i,
+                            enabled=True,
+                            og=False,
+                            conversion=track[1].conversion,
+                            bitrate=track[1].bitrate,
+                            downmix=track[1].downmix,
+                        )
+                    )
+
+            self.tracks.extend(additional_tracks)
+
         super()._new_source(self.tracks)
 
     def update_audio_settings(self):
@@ -586,6 +632,8 @@ class AudioList(FlixList):
             new_track.widgets.convert_to.setCurrentText(track.conversion_codec)
             if track.conversion_codec in lossless:
                 new_track.widgets.convert_bitrate.setDisabled(True)
+                new_track.widgets.convert_bitrate.addItem("lossless")
+                new_track.widgets.convert_bitrate.setCurrentText("lossless")
             else:
                 if track.conversion_bitrate not in [
                     new_track.widgets.convert_bitrate.itemText(i)
@@ -594,6 +642,7 @@ class AudioList(FlixList):
                     new_track.widgets.convert_bitrate.addItem(track.conversion_bitrate)
                 new_track.widgets.convert_bitrate.setCurrentText(track.conversion_bitrate)
             new_track.widgets.title.setText(track.title)
+
             if track.language:
                 new_track.widgets.language.setCurrentText(Lang(track.language).name)
             else:

--- a/fastflix/widgets/panels/audio_panel.py
+++ b/fastflix/widgets/panels/audio_panel.py
@@ -679,8 +679,12 @@ class AudioList(FlixList):
                 all_info=x,
                 disable_dup=disable_dups,
             )
-            self.tracks.append(new_item)
-
-        self.tracks.sort(key=lambda z: (int(not z.original), z.index))
+            for idx, tk in enumerate(self.tracks):
+                if tk.index > new_item.index:
+                    print(f"Inserting at {idx}")
+                    self.tracks.insert(idx, new_item)
+                    break
+            else:
+                self.tracks.append(new_item)
 
         super()._new_source(self.tracks)

--- a/fastflix/widgets/panels/subtitle_panel.py
+++ b/fastflix/widgets/panels/subtitle_panel.py
@@ -230,10 +230,29 @@ class Subtitle(QtWidgets.QTabWidget):
 
 class SubtitleList(FlixList):
     def __init__(self, parent, app: FastFlixApp):
-        super().__init__(app, parent, "Subtitle Tracks", "subtitle")
+        top_layout = QtWidgets.QHBoxLayout()
+
+        top_layout.addWidget(QtWidgets.QLabel(t("Subtitle Tracks")))
+        top_layout.addStretch(1)
+
+        self.remove_all_button = QtWidgets.QPushButton(t("Unselect All"))
+        self.remove_all_button.setFixedWidth(150)
+        self.remove_all_button.clicked.connect(lambda: self.select_all(False))
+        self.save_all_button = QtWidgets.QPushButton(t("Preserve All"))
+        self.save_all_button.setFixedWidth(150)
+        self.save_all_button.clicked.connect(lambda: self.select_all(True))
+
+        top_layout.addWidget(self.remove_all_button)
+        top_layout.addWidget(self.save_all_button)
+
+        super().__init__(app, parent, "Subtitle Tracks", "subtitle", top_row_layout=top_layout)
         self.main = parent.main
         self.app = app
         self._first_selected = False
+
+    def select_all(self, select=True):
+        for track in self.tracks:
+            track.widgets.enable_check.setChecked(select)
 
     def lang_match(self, track: Union[Subtitle, dict], ignore_first=False):
         if not self.app.fastflix.config.opt("subtitle_select"):

--- a/fastflix/widgets/progress_bar.py
+++ b/fastflix/widgets/progress_bar.py
@@ -86,6 +86,8 @@ class ProgressBar(QtWidgets.QFrame):
             for i, task in enumerate(self.tasks, start=1):
                 self.status.setText(task.name)
                 self.app.processEvents()
+                if self.app.fastflix.shutting_down:
+                    self.close()
                 try:
                     task.command(config=self.app.fastflix.config, app=self.app, **task.kwargs)
                 except Exception:
@@ -98,3 +100,6 @@ class ProgressBar(QtWidgets.QFrame):
     def update_progress(self, value):
         self.progress_bar.setValue(value)
         self.app.processEvents()
+        if self.app.fastflix.shutting_down:
+            self.stop_signal.emit()
+            self.close()

--- a/fastflix/widgets/settings.py
+++ b/fastflix/widgets/settings.py
@@ -130,6 +130,7 @@ class Settings(QtWidgets.QWidget):
         nvencc_label = QtWidgets.QLabel(
             link("https://github.com/rigaya/NVEnc/releases", "NVEncC", app.fastflix.config.theme)
         )
+        nvencc_label.setOpenExternalLinks(True)
         self.nvencc_path = QtWidgets.QLineEdit()
         if self.app.fastflix.config.nvencc:
             self.nvencc_path.setText(str(self.app.fastflix.config.nvencc))
@@ -142,6 +143,7 @@ class Settings(QtWidgets.QWidget):
         vceenc_label = QtWidgets.QLabel(
             link("https://github.com/rigaya/VCEEnc/releases", "VCEEncC", app.fastflix.config.theme)
         )
+        vceenc_label.setOpenExternalLinks(True)
         self.vceenc_path = QtWidgets.QLineEdit()
         if self.app.fastflix.config.vceencc:
             self.vceenc_path.setText(str(self.app.fastflix.config.vceencc))
@@ -154,6 +156,7 @@ class Settings(QtWidgets.QWidget):
         qsvencc_label = QtWidgets.QLabel(
             link("https://github.com/rigaya/QSVEnc/releases", "QSVEncC", app.fastflix.config.theme)
         )
+        qsvencc_label.setOpenExternalLinks(True)
         self.qsvenc_path = QtWidgets.QLineEdit()
         if self.app.fastflix.config.qsvencc:
             self.qsvenc_path.setText(str(self.app.fastflix.config.qsvencc))

--- a/fastflix/widgets/video_options.py
+++ b/fastflix/widgets/video_options.py
@@ -163,7 +163,12 @@ class VideoOptions(QtWidgets.QTabWidget):
         if getattr(self.main.current_encoder, "enable_audio", False):
             self.audio.new_source(self.audio_formats)
             streams = copy.deepcopy(self.app.fastflix.current_video.streams)
-            self.audio.apply_profile_settings(profile, streams.audio, self.audio_formats)
+            self.audio.apply_profile_settings(
+                profile,
+                streams.audio,
+                self.audio_formats,
+                og_only=getattr(self.main.current_encoder, "original_audio_tracks_only", False),
+            )
         if getattr(self.main.current_encoder, "enable_subtitles", False):
             self.subtitles.new_source()
         if getattr(self.main.current_encoder, "enable_attachments", False):
@@ -193,7 +198,12 @@ class VideoOptions(QtWidgets.QTabWidget):
             profile = self.app.fastflix.config.profile
 
             if getattr(self.main.current_encoder, "enable_audio", False):
-                self.audio.apply_profile_settings(profile, streams.audio, self.audio_formats)
+                self.audio.apply_profile_settings(
+                    profile,
+                    streams.audio,
+                    self.audio_formats,
+                    og_only=getattr(self.main.current_encoder, "original_audio_tracks_only", False),
+                )
                 self.audio.update_audio_settings()
             if getattr(self.main.current_encoder, "enable_subtitles", False):
                 self.subtitles.get_settings()

--- a/fastflix/widgets/windows/profile_window.py
+++ b/fastflix/widgets/windows/profile_window.py
@@ -196,10 +196,22 @@ class AudioSelect(FlixList):
 
         layout.addWidget(self.passthrough_checkbox, 0, 0)
         layout.addWidget(self.add_button, 0, 1, alignment=QtCore.Qt.AlignRight)
+
         layout.addWidget(self.scroll_area, 1, 0, 1, 2)
+
+        self.hardware_warning = QtWidgets.QLabel(t("Rigaya's encoders will only match one encoding per track"))
+        self.hardware_warning.hide()
+
+        layout.addWidget(self.hardware_warning, 2, 0)
         self.passthrough_checkbox.setChecked(True)
         # self.passthrough_checkbox.setChecked(True)
         super()._new_source(self.tracks)
+
+    def update_settings(self):
+        if getattr(self.main.current_encoder, "original_audio_tracks_only", False):
+            self.hardware_warning.show()
+        else:
+            self.hardware_warning.hide()
 
     def add_track(self):
         self.tracks.append(AudioProfile(self, self.app, self.main, self.inner_widget, len(self.tracks)))
@@ -436,6 +448,7 @@ class ProfileWindow(QtWidgets.QWidget):
             if encoder:
                 self.encoder = encoder
         self.encoder_tab.update_settings()
+        self.audio_select.update_settings()
         self.advanced_options = self.main.video_options.advanced.get_settings()
         self.advanced_tab.text_update(self.advanced_options)
 

--- a/fastflix/widgets/windows/profile_window.py
+++ b/fastflix/widgets/windows/profile_window.py
@@ -30,6 +30,7 @@ from fastflix.models.encode import (
     VCEEncCSettings,
     H264VideoToolboxSettings,
     HEVCVideoToolboxSettings,
+    SVTAVIFSettings,
 )
 from fastflix.models.profiles import AudioMatch, Profile, MatchItem, MatchType, AdvancedOptions
 from fastflix.shared import error_message
@@ -543,6 +544,8 @@ class ProfileWindow(QtWidgets.QWidget):
             new_profile.vceencc_hevc = self.encoder
         elif isinstance(self.encoder, VCEEncCAVCSettings):
             new_profile.vceencc_avc = self.encoder
+        elif isinstance(self.encoder, SVTAVIFSettings):
+            new_profile.svt_av1_avif = self.encoder
         else:
             logger.error("Profile cannot be saved! Unknown encoder type.")
             return


### PR DESCRIPTION
* Adding AVIF support using libsvtav1
* Adding #352 default output directory to settings panel (thanks to Maddie Davis)
* Adding #306 support for audio profiles with pattern matching for rigaya's hardware encoders
* Adding #301 Select All feature for subtitles (thanks to ProFire and Genine-Collin)
* Adding #325 build for Ubuntu 22.04 (thanks to mrjayviper)
* Adding build for MacOS 12
* Adding #322 warning if profile audio match doesn't match anything (thanks to wynterca)
* Adding presumption that 4.x branch is last to support Windows 7 and 8 for update checks
* Fixing #319 no longer disables built in tracks for profile matching (thanks to Owen Quinlan)
* Fixing #218 and #308 subtitle scaling with rigaya's hardware encoders needs to be scaled for 4K content (thanks to wynterca)
* Fixing #350 subtitle burn in quoting (thanks to Maddie Davis)
* Fixing #346 preserve the order of audio tracks when editing a queued job (thanks to Patrick Bassner)
* Fixing #187 closing the main app while a progress bar is active will now stop that task (thanks to Todd Wilkinson)
* Fixing Chinese translations (thanks to leonardyan)
* Fixing new version check not launching at startup