### PR TITLE
Version 5.2.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
   build-nix:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-12, macos-11 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-12, macos-11 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install PySide6 apt Requirements
         run: |
           sudo apt update
-          sudo apt install libopengl0 freeglut3 freeglut3-dev libxcb-icccm4 libxkbcommon-x11-0 libxcb-xkb1 libxcb-render-util0 libxcb-randr0 libxcb-keysyms1 libxcb-image0 -y
+          sudo apt install libopengl0 freeglut3 freeglut3-dev libxcb-icccm4 libxkbcommon-x11-0 libxcb-xkb1 libxcb-render-util0 libxcb-randr0 libxcb-keysyms1 libxcb-image0 libxcb-shape0-dev -y
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Install Python Dependencies

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 * Fixing file extension drop down would not always set correct on encoder change (thanks to GT500org)
 * Fixing missing translations for VVC
 * Fixing VVC was adding extra params it did not support
+* Fixing trying to restore a video from the queue that was using an encoder that no longer exists
 
 ## Version 5.2.1
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 5.2.2
+
+* Fixing #431 Missing ubuntu 20 builds (thanks to techore)
+* Fixing file extension drop down would not always set correct on encoder change (thanks to GT500org)
+* Fixing missing translations for VVC
+* Fixing VVC was adding extra params it did not support
+
 ## Version 5.2.1
 
 * Fixing #426 Version 5.2 does not run on fresh install (thanks to Bandid0)

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -8297,3 +8297,59 @@ UI Scale:
   swe: UI-skala
   pol: Skala UI
   kor: UI 스케일
+IDC Level:
+  eng: IDC Level
+  deu: IDC-Ebene
+  fra: Niveau IDC
+  ita: Livello IDC
+  spa: Nivel IDC
+  zho: IDC级别
+  jpn: IDCレベル
+  rus: Уровень IDC
+  por: Nível IDC
+  swe: IDC-nivå
+  pol: Poziom IDC
+  ukr: Рівень IDC
+  kor: IDC 레벨
+Set the IDC level:
+  eng: Set the IDC level
+  deu: Einstellen des IDC-Pegels
+  fra: Régler le niveau de l'IDC
+  ita: Impostare il livello IDC
+  spa: Ajustar el nivel IDC
+  zho: 设置IDC水平
+  jpn: IDCレベルを設定する
+  rus: Установите уровень IDC
+  por: Definir o nível IDC
+  swe: Ställ in IDC-nivån
+  pol: Ustawić poziom IDC
+  ukr: Встановіть рівень IDC
+  kor: IDC 수준 설정
+Additional vvc params:
+  eng: Additional vvc params
+  deu: Zusätzliche vvc-Parameter
+  fra: Paramètres supplémentaires de la vvc
+  ita: Parametri aggiuntivi di vvc
+  spa: Parámetros vvc adicionales
+  zho: 附加vvc参数
+  jpn: vvcの追加パラメータ
+  rus: Дополнительные параметры vvc
+  por: Parâmetros vvc adicionais
+  swe: Ytterligare parametrar för vvc
+  pol: Dodatkowe parametry vvc
+  ukr: Додаткові параметри vvc
+  kor: 추가 VVC 매개변수
+Extra vvc params in opt=1:opt2=0 format:
+  eng: Extra vvc params in opt=1:opt2=0 format
+  deu: Zusätzliche vvc-Parameter im Format opt=1:opt2=0
+  fra: Paramètres vvc supplémentaires au format opt=1:opt2=0
+  ita: Parametri vvc extra nel formato opt=1:opt2=0
+  spa: Parámetros vvc adicionales en formato opt=1:opt2=0
+  zho: opt=1:opt2=0格式的额外vvc参数
+  jpn: opt=1:opt2=0の形式でvvcパラメータを追加する。
+  rus: Дополнительные параметры vvc в формате opt=1:opt2=0
+  por: Parâmetros vvc adicionais no formato opt=1:opt2=0
+  swe: Extra vvc-parametrar i formatet opt=1:opt2=0
+  pol: Dodatkowe parametry vvc w formacie opt=1:opt2=0
+  ukr: Додаткові параметри vvc у форматі opt=1:opt2=0
+  kor: opt=1:opt2=0 형식의 추가 vvc 매개변수

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -8353,3 +8353,27 @@ Extra vvc params in opt=1:opt2=0 format:
   pol: Dodatkowe parametry vvc w formacie opt=1:opt2=0
   ukr: Додаткові параметри vvc у форматі opt=1:opt2=0
   kor: opt=1:opt2=0 형식의 추가 vvc 매개변수
+That video was added with an encoder that is no longer available, unable to load from queue:
+  eng: That video was added with an encoder that is no longer available, unable to
+    load from queue
+  deu: Dieses Video wurde mit einem Encoder hinzugefügt, der nicht mehr verfügbar
+    ist und nicht aus der Warteschlange geladen werden kann
+  fra: Cette vidéo a été ajoutée avec un encodeur qui n'est plus disponible, impossible
+    de la charger à partir de la file d'attente.
+  ita: Il video è stato aggiunto con un encoder non più disponibile, non è possibile
+    caricarlo dalla coda.
+  spa: Ese vídeo se añadió con un codificador que ya no está disponible, no se puede
+    cargar desde la cola
+  zho: 该视频是用一个不再可用的编码器添加的，无法从队列中加载。
+  jpn: その動画は、利用できなくなったエンコーダーで追加されたため、キューから読み込むことができません。
+  rus: Это видео было добавлено с помощью кодировщика, который больше не доступен,
+    не удается загрузить из очереди
+  por: Esse vídeo foi adicionado com um codificador que já não está disponível, incapaz
+    de carregar a partir da fila
+  swe: Videon lades till med en kodare som inte längre är tillgänglig, kan inte laddas
+    från kön.
+  pol: Ten film został dodany za pomocą kodera, który nie jest już dostępny, nie można
+    go załadować z kolejki
+  ukr: Це відео було додано за допомогою кодера, який більше не доступний і не може
+    бути завантажений з черги
+  kor: 해당 동영상은 더 이상 사용할 수 없는 인코더로 추가되어 대기열에서 로드할 수 없습니다.

--- a/fastflix/encoders/vvc/command_builder.py
+++ b/fastflix/encoders/vvc/command_builder.py
@@ -90,52 +90,6 @@ def build(fastflix: FastFlix):
 
     vvc_params = settings.vvc_params.copy() or []
 
-    if not fastflix.current_video.video_settings.remove_hdr:
-        if fastflix.current_video.video_settings.color_primaries:
-            vvc_params.append(f"colorprim={fastflix.current_video.video_settings.color_primaries}")
-        elif fastflix.current_video.color_primaries:
-            if fastflix.current_video.color_primaries in vvc_valid_color_primaries:
-                vvc_params.append(f"colorprim={fastflix.current_video.color_primaries}")
-            elif fastflix.current_video.color_primaries in color_primaries_mapping:
-                vvc_params.append(f"colorprim={color_primaries_mapping[fastflix.current_video.color_primaries]}")
-
-        if fastflix.current_video.video_settings.color_transfer:
-            vvc_params.append(f"transfer={fastflix.current_video.video_settings.color_transfer}")
-        elif fastflix.current_video.color_transfer:
-            if fastflix.current_video.color_transfer in vvc_valid_color_transfers:
-                vvc_params.append(f"transfer={fastflix.current_video.color_transfer}")
-            elif fastflix.current_video.color_transfer in color_transfer_mapping:
-                vvc_params.append(f"transfer={color_transfer_mapping[fastflix.current_video.color_transfer]}")
-
-        if fastflix.current_video.video_settings.color_space:
-            vvc_params.append(f"colormatrix={fastflix.current_video.video_settings.color_space}")
-        elif fastflix.current_video.color_space:
-            if fastflix.current_video.color_space in vvc_valid_color_matrix:
-                vvc_params.append(f"colormatrix={fastflix.current_video.color_space}")
-            elif fastflix.current_video.color_space in color_matrix_mapping:
-                vvc_params.append(f"colormatrix={color_matrix_mapping[fastflix.current_video.color_space]}")
-
-            if fastflix.current_video.master_display:
-                settings.hdr10 = True
-                vvc_params.append(
-                    "master-display="
-                    f"G{fastflix.current_video.master_display.green}"
-                    f"B{fastflix.current_video.master_display.blue}"
-                    f"R{fastflix.current_video.master_display.red}"
-                    f"WP{fastflix.current_video.master_display.white}"
-                    f"L{fastflix.current_video.master_display.luminance}"
-                )
-
-            if fastflix.current_video.cll:
-                settings.hdr10 = True
-                vvc_params.append(f"max-cll={fastflix.current_video.cll}")
-
-            vvc_params.append(f"hdr10={'1' if settings.hdr10 else '0'}")
-
-        current_chroma_loc = fastflix.current_video.current_video_stream.get("chroma_location")
-        if current_chroma_loc in chromaloc_mapping:
-            vvc_params.append(f"chromaloc={chromaloc_mapping[current_chroma_loc]}")
-
     if fastflix.current_video.video_settings.maxrate:
         vvc_params.append(f"vbv-maxrate={fastflix.current_video.video_settings.maxrate}")
         vvc_params.append(f"vbv-bufsize={fastflix.current_video.video_settings.bufsize}")

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "5.2.1"
+__version__ = "5.2.2"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -773,7 +773,7 @@ class Main(QtWidgets.QWidget):
             return self.app.fastflix.encoders[
                 self.app.fastflix.current_video.video_settings.video_encoder_settings.name
             ]
-        except AttributeError:
+        except (AttributeError, KeyError):
             return self.app.fastflix.encoders[self.convert_to]
 
     def init_start_time(self):
@@ -1358,6 +1358,14 @@ class Main(QtWidgets.QWidget):
 
     @reusables.log_exception("fastflix", show_traceback=True)
     def reload_video_from_queue(self, video: Video):
+        if video.video_settings.video_encoder_settings.name not in self.app.fastflix.encoders:
+            error_message(
+                t("That video was added with an encoder that is no longer available, unable to load from queue")
+            )
+            raise FastFlixInternalException(
+                t("That video was added with an encoder that is no longer available, unable to load from queue")
+            )
+
         self.loading_video = True
 
         self.app.fastflix.current_video = video

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -609,12 +609,6 @@ class Main(QtWidgets.QWidget):
             # self.widgets.scale.keep_aspect.setChecked(self.app.fastflix.config.opt("keep_aspect_ratio"))
             self.widgets.rotate.setCurrentIndex(self.app.fastflix.config.opt("rotate") or 0 // 90)
 
-            # last = self.widgets.output_type_combo.currentText()
-
-            self.widgets.output_type_combo.clear()
-            self.widgets.output_type_combo.addItems(self.current_encoder.video_extensions)
-            self.widgets.output_type_combo.setCurrentText(self.app.fastflix.config.opt("output_type"))
-
             v_flip = self.app.fastflix.config.opt("vertical_flip")
             h_flip = self.app.fastflix.config.opt("horizontal_flip")
 
@@ -760,6 +754,9 @@ class Main(QtWidgets.QWidget):
         if not self.initialized or not self.convert_to:
             return
         self.video_options.change_conversion(self.convert_to)
+        self.widgets.output_type_combo.clear()
+        self.widgets.output_type_combo.addItems(self.current_encoder.video_extensions)
+        self.widgets.output_type_combo.setCurrentText(self.app.fastflix.config.opt("output_type"))
         if not self.app.fastflix.current_video:
             return
 

--- a/fastflix/widgets/panels/queue_panel.py
+++ b/fastflix/widgets/panels/queue_panel.py
@@ -404,8 +404,12 @@ class EncodingQueue(FlixList):
         save_queue(self.app.fastflix.conversion_list, self.app.fastflix.queue_path, self.app.fastflix.config)
 
     def reload_from_queue(self, video):
-        self.main.reload_video_from_queue(video)
-        self.remove_item(video)
+        try:
+            self.main.reload_video_from_queue(video)
+        except FastFlixInternalException:
+            pass
+        else:
+            self.remove_item(video)
 
     def reset_pause_encode(self):
         self.pause_encode.setText(t("Pause Encode"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = '''
 
 [tool.poetry]
 name = "FastFlix"
-version = "5.2.1"
+version = "5.2.2"
 description = "GUI Encoder"
 license = "MIT"
 authors = ["Chris Griffith <chris@cdgriffith.com>", ]


### PR DESCRIPTION
* Fixing #431 Missing ubuntu 20 builds (thanks to techore)
* Fixing file extension drop down would not always set correct on encoder change (thanks to GT500org)
* Fixing missing translations for VVC
* Fixing VVC was adding extra params it did not support
* Fixing trying to restore a video from the queue that was using an encoder that no longer exists