### PR TITLE
Fixed some zho and jpn translations, fixed some typos

### DIFF
--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -31,7 +31,7 @@ AQ Strength:
   ita: Forza AQ
   spa: Fuerza de AQ
   zho: AQ强度
-  jpn: AQの強み
+  jpn: AQの強さ
   rus: Сила AQ
   por: Força de AQ
   swe: AQ styrka
@@ -46,7 +46,7 @@ About:
   ita: Informazioni su
   spa: Acerca de
   zho: 关于
-  jpn: について
+  jpn: Fastflixのバージョン情報
   rus: О программе
   por: Sobre
   swe: Om
@@ -181,7 +181,7 @@ All queue items have completed:
   ita: Tutte le voci della coda sono state completate
   spa: Todos los artículos de la cola se han completado
   zho: 所有排队项目已完成
-  jpn: すべてのキューアイテムが完了しました
+  jpn: キューにあるアイテムが全て完了しました
   rus: Все пункты очереди завершены
   por: Todos os itens da fila foram completados
   swe: Alla köposter har avslutats.
@@ -270,7 +270,7 @@ Auto Burn-in first forced or default subtitle track:
   fra: Auto Burn-in première piste de sous-titres forcée ou par défaut
   ita: Auto Burn-in prima traccia sottotitoli forzata o predefinita
   spa: Auto Burn-in primera pista de subtítulos forzados o por defecto
-  zho: 自动内嵌第一条分配为forced或default的字幕轨
+  zho: 自动内嵌第一条分配为forced或default的字幕
   jpn: 最初の強制またはデフォルトの字幕トラックを自動的にバーンインする
   rus: Автоматическое включение первой принудительной дорожки субтитров или дорожки
     субтитров по умолчанию
@@ -453,7 +453,7 @@ Bottom:
   ita: In basso
   spa: Abajo
   zho: 下端
-  jpn: ボトム
+  jpn: 下
   rus: Дно
   por: Fundo
   swe: Botten
@@ -1296,7 +1296,7 @@ Crop Detect Points:
   ita: Ritagliare i punti di rilevamento
   spa: Puntos de detección de cultivos
   zho: 裁切检测点
-  jpn: クロップディテクトポイント
+  jpn: クロップ検知ポイント
   rus: Точки обнаружения обрезки
   por: Pontos de Detecção de Culturas
   swe: Skördepunkter för upptäckt av grödor
@@ -1356,7 +1356,7 @@ Custom ffmpeg options:
   ita: Opzioni ffmpeg personalizzate
   spa: Opciones personalizadas de ffmpeg
   zho: 自定义ffmpeg选项
-  jpn: カスタム ffmpeg オプション
+  jpn: ffmpegのカスタムオプション
   rus: Пользовательские параметры ffmpeg
   por: Opções ffmpeg personalizadas
   swe: Anpassade ffmpeg-alternativ
@@ -2644,7 +2644,7 @@ Have to select a video first:
   ita: Devi prima selezionare un video
   spa: Primero hay que seleccionar un video.
   zho: 需要先选择一个视频
-  jpn: 最初にビデオを選択する必要があります。
+  jpn: 最初に動画を選択する必要があります。
   rus: Сначала нужно выбрать видео
   por: Ter de seleccionar primeiro um vídeo
   swe: Måste välja en video först
@@ -3281,7 +3281,7 @@ No Flip:
   ita: Senza capovolgere
   spa: No hay vuelta atrás
   zho: 无翻转
-  jpn: フリップなし
+  jpn: 反転なし
   rus: Без поворота
   por: Sem Flip
   swe: Ingen flip
@@ -3296,7 +3296,7 @@ No Rotation:
   ita: Nessuna rotazione
   spa: No hay rotación
   zho: 无旋转
-  jpn: ノーローテーション
+  jpn: 回転なし
   rus: Без вращения
   por: Sem Rotação
   swe: Ingen rotation
@@ -3311,7 +3311,7 @@ No Source Selected:
   ita: Nessuna fonte selezionata
   spa: No se ha seleccionado ninguna fuente
   zho: 未选择源文件
-  jpn: ソース選択なし
+  jpn: ソース選択されていない
   rus: Источник не выбран
   por: Nenhuma Fonte Seleccionada
   swe: Ingen källa vald
@@ -3378,7 +3378,7 @@ No encoding is currently in process, starting encode:
   ita: Nessuna codifica è attualmente in corso, iniziando a codificare
   spa: Ninguna codificación está actualmente en proceso, comenzando a codificar
   zho: 目前没有正在进行的编码，编码开始。
-  jpn: 現在エンコード中のものはなく、エンコード開始
+  jpn: 現在エンコード中のものはない。エンコード開始
   rus: В настоящее время кодирование не выполняется, начинаем кодирование
   por: Nenhuma codificação está actualmente em processo, começando a codificação
   swe: Ingen kodning pågår för närvarande, börja koda.
@@ -3852,7 +3852,7 @@ Profile Name:
   por: Nome do perfil
   swe: Profilnamn
   pol: Nazwa profilu
-  ukr: Ім'я профілю Ім'я профілю
+  ukr: 'Ім'я профілю Ім'я профілю'
   kor: 프로필 이름
   ron: Numele profilului
 Profile_encoderopt:
@@ -3861,8 +3861,8 @@ Profile_encoderopt:
   fra: Profil
   ita: Profilo
   spa: Perfil
-  zho: 规格
-  jpn: Profile
+  zho: 配置
+  jpn: プロフィール
   rus: Профиль_опции_энкодера
   por: Perfil
   swe: Profile
@@ -3876,8 +3876,8 @@ Profile_newprofiletooltip:
   fra: Profil
   ita: Profilo
   spa: Perfil
-  zho: 规格
-  jpn: Profile
+  zho: 配置
+  jpn: プロフィール
   rus: Профиль_подсказка_нового_профиля
   por: Perfil
   swe: Profile
@@ -3891,8 +3891,8 @@ Profile_window:
   fra: Profil
   ita: Profilo
   spa: Perfil
-  zho: 规格
-  jpn: Profile
+  zho: 配置
+  jpn: プロフィール
   rus: Профиль_окно
   por: Perfil
   swe: Profile
@@ -4043,7 +4043,7 @@ Queue has been paused:
   ita: La coda è stata messa in pausa
   spa: La cola se ha detenido
   zho: 队列已暂停
-  jpn: キューが一時停止している
+  jpn: キューは一時停止している
   rus: Очередь была приостановлена
   por: A fila foi interrompida
   swe: Kö har pausats
@@ -4078,7 +4078,7 @@ Raise or lower per-block quantization based on complexity analysis of the source
   spa: Aumentar o disminuir la cuantificación por bloque basada en el análisis de
     la complejidad de la imagen de origen.
   zho: 根据对源图像的复杂度分析，提升或降低各个块的量化。
-  jpn: ソース画像の複雑さの分析に基づいて、ブロックごとの量子化率を上げたり下げたりします。
+  jpn: ソース画像の複雑さの分析に基づいて、ブロックごとの量子化率を上げるか下げる。
   rus: Повышение или понижение блочного квантования на основе анализа сложности исходного
     изображения.
   por: Quantificação por bloco, para cima ou para baixo, com base na análise da complexidade
@@ -4128,8 +4128,8 @@ Ready to encode:
   fra: Prêt à encoder
   ita: Pronto a codificare
   spa: Listo para codificar
-  zho: 准备编码
-  jpn: エンコードの準備完了
+  zho: 准备好编码
+  jpn: エンコードの準備できました
   rus: Готовность к кодированию
   por: Pronto a codificar
   swe: Redo att koda
@@ -4209,7 +4209,7 @@ Remove completed tasks:
   ita: Rimuovere i compiti completati
   spa: Eliminar las tareas completadas
   zho: 删除已完成的任务
-  jpn: 完了したタスクの削除
+  jpn: 完了したタスクを削除する
   rus: Удалить выполненные задания
   por: Retirar tarefas concluídas
   swe: Ta bort avslutade uppgifter
@@ -4499,7 +4499,7 @@ Scrub away all incoming metadata, like video titles, unique markings and so on.:
   spa: Borra todos los metadatos entrantes, como títulos de video, marcas únicas y
     demás.
   zho: 擦除输入文件中所有的元数据，如视频标题、唯一标记等。
-  jpn: ビデオのタイトルやユニークなマークなど、入力されたメタデータをすべて消去します。
+  jpn: 動画のタイトルやユニークなマークなど、元のメタデータをすべて消去します。
   rus: Удалите все входящие метаданные, такие как названия видео, уникальные метки
     и так далее.
   por: Eliminar todos os metadados recebidos, como títulos de vídeo, marcações únicas
@@ -4523,8 +4523,8 @@ Selects which NVENC capable GPU to use. First GPU is 0, second is 1, and so on:
     è 1, e così via
   spa: Selecciona qué GPU con capacidad NVENC se va a utilizar. La primera GPU es
     0, la segunda es 1, y así sucesivamente
-  zho: 选择使用哪个NVENC功能的GPU。第一个GPU为0，第二个为1，以此类推。
-  jpn: どのNVENC対応GPUを使用するかを選択します。最初のGPUは0、2番目は1、というように。
+  zho: 选择使用哪个有NVENC功能的GPU。第一个GPU为0，第二个为1，以此类推。
+  jpn: どのNVENC対応GPUを使用するか選択してください。最初のGPUは0、2番目は1。
   rus: Выбрать, какой GPU с поддержкой NVENC будет использоваться. Первый GPU - 0,
     второй - 1 и так далее.
   por: Selecciona qual a GPU NVENC capaz de utilizar. A primeira GPU é 0, a segunda
@@ -4560,7 +4560,7 @@ Set the "title" tag, sometimes shown as "Movie Name":
   ita: Impostare il tag "title", a volte mostrato come "Movie Name" (nome del film)
   spa: Poner la etiqueta "título", a veces se muestra como "Nombre de la película"
   zho: 设置“标题”（title，有时显示为“电影名称”（Movie Name））标签
-  jpn: '"title "タグを設定します。"Movie Name "と表示されることもあります。'
+  jpn: '"title"タグを設定します。"Movie Name"と表示されることもあります。'
   rus: Установить тег "title", который иногда отображается как "Название фильма".
   por: Definir a etiqueta "título", por vezes exibida como "Nome do filme".
   swe: Ange "title"-taggen, som ibland visas som "Movie Name".
@@ -4689,21 +4689,21 @@ Size Estimate:
   ukr: Оцінка розміру
   kor: 크기 견적
   ron: Dimensiune estimată
-'"Slow" is the slowest personally recommended, presets slower this result in much smaller gains':
-  deu: '"Slow" ist die langsamste persönlich empfohlene Einstellung, langsamere Voreinstellungen führen zu viel geringeren Verstärkungen'
-  eng: '"Slow" is the slowest personally recommended, presets slower this result in much smaller gains'
-  fra: '"Slow" est le plus lent personnellement recommandé, les préréglages plus lents entraînent des gains beaucoup plus faibles'
-  ita: '"Slow" è il più lento consigliato personalmente, i preset più lenti si traducono in guadagni molto minori'
-  spa: '"Slow" es el más lento recomendado personalmente, los ajustes preestablecidos más lentos dan como resultado ganancias mucho menores'
+'"Slow" is the slowest preset personally recommended, presets slower than this result in much smaller gains':
+  deu: '„Slow“ ist die langsamste persönlich empfohlene Voreinstellung, langsamere Voreinstellungen als diese führen zu viel geringeren Verstärkungen'
+  eng: '"Slow" is the slowest preset personally recommended, presets slower than this result in much smaller gains'
+  fra: '"Slow" est le préréglage le plus lent personnellement recommandé, les préréglages plus lents que cela entraînent des gains beaucoup plus faibles'
+  ita: '"Slow" è il preset più lento consigliato personalmente, i preset più lenti di questo si traducono in guadagni molto minori'
+  spa: '"Lento" es el preajuste más lento recomendado personalmente, los preajustes más lentos que este dan como resultado ganancias mucho más pequeñas'
   zho: '个人建议使用slow。比这更慢的设定获得的好处会小得多。'
   jpn: '個人的にはslowのプリセット設定はおすすめです。それよりも遅いプリセットを使うとメリットが多くないです。'
-  rus: '«Медленный» — самый медленный, рекомендуемый лично, предустановки медленнее, это приводит к гораздо меньшему приросту'
-  por: '"Slow" é o mais lento pessoalmente recomendado, predefinições mais lentas resultam em ganhos muito menores'
-  swe: '"Slow" är den långsammaste personligen rekommenderade, förinställningar långsammare detta resulterar i mycket mindre vinster'
-  pol: '„Slow” jest najwolniejszym osobiście zalecanym ustawieniem, wolniejsze ustawienia wstępne skutkują znacznie mniejszymi wzmocnieniami'
-  ukr: '"Повільний" є найповільнішим, рекомендованим особисто, попередні налаштування повільніше це призводить до набагато менших приростів'
-  kor: '"Slow"는 개인적으로 권장되는 가장 느린 속도이며 사전 설정을 느리게 하면 게인이 훨씬 작아집니다.'
-  ron: '„Slow” este cel mai lent recomandat personal, presetări mai lente, ceea ce duce la câștiguri mult mai mici'
+  rus: '«Slow» — самая медленная предустановка, рекомендуемая лично, более медленные предустановки дают гораздо меньший прирост'
+  por: '"Slow" é a predefinição mais lenta recomendada pessoalmente, predefinições mais lentas do que esta resultam em ganhos muito menores'
+  swe: '"Slow" är den långsammaste förinställningen som personligen rekommenderas, förinställningar långsammare än detta resulterar i mycket mindre vinster'
+  pol: '„Slow” to najwolniejsze ustawienie wstępne, które osobiście zalecamy, ustawienia wolniejsze od tego powodują znacznie mniejsze wzmocnienia'
+  ukr: '«Slow» — це найповільніший пресет, рекомендований особисто, пресети, повільніші за цей, призводять до значно менших посилень'
+  kor: '"Slow"는 개인적으로 권장되는 가장 느린 사전 설정이며, 이보다 느린 사전 설정은 게인이 훨씬 적습니다.'
+  ron: '„Slow” este cea mai lentă presetare recomandată personal, presetări mai lente decât aceasta duc la câștiguri mult mai mici'
 Slower presets will generally achieve better compression efficiency (and generate smaller bitstreams).:
   deu: Langsamere Voreinstellungen erzielen im Allgemeinen eine bessere Komprimierungseffizienz
     (und erzeugen kleinere Bitströme).
@@ -4842,7 +4842,7 @@ Start:
   ita: Iniziare
   spa: Comienza
   zho: 开始
-  jpn: スタート
+  jpn: 開始
   rus: Начать
   por: Início
   swe: Starta
@@ -4978,7 +4978,7 @@ The GUI might have died, but I'm going to keep converting!:
   ita: L'interfaccia grafica sarà anche morta, ma continuerò a convertirmi!
   spa: ¡El GUI puede haber muerto, pero voy a seguir convirtiendo!
   zho: 图形界面可能已经崩溃，但转换将继续进行！
-  jpn: GUIは死んでしまったかもしれませんが、私は変換し続けるつもりです!
+  jpn: GUIは固まってしまったかもしれませんが、私は変換し続けるつもりです!
   rus: Возможно, графический интерфейс умер, но конвертация продолжится!
   por: A GUI pode ter morrido, mas eu vou continuar a converter-me!
   swe: GUI må ha dött, men jag kommer att fortsätta konvertera!
@@ -5063,7 +5063,7 @@ There was an error during conversion and the queue has stopped:
   ita: C'è stato un errore durante la conversione e la coda si è fermata
   spa: Hubo un error durante la conversión y la cola se ha detenido
   zho: 转换过程中出现错误，队列已经停止
-  jpn: 変換中にエラーが発生し、キューが停止しました
+  jpn: 変換中にエラーが発生し、キューが停止されました
   rus: Во время преобразования произошла ошибка, и очередь остановилась
   por: Houve um erro durante a conversão e a fila parou
   swe: Det uppstod ett fel under konverteringen och kön har stoppats.
@@ -5109,7 +5109,7 @@ This improves encoding speed significantly on systems that are otherwise underut
   spa: Esto mejora significativamente la velocidad de codificación en los sistemas
     que de otra manera son subutilizados al codificar el VP9.
   zho: 在编码VP9时资源利用不足的系统上，此选项能够显著提升编码速度。
-  jpn: これにより、VP9をエンコードする際に十分に活用されていないシステムにおいて、エンコード速度が大幅に向上します。
+  jpn: これにより、VP9をエンコードする際に十分に利用されていないシステムにおいて、エンコード速度が大幅に向上します。
   rus: Это значительно повышает скорость кодирования на системах, которые по-другому
     недостаточно используются при кодировании VP9.
   por: Isto melhora significativamente a velocidade de codificação em sistemas que
@@ -5174,7 +5174,7 @@ This is used for ultra-high bitrates with zero loss of quality.:
   ita: 'Questa opzione non viene riavviata a meno che non sia necessario conformarsi '
   spa: 'Esta opción no se reinicia a menos que se necesite conformar '
   zho: 除非您需要为了刻录到物理光盘而遵守蓝光标准，
-  jpn: このオプションは、以下の条件を満たす必要がない限り、推奨されません。
+  jpn: このオプションは、以下の場合でない限り、推奨されません。
   rus: Этот вариант не рекомендуется использовать, если не требуется соответствие
   por: Esta opção não é reiniciada a menos que precise de se conformar
   swe: Det här alternativet rekommenderas inte om du inte behöver anpassa dig till
@@ -5203,7 +5203,7 @@ Tier:
   fra: Tier
   ita: Livello
   spa: Tier
-  zho: 层级
+  zho: 层
   jpn: ティア
   rus: Ярус
   por: Nível
@@ -5219,7 +5219,7 @@ Tile Columns:
   ita: Colonne di piastrelle
   spa: Columnas de azulejos
   zho: Tile列数量
-  jpn: タイルコラム
+  jpn: タイルの列数
   rus: Столбцы плитки
   por: Colunas de Ladrilho
   swe: Kakelpelare
@@ -5234,7 +5234,7 @@ Tile Rows:
   ita: File di piastrelle
   spa: Filas de azulejos
   zho: Tile行数量
-  jpn: タイルの列
+  jpn: タイルの行数
   rus: Строки плитки
   por: Fileiras de Azulejos
   swe: Rader av kakelplattor
@@ -5309,7 +5309,7 @@ Top:
   ita: Top
   spa: Top
   zho: 上端
-  jpn: トップ
+  jpn: 上
   rus: Верх
   por: Início
   swe: Topp
@@ -5324,7 +5324,7 @@ Total video height must be greater than 0:
   ita: L'altezza totale del video deve essere superiore a 0
   spa: La altura total del video debe ser mayor que 0
   zho: 视频总高度必须大于0
-  jpn: ビデオの全高が0より大きいこと
+  jpn: 動画の全高が0より大きいこと
   rus: Общая высота видео должна быть больше 0
   por: A altura total do vídeo deve ser superior a 0
   swe: Den totala videohöjden måste vara större än 0
@@ -5339,7 +5339,7 @@ Tune:
   ita: Tune
   spa: Sintoniza
   zho: 调校
-  jpn: チューン
+  jpn: チューニング
   rus: Настроить
   por: Melodia
   swe: Stäm av
@@ -5399,7 +5399,7 @@ Use --bframes 0 to force all P/I low-latency encodes.:
   ita: Utilizzare --bframes 0 per forzare tutte le codifiche P/I a bassa latenza.
   spa: Use --bframes 0 para forzar todos los códigos de baja latencia P/I.
   zho: 使用--bframes 0强制进行全P/I帧的低延迟编码。
-  jpn: すべてのP/I低レイテンシーエンコードを強制するには、--bframes 0を使用します。
+  jpn: すべてのP/I低レイテンシーエンコードを強制するには、--bframes 0を使用してください。
   rus: Используйте --bframes 0, чтобы заставить все P/I кодировать с низкой задержкой.
   por: Use --bframes 0 para forçar todos os códigos P/I de baixa latência.
   swe: Använd --bframes 0 för att tvinga fram alla P/I-kodningar med låg latenstid.
@@ -5430,7 +5430,7 @@ Use Sane Audio Selection (customizable in config file):
   ita: Utilizzare Sane Audio Selection (aggiornabile nel file di configurazione)
   spa: Usar la Selección de Audio Sane (actualizable en el archivo de configuración)
   zho: 使用合理音频编码选择（可在配置文件中更改）
-  jpn: Sane Audio Selectionの使用（設定ファイルでカスタマイズ可能）
+  jpn: 合理的なオーディオを選択する（設定ファイルでカスタマイズ可能）
   rus: Использовать Разумный выбор аудио (настраивается в конфигурационном файле)
   por: Usar Selecção Áudio Sã (personalizável em ficheiro de configuração)
   swe: Använd Sane Audio Selection (anpassningsbart i konfigurationsfilen)
@@ -5462,7 +5462,7 @@ Useful when you have the "Too many packets buffered for output stream" error:
   spa: Útil cuando se tiene el error "Demasiados paquetes almacenados en la memoria
     intermedia para el flujo de salida".
   zho: 当出现“输出流缓冲的数据包太多”（Too many packets buffered for output stream）错误时有用。
-  jpn: Too many packets buffered for output stream "というエラーが発生した場合に有効です。
+  jpn: '"Too many packets buffered for output stream"というエラーが発生した場合で役に立つ。'
   rus: Полезно, когда у вас возникает ошибка "Слишком много пакетов буферизировано
     для выходного потока".
   por: Útil quando se tem o erro "Demasiados pacotes protegidos para o fluxo de saída".
@@ -5508,7 +5508,7 @@ Using a single frame thread gives a slight improvement in compression,:
     della compressione,
   spa: Usar un solo hilo de cuadro da una ligera mejora en la compresión,
   zho: 使用单帧线程会使压缩率略有提高，
-  jpn: シングルフレームスレッドを使用すると、圧縮率がわずかに向上します。
+  jpn: シングルフレームスレッドを使用すると、圧縮率が少し向上します。
   rus: Использование одного кадрового потока дает небольшое улучшение сжатия,
   por: A utilização de um único fio de moldura dá uma ligeira melhoria na compressão,
   swe: Användning av en tråd med en enda ram ger en liten förbättring av komprimeringen,
@@ -5523,7 +5523,7 @@ VBR Target:
   ita: Obiettivo VBR
   spa: Objetivo VBR
   zho: 目标VBR
-  jpn: VBRターゲット
+  jpn: VBR目標
   rus: VBR Цель
   por: Alvo VBR
   swe: VBR-mål
@@ -5537,8 +5537,8 @@ VBR Target:
   fra: 'Les valeurs : 0:aucun ; 1:rapide ; 2:plein(treillis) par défaut'
   ita: 'Valori: 0:nessuno; 1:veloce; 2:pieno (traliccio) predefinito'
   spa: 'Valores: 0:ninguno; 1:rápido; 2:completo (enrejado) por defecto'
-  zho: 取值：0:none；1:fast；2:full(trellis)（默认）
-  jpn: 値を指定します。0：なし、1：速い、2：フル（トレリス）デフォルト
+  zho: '取值：0:none；1:fast；2:full(trellis)（默认）'
+  jpn: '値を指定します。0：なし、1：速い、2：フル（tresllis）デフォルト'
   rus: 'Значения: 0:нет; 1:быстро; 2:полностью (решетка) по умолчанию'
   por: 'Valores: 0:nenhum; 1:rápido; 2:cheio(trellis) por defeito'
   swe: 'Värden: 0:ingen; 1:snabb; 2:full(trellis) standard'
@@ -5568,7 +5568,7 @@ Various:
   ita: Varie
   spa: Varios
   zho: 多种许可
-  jpn: 様々な
+  jpn: 複数の
   rus: Разное
   por: Vários
   swe: Olika
@@ -5583,7 +5583,7 @@ Vert + Hoz Flip:
   ita: Vert + Hoz Flip
   spa: Vert + Hoz Flip
   zho: 垂直+水平翻转
-  jpn: Vert + Hoz Flip
+  jpn: 上下反転と左右反転
   rus: Верт + Гор переворот
   por: Vert + Hoz Flip
   swe: Vert + Hoz Flip
@@ -5643,7 +5643,7 @@ View:
   ita: Visualizza
   spa: Ver
   zho: 查看
-  jpn: ビュー
+  jpn: 閲覧
   rus: Просмотр
   por: Ver
   swe: Visa
@@ -5689,7 +5689,7 @@ View GUI Debug Logs:
   ita: 'ATTENZIONE: Ci vorrà molto più tempo e il risultato sarà un file più grande'
   spa: 'ADVERTENCIA: Esto tomará mucho más tiempo y resultará en un archivo más grande'
   zho: 警告：这将导致转换用时大幅延长，输出文件体积增大。
-  jpn: 警告：この作業は時間がかかり、ファイルも大きくなります。
+  jpn: 警告：この作業はかなりの時間がかかり、ファイルも大きくなります。
   rus: 'ВНИМАНИЕ: Это займет гораздо больше времени и приведет к увеличению размера
     файла'
   por: 'AVISO: Isto levará muito mais tempo e resultará num ficheiro maior'
@@ -5729,7 +5729,7 @@ Wait for the current command to finish, and stop the next command from processin
   ita: "Attenzione: L'audio non verrà modificato"
   spa: 'Advertencia: El audio no será modificado'
   zho: 警告： 音频不会被修改
-  jpn: 警告音声は修正されません
+  jpn: 注意喚起：音声は変えません
   rus: 'Предупреждение: Аудио не будет изменено'
   por: 'Advertência: O áudio não será modificado'
   swe: 'Varning: Ljudet kommer inte att ändras'
@@ -5744,7 +5744,7 @@ Watch:
   ita: Guarda
   spa: Mira
   zho: 观看
-  jpn: ウォッチ
+  jpn: 閲覧
   rus: Смотреть
   por: Ver
   swe: Titta på
@@ -5914,7 +5914,7 @@ You are using the latest version of FastFlix:
   ita: State utilizzando l'ultima versione di FastFlix
   spa: Está usando la última versión de FastFlix
   zho: 当前FastFlix为最新版本
-  jpn: 最新版のFastFlixを使用しています。
+  jpn: FastFlixは最新版です。
   rus: Вы используете последнюю версию FastFlix
   por: Está a utilizar a última versão de FastFlix
   swe: Du använder den senaste versionen av FastFlix
@@ -5962,7 +5962,7 @@ and the amount of work performed by the full trellis version of --b-adapt lookah
   spa: y la cantidad de trabajo realizado por la versión completa de la espaldera
     de --b-adaptado lookahead.
   zho: lookahead在full(trellis)模式下执行的工作量有二次方的影响。
-  jpn: と、フルトレリス版の--b-adapt lookaheadによる作業量を示しています。
+  jpn: と、フルtrellis版の--b-adapt lookaheadによる作業量を示しています。
   rus: и объем работы, выполняемой версией полной решетки --b-adapt lookahead.
   por: e a quantidade de trabalho realizado pela versão completa de --b-adapt lookahead.
   swe: och den mängd arbete som utförs av den fullständiga trellisversionen av --b-adapt
@@ -6023,7 +6023,7 @@ attachment tracks found:
   ita: tracce di attacco trovate
   spa: pistas de adjuntos encontradas
   zho: 发现附件轨
-  jpn: アタッチメントトラックが見つかりました
+  jpn: 添付トラックが見つかりました
   rus: найдены следы прикрепления
   por: rastos de anexos encontrados
   swe: Spår för fastsättning hittades
@@ -6263,8 +6263,8 @@ data tracks found:
   fra: 'dhdr10-opt : Réduire les frais généraux du SEI'
   ita: 'dhdr10-opt: Riduce le spese generali SEI'
   spa: 'dhdr10-opt: Reduce los gastos de SEI'
-  zho: dhdr10-opt：减少SEI开销
-  jpn: dhdr10-opt:SEI のオーバーヘッドを削減
+  zho: 'dhdr10-opt：减少SEI开销'
+  jpn: 'dhdr10-opt:SEI のオーバーヘッドを削減'
   rus: 'dhdr10-opt: Уменьшает накладные расходы SEI'
   por: 'dhdr10-opt: Reduz as despesas gerais do SEI'
   swe: 'dhdr10-opt: Minskar SEI:s omkostnader'
@@ -6278,8 +6278,8 @@ data tracks found:
   fra: 'exemples : level-idc=4.1:rc-lookahead=10'
   ita: 'esempi: level-idc=4.1:rc-lookahead=10'
   spa: 'ejemplos: level-idc=4.1:rc-lookahead=10'
-  zho: 示例：level-idc=4.1:rc-lookahead=10。
-  jpn: 例：level-idc=4.1:rc-lookahead=10
+  zho: '示例：level-idc=4.1:rc-lookahead=10。'
+  jpn: '例：level-idc=4.1:rc-lookahead=10'
   rus: 'примеры: level-idc=4.1:rc-lookahead=10'
   por: 'exemplos: level-idc=4.1:rc-lookahead=10'
   swe: 'exempel: level-idc=4.1:rc-lookahead=10'
@@ -6293,8 +6293,8 @@ data tracks found:
   fra: 'des fils de trame : Nombre de trames codées simultanément.'
   ita: 'telaio-filettature: Numero di frame codificati simultaneamente.'
   spa: 'Hilos de marcos: Número de cuadros codificados simultáneamente.'
-  zho: frame-threads：同时编码的帧数。
-  jpn: frame-threads。同時に符号化されるフレームの数。
+  zho: 'frame-threads：同时编码的帧数。'
+  jpn: 'frame-threads。同時にエンコードされるフレームの数。'
   rus: 'frame-threads: Количество параллельно кодируемых кадров.'
   por: 'frame-threads: Número de quadros codificados em simultâneo.'
   swe: 'ramtrådar: Antal samtidigt kodade ramar.'
@@ -6310,7 +6310,7 @@ good is the default and recommended for most applications:
   ita: buono è il valore predefinito e raccomandato per la maggior parte delle applicazioni
   spa: bueno es el predeterminado y recomendado para la mayoría de las aplicaciones
   zho: good是默认值，建议用于大多数应用。
-  jpn: ほとんどのアプリケーションで推奨されています。
+  jpn: ほとんどの場合でgoodを推奨されています。
   rus: хороший - по умолчанию и рекомендуется для большинства приложений
   por: bom é o padrão e recomendado para a maioria das aplicações
   swe: good är standard och rekommenderas för de flesta tillämpningar.
@@ -6417,7 +6417,7 @@ is a default profile and will not be removed:
   ita: è un profilo predefinito e non verrà rimosso
   spa: es un perfil predeterminado y no se eliminará
   zho: 是默认配置，不会被删除。
-  jpn: はデフォルトのプロファイルであり、削除されることはありません。
+  jpn: はデフォルトのプロファイルであり、削除されることはできません。
   rus: является профилем по умолчанию и не будет удален
   por: é um perfil padrão e não será removido
   swe: är en standardprofil och kommer inte att tas bort
@@ -6432,7 +6432,7 @@ is extremely source dependant:
   ita: è estremamente dipendente dalla fonte
   spa: es extremadamente dependiente de la fuente
   zho: 与源文件有很大关系
-  jpn: はソースに大きく依存します。
+  jpn: はソースに大きく依存しています。
   rus: чрезвычайно зависит от источника
   por: é extremamente dependente da fonte
   swe: är extremt källberoende.
@@ -6468,7 +6468,7 @@ it will generally just increase memory use.:
     1 segundo (Blu-ray spec)'
   zho: 'keyint: Enable Intra-Encoding by forcing keyframes every 1 second (Blu-ray
     spec)'
-  jpn: keyint：1秒ごとにキーフレームを強制的に生成してイントラエンコードを有効にする（Blu-ray仕様）。
+  jpn: 'keyint：1秒ごとにキーフレームを強制的に生成してイントラエンコードを有効にする（Blu-ray仕様）。'
   rus: 'keyint: Включить внутреннее кодирование путем принудительного воспроизведения
     ключевых кадров каждые 1 секунду (спецификация Blu-ray).'
   por: 'keyint: Activar a Intra-Codificação forçando os keyframes a cada 1 segundo
@@ -6608,8 +6608,8 @@ preset:
   ita: 'preimpostata: Più lento è il preset, migliore è la compressione e la qualità'
   spa: 'preestablecido: Cuanto más lento el preajuste, mejor será la compresión y
     la calidad'
-  zho: preset：较慢的预设能提供更好的压缩比和质量。
-  jpn: のプリセットがあります。プリセットの速度が遅いほど、圧縮率と品質が向上します
+  zho: 'preset：较慢的预设能提供更好的压缩比和质量。'
+  jpn: 'プリセットの速度が遅いほど、圧縮率と品質が向上します。'
   rus: 'предустановка: Чем медленнее предустановка, тем лучше сжатие и качество'
   por: 'pré-definido: Quanto mais lenta for a predefinição, melhor será a compressão
     e qualidade'
@@ -6642,7 +6642,7 @@ profile:
   fra: profil
   ita: profilo
   spa: perfil
-  zho: profile
+  zho: 配置
   jpn: プロフィール
   rus: профиль
   por: perfil
@@ -6657,8 +6657,8 @@ profile:
   fra: 'profil : Appliquer un profil de codage'
   ita: 'profilo: Applicare un profilo di codifica'
   spa: 'perfil: Hacer cumplir un perfil codificado'
-  zho: profile：应用一个编码规格
-  jpn: プロファイルを使用しています。エンコードプロファイルの適用
+  zho: '配置：应用一个编码配置'
+  jpn: 'プロフィール：エンコードプロファイルを適用してください。'
   rus: 'профиль: Применить профиль кодирования'
   por: 'perfil: Forçar um perfil de codificação'
   swe: 'profil: Genomdriva en kodningsprofil'
@@ -6674,8 +6674,8 @@ profile:
     punta'
   spa: 'perfil: Perfil de codificación del VP9 - debe coincidir con la profundidad
     del bit'
-  zho: profile：VP9编码规格——必须与位深度相匹配。
-  jpn: プロファイルを使用しています。VP9コーディングプロファイル - ビット深度と一致する必要があります
+  zho: '配置：VP9编码规格——必须与位深度相匹配。'
+  jpn: 'プロファイルを使用しています。VP9コーディングプロファイル - ビット深度と一致する必要があります'
   rus: 'профиль: Профиль кодирования VP9 - должен соответствовать битовой глубине'
   por: 'perfil: perfil de codificação VP9 - deve corresponder à profundidade do bit'
   swe: 'profil: VP9-kodningsprofil - måste matcha bitdjupet'
@@ -6691,7 +6691,7 @@ python-box:
   ita: python-box
   spa: python-box
   zho: python-box
-  jpn: パイソンボックス
+  jpn: python-box
   rus: python-box
   por: python-box
   swe: python-box
@@ -6726,7 +6726,7 @@ rav1e github:
   spa: 'repetición de los encabezamientos: Si se activa, x265 emitirá encabezados
     VPS, SPS y PPS con cada fotograma clave.'
   zho: repeat-headers：如果启用，x265将随每个关键帧加入VPS，SPS和PPS标头。
-  jpn: repeat-headersを使用します。有効にすると、x265はキーフレームごとにVPS、SPS、PPSの各ヘッダを出力します。
+  jpn: repeat-headersを有効にすると、x265はキーフレームごとにVPS、SPS、PPSの各ヘッダを出力します。
   rus: 'повторять заголовки: Если включено, x265 будет выдавать заголовки VPS, SPS
     и PPS с каждым ключевым кадром.'
   por: 'cabeçalhos de repetição: Se activado, x265 irá emitir cabeçalhos VPS, SPS,
@@ -6801,7 +6801,7 @@ that move across the video from one side to the other and thereby refresh the im
     l'immagine
   spa: que se mueven a través del video de un lado a otro y así refrescan la imagen
   zho: 这些intra blocks的位置在若干帧的时间内从视频一侧移动到另一侧，
-  jpn: 映像の中を左右に移動することで映像を更新する
+  jpn: 画像の中を左右に移動することで画像を更新する
   rus: которые перемещаются по видео с одной стороны на другую и тем самым обновляют
     изображение
   por: que se movem através do vídeo de um lado para o outro e assim refrescam a imagem
@@ -6820,7 +6820,7 @@ the resolution-to-:
   ita: il risuonare
   spa: la reso
   zho: 分辨率与
-  jpn: 決議から
+  jpn: 解像度と
   rus: разрешение на
   por: a resolução de
   swe: resolutionen-till
@@ -6897,7 +6897,7 @@ There are no videos to start converting:
   ita: Non ci sono video da convertire
   spa: No hay vídeos para empezar a convertir
   zho: 没有视频可以开始转换
-  jpn: 変換を開始するためのビデオがありません
+  jpn: 変換する動画はありません
   rus: Нет видео, чтобы начать конвертацию
   por: Não há vídeos para começar a converter
   swe: Det finns inga videor att börja konvertera
@@ -6932,7 +6932,7 @@ Are you sure you want to stop the current encode?:
   ita: Sei sicuro di voler fermare la codifica in corso?
   spa: ¿Está seguro de que quiere detener la codificación actual?
   zho: 你确定要停止当前的编码吗？
-  jpn: 本当に現在のエンコードを止めていいのか？
+  jpn: 本当に現在実行中のエンコードを中止してもいいですか？
   rus: Вы уверены, что хотите остановить текущее кодирование?
   por: Tem a certeza de que quer parar o código actual?
   swe: Är du säker på att du vill stoppa den pågående kodningen?
@@ -6947,7 +6947,7 @@ Confirm Stop Encode:
   ita: Confermare Stop Encode
   spa: Confirmar parada de codificación
   zho: 确认停止编码
-  jpn: 確認 停止 エンコード
+  jpn: エンコード中止を確認
   rus: Подтверждение остановки кодирование
   por: Confirmar Codificação de paragem
   swe: Bekräfta Stop Encode
@@ -6962,7 +6962,7 @@ Use Sane Audio Selection (updatable in config file):
   ita: Usa la selezione audio (aggiornabile nel file di configurazione)
   spa: Utilizar la selección de audio (actualizable en el archivo de configuración)
   zho: 使用音频合理选择（可在配置文件中更改）
-  jpn: Sane Audio Selectionの使用（設定ファイルで変更可能）
+  jpn: 合理的なオーディオを選択する（設定ファイルで変更可能）
   rus: Используйте Разумный выбор аудио (обновляется в конфигурационном файле)
   por: Use Sane Audio Selection (actualizável em ficheiro de configuração)
   swe: Använd Sane Audio Selection (kan uppdateras i konfigurationsfilen)
@@ -6977,7 +6977,7 @@ HDR10+ Parser:
   ita: HDR10+ Parser
   spa: Analizador HDR10+
   zho: HDR10+解析器
-  jpn: HDR10+パーサー
+  jpn: HDR10+分析器
   rus: Парсер HDR10+
   por: HDR10+ Parser
   swe: HDR10+ Parser
@@ -7007,7 +7007,7 @@ Would you like to keep them in the queue?:
   ita: Volete tenerli in coda?
   spa: ¿Quiere mantenerlos en la cola?
   zho: 你想把他们留在队列中吗？
-  jpn: このままキューに入れておきますか？
+  jpn: このままキューに残しますか？
   rus: Хотите ли вы оставить их в очереди?
   por: Gostaria de os manter na fila de espera?
   swe: Vill du behålla dem i kön?
@@ -7037,7 +7037,7 @@ There is already a video being processed:
   ita: C'è già un video in elaborazione
   spa: Ya hay un vídeo en proceso
   zho: 已经有一个视频正在处理中
-  jpn: すでに処理中の動画がある
+  jpn: すでに処理中の動画があります
   rus: Видео уже обрабатывается
   por: Já há um vídeo a ser processado
   swe: Det finns redan en video som håller på att bearbetas
@@ -7097,7 +7097,7 @@ Custom VCEEncC options:
   ita: Opzioni VCEEncC personalizzate
   spa: Opciones personalizadas de VCEEncC
   zho: 自定义VCEEncC选项
-  jpn: カスタムVCEEncCオプション
+  jpn: VCEEncCのカスタムオプション
   rus: Пользовательские опции VCEEncC
   por: Opções VCEEncC personalizadas
   swe: Anpassade VCEEncC-alternativ
@@ -7127,7 +7127,7 @@ Variance Based Adaptive Quantization:
   ita: Quantizzazione adattiva basata sulla varianza
   spa: Cuantización adaptativa basada en la varianza
   zho: 基于方差的自适应量化
-  jpn: Variance Based Adaptive Quantization（分散ベースの適応型量子化
+  jpn: Variance Based Adaptive Quantization（分散ベースの適応型量子化）
   rus: Адаптивное квантование на основе дисперсии
   por: Quantização Adaptativa com Base na Variância
   swe: Variansbaserad adaptiv kvantisering
@@ -7231,8 +7231,8 @@ Decoder:
   fra: "Hardware : utiliser libavformat + décodeur matériel pour l'entrée"
   ita: "Hardware: usa libavformat + decoder hardware per l'ingresso"
   spa: 'Hardware: utilizar libavformat + decodificador de hardware para la entrada'
-  zho: Hardware：使用libavformat+硬件解码器进行输入
-  jpn: ハードウェア：入力にlibavformat＋ハードウェアデコーダを使用
+  zho: 'Hardware：使用libavformat+硬件解码器'
+  jpn: 'ハードウェア：入力にlibavformat＋ハードウェアデコーダを使用'
   rus: 'Аппаратное обеспечение: использование libavformat + аппаратного декодера для
     ввода'
   por: 'Hardware: usar libavformat + descodificador de hardware para entrada'
@@ -7248,8 +7248,8 @@ Decoder:
   fra: 'Software : utiliser avcodec + décodeur logiciel'
   ita: 'Software: usa avcodec + decoder software'
   spa: 'Software: utilizar avcodec + decodificador de software'
-  zho: Software：使用avcodec + 软件解码器
-  jpn: ソフトウェア：avcodec + ソフトウェアデコーダを使用
+  zho: 'Software：使用avcodec + 软件解码器'
+  jpn: 'ソフトウェア：avcodec + ソフトウェアデコーダを使用'
   rus: 'Программное обеспечение: используйте avcodec + программный декодер'
   por: 'Software: utilizar avcodec + descodificador de software'
   swe: 'Programvara: Använd avcodec + mjukvaruavkodare'
@@ -7294,7 +7294,7 @@ Concatenation Builder:
   ita: Costruttore di concatenazioni
   spa: Constructor de Concatenación
   zho: 创建合并序列
-  jpn: コンカチネーションビルダー
+  jpn: 連結ビルダー
   rus: Конструктор конкатенации
   por: Construtor de Concatenação
   swe: Byggare för sammankoppling
@@ -7446,8 +7446,8 @@ Drag and Drop to reorder - All items need to be same dimensions:
   ita: Drag and Drop per riordinare - Tutti gli elementi devono avere le stesse dimensioni
   spa: Arrastrar y soltar para reordenar - Todos los elementos deben tener las mismas
     dimensiones
-  zho: 拖放来重新排序 - 所有项目的尺寸都需要相同
-  jpn: ドラッグ＆ドロップで再注文 - すべてのアイテムが同じ寸法である必要があります。
+  zho: '拖放来重新排序 - 所有项目的尺寸都需要相同'
+  jpn: 'ドラッグ＆ドロップで並び替え - すべてのアイテムが同じ寸法である必要があります。'
   rus: Перетаскивание для изменения порядка - все элементы должны иметь одинаковые
     размеры
   por: Arrastar e largar para reordenar - Todos os artigos precisam de ter as mesmas
@@ -7471,7 +7471,7 @@ The following items were excluded as they could not be identified as image or vi
   spa: Se han excluido los siguientes elementos por no poder ser identificados como
     archivos de imagen o vídeo
   zho: 以下项目被排除在外，因为它们无法被识别为图像或视频文件
-  jpn: 以下のものは、画像・映像ファイルとして識別できないため、除外しました。
+  jpn: 以下のものは、画像・動画ファイルとして識別できないため、除外しました。
   rus: Следующие элементы были исключены, поскольку их нельзя было идентифицировать
     как файлы изображений или видеофайлы
   por: Os seguintes itens foram excluídos por não poderem ser identificados como ficheiros
@@ -7569,7 +7569,7 @@ does not support concatenating files together:
   spa: 'ADVERTENCIA: Esta función no es proporcionada por el software del codificador
     directamente'
   zho: 警告：编码器软件不直接提供这一功能。
-  jpn: 警告：この機能は、エンコーダソフトウェアが直接提供するものではありません。
+  jpn: 注意喚起：この機能は、エンコーダソフトウェアが直接提供するものではありません。
   rus: 'ВНИМАНИЕ: Эта функция не обеспечивается непосредственно программным обеспечением
     энкодера'
   por: 'AVISO: Esta funcionalidade não é fornecida directamente pelo software codificador'
@@ -7602,7 +7602,7 @@ Are you sure you want to continue?:
   ita: Sei sicuro di voler continuare?
   spa: ¿Está seguro de que desea continuar?
   zho: 你确定你要继续吗?
-  jpn: 本当に続けていいのか？
+  jpn: 本当に続けてもいいですか？
   rus: Вы уверены, что хотите продолжать?
   por: Tem a certeza de que quer continuar?
   swe: Är du säker på att du vill fortsätta?
@@ -7617,7 +7617,7 @@ Pause Warning:
   ita: Avviso di pausa
   spa: Advertencia de pausa
   zho: 暂停警告
-  jpn: ポーズ警告
+  jpn: 中止注意
   rus: Предупреждение о паузе
   por: Aviso de Pausa
   swe: Varning för paus
@@ -7632,8 +7632,8 @@ First:
   fra: Premier
   ita: Prima
   spa: Primero
-  zho: 首先
-  jpn: ファースト
+  zho: 开始
+  jpn: 先頭
   rus: Первый
   por: Primeiro
   swe: Första
@@ -7647,7 +7647,7 @@ Last:
   fra: Dernier site
   ita: Ultimo
   spa: Última
-  zho: 最后一次
+  zho: 最后
   jpn: 最後
   rus: Последний
   por: Último
@@ -7663,7 +7663,7 @@ Track Number:
   ita: Numero di traccia
   spa: Número de pista
   zho: 轨道编号
-  jpn: トラックナンバー
+  jpn: トラック番号
   rus: Номер дорожки
   por: Número da faixa
   swe: Spårnummer
@@ -7677,7 +7677,7 @@ Channels:
   fra: Chaînes
   ita: Canali
   spa: Canales
-  zho: 渠道
+  zho: 声道
   jpn: チャンネル
   rus: Каналы
   por: Canais
@@ -7693,7 +7693,7 @@ Audio Select:
   ita: Selezione audio
   spa: Selección de audio
   zho: 音频选择
-  jpn: オーディオセレクト
+  jpn: オーディオ選択
   rus: Выбор аудио
   por: Selecione o áudio
   swe: Ljudval
@@ -7768,7 +7768,7 @@ Select By:
   ita: Seleziona per
   spa: Seleccionar por
   zho: 选择方式
-  jpn: で選ぶ
+  jpn: 選び方
   rus: Выбрать по
   por: Selecione por
   swe: Välj efter
@@ -7796,7 +7796,7 @@ License:
   fra: Licence
   ita: Licenza
   spa: Licencia
-  zho: 许可证
+  zho: 许可
   jpn: ライセンス
   rus: Лицензия
   por: Licença
@@ -7857,7 +7857,7 @@ Extra svt av1 params in opt=1:opt2=0 format:
   ita: Parametri extra svt av1 nel formato opt=1:opt2=0
   spa: Parámetros extra svt av1 en formato opt=1:opt2=0
   zho: 额外的svt av1参数，格式为opt=1:opt2=0
-  jpn: opt=1:opt2=0のフォーマットでの余分なsvt av1パラメータ
+  jpn: opt=1:opt2=0のフォーマットでの他のsvt av1パラメータ
   rus: Дополнительные параметры svt av1 в формате opt=1:opt2=0
   por: Parâmetros av1 extra svt no formato opt=1:opt2=0
   swe: Extra svt av1-parametrar i formatet opt=1:opt2=0
@@ -8090,8 +8090,8 @@ AVC coding profile:
   fra: Profil de codage AVC
   ita: Profilo di codifica AVC
   spa: Perfil de codificación AVC
-  zho: AVC编码规格
-  jpn: AVC符号化プロファイル
+  zho: AVC编码配置
+  jpn: AVCエンコードプロファイル
   rus: Профиль кодирования AVC
   por: Perfil de codificação AVC
   swe: AVC-kodningsprofil
@@ -8211,7 +8211,7 @@ Frames After:
   ita: Fotogrammi dopo
   spa: Fotogramas después
   zho: 之后的帧数
-  jpn: フレーム数
+  jpn: 後のフレーム数
   rus: Кадры после
   por: Quadros após
   swe: Bilder efter
@@ -8371,8 +8371,8 @@ It will update it with the contents of:
   fra: Il le mettra à jour avec le contenu de
   ita: Lo aggiornerà con il contenuto di
   spa: Lo actualizará con el contenido de
-  zho: 它将用以下内容更新它
-  jpn: の内容で更新されます。
+  zho: 将用以下内容更新
+  jpn: 以下の内容で更新されます。
   rus: Он обновит его содержимым
   por: Ele o atualizará com o conteúdo de
   swe: Den kommer att uppdatera den med innehållet i
@@ -8387,7 +8387,7 @@ Are you sure you want to proceed?:
   ita: Sei sicuro di voler procedere?
   spa: ¿Estás seguro de que quieres continuar?
   zho: 确定要继续吗？
-  jpn: 本当に進めていいんですか？
+  jpn: 本当に進めてもいいですか？
   rus: Вы уверены, что хотите продолжить?
   por: Você tem certeza de que quer prosseguir?
   swe: Är du säker på att du vill fortsätta?
@@ -8432,7 +8432,7 @@ Load Queue:
   ita: Coda di carico
   spa: Cola de carga
   zho: 加载队列
-  jpn: ロードキュー
+  jpn: キューをロードする
   rus: Загрузить очередь
   por: Fila de carga
   swe: Belastningskö
@@ -8447,7 +8447,7 @@ Queue saved to:
   ita: Coda salvata in
   spa: Cola guardada en
   zho: 队列保存到
-  jpn: に保存されたキュー
+  jpn: に保存されました
   rus: Очередь сохранена в
   por: Fila salva para
   swe: Kö sparad till
@@ -8462,7 +8462,7 @@ That file doesn't exist:
   ita: Quel file non esiste
   spa: Ese archivo no existe
   zho: 该文件不存在
-  jpn: そのファイルは存在しません
+  jpn: 該当ファイルは存在しません
   rus: Этот файл не существует
   por: Esse arquivo não existe
   swe: Den filen finns inte
@@ -8477,7 +8477,7 @@ There are more than 100 files, skipping pre-processing.:
   ita: Ci sono più di 100 file, saltando la pre-elaborazione.
   spa: Hay más de 100 archivos, omitiendo el preprocesamiento.
   zho: 文件多于100个，跳过预处理。
-  jpn: 前処理を省いて100ファイル以上あります。
+  jpn: 100ファイル以上ありますので、プリプロセスをスキップします。
   rus: Имеется более 100 файлов, пропуская предварительную обработку.
   por: Existem mais de 100 ficheiros, saltando o pré-processamento.
   swe: Det finns mer än 100 filer, och du kan hoppa över förbehandlingen.
@@ -8494,7 +8494,7 @@ No audio tracks matched for this profile, enable first track?:
   spa: No hay pistas de audio que coincidan con este perfil, habilitar la primera
     pista?
   zho: 此配置文件没有匹配的音轨，启用第一个音轨？
-  jpn: このプロファイルに一致するオーディオトラックがありません、最初のトラックを有効にしますか？
+  jpn: このプロファイルに一致するオーディオトラックがありません。最初のトラックを有効にしますか？
   rus: Для этого профиля не подобраны звуковые дорожки, включить первую дорожку?
   por: Não há faixas de áudio correspondentes a este perfil, permitir a primeira faixa?
   swe: Inga ljudspår har matchats för den här profilen, aktivera det första spåret?
@@ -8509,7 +8509,7 @@ No Audio Match:
   ita: Nessuna corrispondenza audio
   spa: No hay coincidencia de audio
   zho: 没有音频匹配
-  jpn: オーディオマッチングなし
+  jpn: マッチしたオーディオはありません
   rus: Нет звукового соответствия
   por: Sem Audio Match
   swe: Ingen ljudmatchning
@@ -8539,7 +8539,7 @@ Preserve All:
   ita: Conservare tutto
   spa: Conservar todo
   zho: 保存所有
-  jpn: プリザーブオール
+  jpn: 全て保留
   rus: Сохранить все
   por: Preservar tudo
   swe: Bevara allt
@@ -8630,7 +8630,7 @@ No Default Source Folder:
   ita: Nessuna cartella di origine predefinita
   spa: No hay carpeta de origen por defecto
   zho: 没有默认的源文件夹
-  jpn: デフォルトのソースフォルダなし
+  jpn: デフォルトのソースフォルダはありません
   rus: Нет Исходной папки по умолчанию
   por: Sem pasta de origem por defeito
   swe: Ingen standardkällmapp
@@ -8644,8 +8644,8 @@ Stay on Top:
   fra: Rester au top
   ita: Rimanere al top
   spa: Manténgase en la cima
-  zho: 保持巅峰状态
-  jpn: トップに君臨する
+  zho: 窗口保持再最上方
+  jpn: ウィンドウを最上位にする
   rus: Оставаться поверх
   por: Fique no topo
   swe: Håll dig på topp
@@ -8734,7 +8734,7 @@ Load Directory:
   fra: Chargement du répertoire
   ita: Elenco dei carichi
   spa: Cargar directorio
-  zho: 负载目录
+  zho: 加载目录
   jpn: ロードディレクトリ
   rus: Загрузить каталог
   por: Directório de Carga
@@ -8780,7 +8780,7 @@ Long Edge:
   ita: Bordo lungo
   spa: Borde largo
   zho: 长边
-  jpn: ロングエッジ
+  jpn: 長い端
   rus: Длинная кромка
   por: Bordo Longo
   swe: Lång kant
@@ -8825,7 +8825,7 @@ Custom (w:h):
   fra: Sur mesure (l:h)
   ita: Personalizzato (l:h)
   spa: Personalizado (ancho:alto)
-  zho: 定制 (w:h)
+  zho: 自定义(w:h)
   jpn: カスタム（w：h）
   rus: Пользовательский (w:h)
   por: Personalizado (w:h)
@@ -9030,7 +9030,7 @@ Constant Quality, Intelligent Constant Quality, Intelligent + Lookahead Constant
   spa: Calidad constante, Inteligente Calidad constante, Inteligente + Lookahead Calidad
     constante
   zho: 恒定质量，智能恒定质量，智能+前瞻恒定质量
-  jpn: 一定品質、インテリジェント一定品質、インテリジェント＋ルックアヘッド一定品質
+  jpn: 品質固定、インテリジェント品質固定、インテリジェント＋ルックアヘッド品質固定
   rus: Постоянное качество, интеллектуальное постоянное качество, интеллектуальное
     качество + опережающее постоянное качество
   por: Qualidade Constante, Qualidade Constante Inteligente, Qualidade Constante Inteligente
@@ -9055,7 +9055,7 @@ The following items were excluded as they could not be identified as a video fil
   spa: Se excluyeron los siguientes elementos por no poder identificarse como archivos
     de vídeo
   zho: 以下项目被排除在外，因为它们不能被确定为视频文件
-  jpn: 以下のものは、ビデオファイルとして識別できないため、除外した。
+  jpn: 以下のものは、動画ファイルとして識別できないため、除外した。
   rus: Следующие предметы были исключены, так как их нельзя было идентифицировать
     как видеофайлы
   por: Os seguintes itens foram excluídos por não poderem ser identificados como ficheiros
@@ -9075,7 +9075,7 @@ more:
   ita: di più
   spa: más
   zho: 更多
-  jpn: も
+  jpn: もっと
   rus: больше
   por: mais
   swe: mer
@@ -9134,7 +9134,7 @@ Device:
   fra: Dispositif
   ita: Dispositivo
   spa: Dispositivo
-  zho: 器材
+  zho: 设备
   jpn: デバイス
   rus: Устройство
   por: Dispositivo
@@ -9149,8 +9149,8 @@ Don't Select Any Audio:
   fra: Ne pas sélectionner d'audio
   ita: Non selezionare alcun audio
   spa: No seleccione ningún audio
-  zho: 不要选择任何音频
-  jpn: 任意のオーディオを選択しない
+  zho: 不选择任何音频
+  jpn: オーディオを選択しない
   rus: Не выбирайте аудио
   por: Não seleccione nenhum áudio
   swe: Välj inte något ljud
@@ -9164,7 +9164,7 @@ Adaptive Reference Frames:
   fra: Cadres de référence adaptatifs
   ita: Cornici di riferimento adattive
   spa: Marcos de referencia adaptativos
-  zho: 自适应参考框架
+  zho: 自适应参考Z帧
   jpn: アダプティブリファレンスフレーム
   rus: Адаптивные опорные кадры
   por: Quadros de referência adaptativos
@@ -9182,7 +9182,7 @@ Adaptively select list of reference frames to improve encoding quality.:
     la qualità della codifica.
   spa: Selección adaptativa de la lista de fotogramas de referencia para mejorar la
     calidad de la codificación.
-  zho: 自适应地选择参考帧列表以提高编码质量。
+  zho: 自适应地选择参考帧的列表以提高编码质量。
   jpn: エンコード品質を向上させるために、参照フレームのリストを適応的に選択する。
   rus: Адаптивный выбор списка опорных кадров для улучшения качества кодирования.
   por: Seleccionar de forma adaptativa a lista de quadros de referência para melhorar
@@ -9199,7 +9199,7 @@ Adaptive Long-Term Reference Frames:
   fra: Cadres de référence adaptatifs à long terme
   ita: Quadri di riferimento adattativi a lungo termine
   spa: Marcos de referencia a largo plazo adaptables
-  zho: 自适应的长期参考框架
+  zho: 自适应的长期参考帧
   jpn: 適応型長期基準フレーム
   rus: Адаптивные долгосрочные опорные кадры
   por: Quadros de referência adaptativos de longo prazo
@@ -9468,8 +9468,8 @@ Lookahead distance:
   fra: Distance d'anticipation
   ita: Distanza di sicurezza
   spa: Distancia de seguridad
-  zho: 前瞻性距离
-  jpn: ルックアヘッド距離
+  zho: 向前看的距离
+  jpn: 前向きの距離
   rus: Дистанция опережения
   por: Distância Lookahead
   swe: Avstånd till nästa tidpunkt
@@ -9529,7 +9529,7 @@ Enable long-term reference frame:
   ita: Abilitazione del quadro di riferimento a lungo termine
   spa: Habilitar el marco de referencia a largo plazo
   zho: 启用长期参考框架
-  jpn: 長期的な基準フレームを有効にする
+  jpn: 長期的な参照フレームを有効にする
   rus: Включить долгосрочную систему отсчета
   por: Habilitar quadro de referência a longo prazo
   swe: Aktivera långsiktig referensram
@@ -9708,8 +9708,8 @@ B Depth:
   fra: B Profondeur
   ita: B Profondità
   spa: B Profundidad
-  zho: B 深度
-  jpn: Bデプス
+  zho: B深度
+  jpn: B深度
   rus: B Глубина
   por: B Profundidade
   swe: B Djup
@@ -9883,8 +9883,8 @@ AUD:
   fra: AUD
   ita: AUD
   spa: AUD
-  zho: 澳元
-  jpn: 豪ドル
+  zho: AUD
+  jpn: AUD
   rus: AUD
   por: AUD
   swe: AUD
@@ -9898,7 +9898,7 @@ Include AUD:
   fra: Inclure l'AUD
   ita: Includere AUD
   spa: Incluir AUD
-  zho: 包括澳元
+  zho: 包括AUD
   jpn: AUDを含む
   rus: Включая AUD
   por: Incluir AUD
@@ -9913,8 +9913,8 @@ Forced:
   fra: Forcé
   ita: Costretto
   spa: Forzado
-  zho: 被迫的
-  jpn: フォースド
+  zho: 强制的
+  jpn: 強制的
   rus: Принудительный
   por: Forçado
   swe: Tvingad
@@ -9928,7 +9928,7 @@ Default:
   fra: Défaut
   ita: Predefinito
   spa: Por defecto
-  zho: 默认情况下
+  zho: 默认
   jpn: デフォルト
   rus: По умолчанию
   por: Predefinição
@@ -9943,8 +9943,8 @@ Hearing Impaired:
   fra: Malentendants
   ita: Non udenti
   spa: Discapacidad auditiva
-  zho: 听力障碍者
-  jpn: 聴覚障害者
+  zho: 听障者
+  jpn: 聴覚障がい者
   rus: Нарушение слуха
   por: Deficiente Auditivo
   swe: Hörselskadade
@@ -9958,7 +9958,7 @@ Original:
   fra: Original
   ita: Originale
   spa: Original
-  zho: 原创
+  zho: 原始
   jpn: オリジナル
   rus: Оригинал
   por: Original
@@ -10018,7 +10018,7 @@ Dub:
   fra: Dub
   ita: Dub
   spa: Dub
-  zho: 录音
+  zho: 配音
   jpn: ダブ
   rus: Dub
   por: Dub
@@ -10048,7 +10048,7 @@ default:
   fra: par défaut
   ita: predefinito
   spa: por defecto
-  zho: 违约
+  zho: 默认
   jpn: デフォルト
   rus: по умолчанию
   por: padrão
@@ -10063,7 +10063,7 @@ original:
   fra: original
   ita: originale
   spa: original
-  zho: 原始的
+  zho: 原始
   jpn: オリジナル
   rus: оригинал
   por: original
@@ -10078,7 +10078,7 @@ forced:
   fra: forcée
   ita: forzato
   spa: forzado
-  zho: 被迫
+  zho: 强制
   jpn: 強制的
   rus: принудительно
   por: forçado
@@ -10198,8 +10198,8 @@ hearing_impaired:
   fra: Malentendants
   ita: Non udenti
   spa: Discapacidad auditiva
-  zho: 听力障碍者
-  jpn: 聴覚障害者
+  zho: 听障者
+  jpn: 聴覚障がい者
   rus: Нарушение слуха
   por: Deficiente Auditivo
   swe: Hörselskadade
@@ -10213,7 +10213,7 @@ visual_impaired:
   fra: Malvoyants
   ita: Improvvisazione visiva
   spa: Discapacidad visual
-  zho: 视觉障碍
+  zho: 视障者
   jpn: 視覚障がい者
   rus: Слабовидящие
   por: Deficiente Visual

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -121,7 +121,7 @@ Additional x265 params:
   ita: Parametri aggiuntivi x265
   spa: Parámetros adicionales x265
   zho: 额外的x265参数
-  jpn: 追加のx265パラメター
+  jpn: 追加のx265パラメータ
   rus: Дополнительные параметры x265
   por: Parâmetros adicionais x265
   swe: Ytterligare parametrar för x265
@@ -136,7 +136,7 @@ Advanced:
   ita: Avanzato
   spa: Avanzado
   zho: 高级
-  jpn: アドバンスド
+  jpn: 高度な
   rus: Расширенный
   por: Avançado
   swe: Avancerad
@@ -181,7 +181,7 @@ All queue items have completed:
   ita: Tutte le voci della coda sono state completate
   spa: Todos los artículos de la cola se han completado
   zho: 所有排队项目已完成
-  jpn: すべてのキューアイテムが完了
+  jpn: すべてのキューアイテムが完了しました
   rus: Все пункты очереди завершены
   por: Todos os itens da fila foram completados
   swe: Alla köposter har avslutats.
@@ -226,7 +226,7 @@ Audio select language:
   ita: Audio seleziona la lingua
   spa: Audio seleccionar idioma
   zho: 选择音频语言
-  jpn: オーディオの選択言語
+  jpn: オーディオ言語の選択
   rus: Выбор языка аудио
   por: Seleccione a língua do áudio
   swe: Ljud väljer språk
@@ -256,7 +256,7 @@ Auto:
   ita: Auto
   spa: Auto
   zho: 自动
-  jpn: オート
+  jpn: 自動的
   rus: Авто
   por: Auto
   swe: Auto
@@ -271,7 +271,7 @@ Auto Burn-in first forced or default subtitle track:
   ita: Auto Burn-in prima traccia sottotitoli forzata o predefinita
   spa: Auto Burn-in primera pista de subtítulos forzados o por defecto
   zho: 自动内嵌第一条分配为forced或default的字幕轨
-  jpn: オートバーンイン最初の強制またはデフォルトの字幕トラック
+  jpn: 最初の強制またはデフォルトの字幕トラックを自動的にバーンインする
   rus: Автоматическое включение первой принудительной дорожки субтитров или дорожки
     субтитров по умолчанию
   por: Auto Burn-in primeira faixa de subtítulos forçada ou por defeito
@@ -288,7 +288,7 @@ Auto Crop:
   ita: Auto Crop
   spa: Auto Crop
   zho: 自动裁切
-  jpn: オートクロップ
+  jpn: 自動クロップ
   rus: Автообрезка
   por: Cultura Automóvel
   swe: Automatisk beskärning
@@ -303,7 +303,7 @@ Auto Crop - Finding black bars at:
   ita: Auto Crop - Trovare barre nere a
   spa: Auto Crop - Encontrar barras negras en
   zho: 自动裁切 - 寻找位于此时刻的黑边：
-  jpn: オートクロップ - 黒いバーを見つける
+  jpn: 自動クロップ - 黒いバーを見つける
   rus: Автообрезка - Нахождение черных полос в
   por: Auto Crop - Encontrar barras pretas em
   swe: Automatisk beskärning - Hitta svarta streck vid
@@ -333,7 +333,7 @@ Automatically enabled when an interlaced video is detected:
   ita: Abilitato automaticamente quando viene rilevato un video interlacciato
   spa: Se activa automáticamente cuando se detecta un vídeo entrelazado
   zho: 当检测到隔行扫描视频时自动启用此项。
-  jpn: インターレースビデオが検出されると自動的に有効になります。
+  jpn: インターレース動画が検出されると自動的に有効になります。
   rus: Автоматически включается при обнаружении чересстрочного видео
   por: Activado automaticamente quando um vídeo entrelaçado é detectado
   swe: Aktiveras automatiskt när en interlaced video upptäcks.
@@ -348,7 +348,7 @@ B Adapt:
   ita: B Adattare
   spa: B Adaptar
   zho: B Adapt
-  jpn: Bアダプタ
+  jpn: Bアダプト
   rus: B Адаптация
   por: B Adaptar
   swe: B Anpassning
@@ -438,7 +438,7 @@ Both Passes:
   ita: Entrambi i Pass
   spa: Ambos pases
   zho: 两遍均应用
-  jpn: 両方のパス
+  jpn: 1回目と2回目両方
   rus: Оба прохода
   por: Ambos os Passes
   swe: Båda passen
@@ -484,7 +484,7 @@ Break the video into rows to encode faster (lesser quality):
   ita: Suddividere il video in righe per codificare più velocemente (qualità inferiore)
   spa: Dividir el video en filas para codificar más rápido (menor calidad)
   zho: 将视频按行分割，以更快地进行编码（质量较差）。
-  jpn: 速くエンコードするためにビデオを列に分割する（画質は劣る）
+  jpn: 速くエンコードするためにビデオを列に分割する（画質は落ちる）
   rus: Разбейте видео на строки для более быстрого кодирования (с меньшим качеством)
   por: Quebrar o vídeo em filas para codificar mais rapidamente (menor qualidade)
   swe: Dela upp videon i rader för att koda snabbare (sämre kvalitet)
@@ -544,8 +544,8 @@ CPU Used:
   fra: CPU utilisé
   ita: CPU usata
   spa: CPU utilizado
-  zho: CPU用量
-  jpn: 使用CPU
+  zho: CPU使用率
+  jpn: CPU使用率
   rus: Используемый процессор
   por: CPU utilizada
   swe: CPU som används
@@ -590,7 +590,7 @@ Cancel Conversion:
   ita: Annullare la conversione
   spa: Cancelar la conversión
   zho: 取消转换
-  jpn: 変換キャンセル
+  jpn: 変換をキャンセルする
   rus: Отменить преобразование
   por: Cancelar Conversão
   swe: Avbryt konvertering
@@ -605,7 +605,7 @@ Cancel has been requested, killing encoding:
   ita: È stata richiesta la cancellazione, uccidendo la codifica
   spa: Se ha solicitado la cancelación, matando la codificación
   zho: 已请求取消，正在终止编码
-  jpn: キャンセルが要求された場合、エンコーディングを殺す
+  jpn: キャンセルが要求されました、エンコーディングを終了中
   rus: Была запрошена отмена, прекращающая кодирование
   por: Foi pedido o cancelamento, codificação de mortes
   swe: Avbryt har begärts, dödande kodning
@@ -635,7 +635,7 @@ Cancelled:
   ita: Cancellato
   spa: Cancelado
   zho: 已取消
-  jpn: キャンセル
+  jpn: キャンセルされた
   rus: Отменено
   por: Cancelado
   swe: Avbokad
@@ -649,8 +649,8 @@ Cancelled - Ready to try again:
   fra: Annulé - Prêt à réessayer
   ita: Annullato - Pronto a riprovare
   spa: Cancelado - Listo para intentarlo de nuevo
-  zho: 已取消 - 准备重试
-  jpn: キャンセル - 再試行の準備
+  zho: 已取消 - 已准备好重试
+  jpn: キャンセルされました - 再試行できます
   rus: Отменено - готовы повторить попытку
   por: Cancelado - Pronto para tentar novamente
   swe: Avbruten - redo att försöka igen
@@ -665,7 +665,7 @@ Cannot remove afterwards!:
   ita: Non può essere rimosso dopo!
   spa: No se puede quitar después!
   zho: 字幕内嵌之后无法去除！
-  jpn: 後から削除できない！？
+  jpn: バーンインした字幕は後から削除できない！
   rus: Невозможно потом удалить!
   por: Não é possível remover depois!
   swe: Kan inte tas bort efteråt!
@@ -680,7 +680,7 @@ Check for Newer Version of FastFlix:
   ita: Verifica la presenza di una versione più recente di FastFlix
   spa: Busca la nueva versión de FastFlix
   zho: 检查FastFlix更新
-  jpn: 新しいバージョンのFastFlixのチェック
+  jpn: 新しいバージョンのFastFlixをチェックする
   rus: Проверьте наличие новой версии FastFlix
   por: Verificar a existência de uma versão mais recente de FastFlix
   swe: Kontrollera om det finns en nyare version av FastFlix
@@ -695,7 +695,7 @@ Clean Old Logs:
   ita: Pulire i vecchi tronchi
   spa: Limpiar los viejos troncos
   zho: 清理旧日志
-  jpn: 古い丸太をきれいにする
+  jpn: 古いログを削除する
   rus: Очистить старые журналы
   por: Toros antigos limpos
   swe: Rengör gamla stockar
@@ -709,8 +709,8 @@ Clear Completed:
   fra: Clair Terminé
   ita: Chiaro Completato
   spa: Claro Completado
-  zho: 清理已完成项目
-  jpn: クリア完了
+  zho: 清理已完成。
+  jpn: 削除が完了しました。
   rus: Очистка завершена
   por: Limpar Completado
   swe: Klart slutfört
@@ -740,7 +740,7 @@ CodeCalamity UHD HDR Encoding Guide:
   ita: Guida alla codifica CodeCalamity UHD HDR
   spa: CodeCalamity UHD Guía de codificación HDR
   zho: CodeCalamity的UHD HDR编码指南（英文）
-  jpn: CodeCalamity UHD HDRエンコーディングガイド
+  jpn: CodeCalamity UHD HDRエンコーディングガイド（英語）
   rus: CodeCalamity Руководство по кодированию UHD HDR
   por: CodeCalamity UHD Guia de Codificação de HDR
   swe: CodeCalamity UHD HDR-kodningsguide
@@ -799,7 +799,7 @@ Command has completed:
   fra: Le commandement a terminé
   ita: Il comando ha completato
   spa: El comando ha completado
-  zho: 命令已完成
+  zho: 命令已完成。
   jpn: コマンドが完了しました。
   rus: Команда выполнена
   por: Comando completado
@@ -817,7 +817,7 @@ Command worker received request to pause current encode:
   spa: El trabajador del comando recibió una solicitud para pausar la codificación
     actual
   zho: 命令执行程序收到了暂停当前编码的请求
-  jpn: コマンドワーカーが現在のエンコードを一時停止するリクエストを受信
+  jpn: コマンドワーカーが現在のエンコードを一時停止するリクエストを受信しました
   rus: Оператор получил запрос на приостановку текущего кодирования
   por: Comando operário recebeu pedido para pausar a codificação de corrente
   swe: Kommandotjänstemannen har mottagit en begäran om att pausa den pågående kodningen.
@@ -836,7 +836,7 @@ Command worker received request to pause encoding after the current item complet
   spa: El trabajador del comando recibió la solicitud de pausar la codificación después
     de que el elemento actual complete
   zho: 命令执行程序收到了在当前项目完成后暂停编码的请求
-  jpn: コマンドワーカーが、現在のアイテムが完了した後にエンコードを一時停止するリクエストを受信した
+  jpn: コマンドワーカーが、現在のアイテムが完了した後にエンコードを一時停止するリクエストを受信しました
   rus: Оператор получил запрос на приостановку кодирования после завершения текущего
     элемента
   por: O trabalhador de comando recebeu um pedido para pausar a codificação após a
@@ -857,7 +857,7 @@ Command worker received request to resume encoding:
   ita: L'operatore di comando ha ricevuto la richiesta di riprendere la codifica
   spa: El comandante recibió la solicitud de reanudar la codificación
   zho: 命令执行程序收到了恢复编码的请求
-  jpn: コマンドワーカーがエンコード再開のリクエストを受信
+  jpn: コマンドワーカーがエンコード再開のリクエストを受信しました
   rus: Оператор получил запрос на возобновление кодирования
   por: O trabalhador de comando recebeu um pedido para retomar a codificação
   swe: Kommandotjänstemannen har mottagit en begäran om att återuppta kodningen.
@@ -874,7 +874,7 @@ Command worker received request to resume paused encode:
   spa: El trabajador del comando recibió la solicitud de reanudar la codificación
     en pausa
   zho: 命令执行程序收到了恢复已暂停编码的请求
-  jpn: コマンドワーカーが一時停止したエンコードの再開要求を受信
+  jpn: コマンドワーカーが一時停止したエンコードの再開要求を受信しました
   rus: Оператор получил запрос на возобновление приостановленного кодирования
   por: O trabalhador de comando recebeu pedido para retomar o codigo pausado
   swe: Kommandotjänstemannen har mottagit en begäran om att återuppta pausad kodning.
@@ -919,7 +919,7 @@ Constant:
   ita: Costante
   spa: Constante
   zho: 恒定
-  jpn: コンスタントに
+  jpn: 一定の
   rus: Постоянная
   por: Constante
   swe: Konstant
@@ -964,7 +964,7 @@ Conversion worker shutting down:
   ita: Operaio di conversione in chiusura
   spa: El cierre del trabajador de conversión
   zho: 正在关闭转换程序
-  jpn: 変換作業者のシャットダウン
+  jpn: コンバージョンワーカーのシャットダウンしている
   rus: Выключение конвертера
   por: Encerramento do trabalhador de conversão
   swe: Konverteringsarbetaren stänger av
@@ -1009,7 +1009,7 @@ Copy Chapters:
   ita: Copiare i capitoli
   spa: Copiar capítulos
   zho: 复制章节
-  jpn: コピーチャプター
+  jpn: チャプターをコピーする
   rus: Копирование глав
   por: Copiar Capítulos
   swe: Kopiera kapitel
@@ -1054,7 +1054,7 @@ Copy Landscape Cover:
   ita: Copiare la copertura del paesaggio
   spa: Copia de la portada del paisaje
   zho: 复制横向封面
-  jpn: コピー・ランドスケープ・カバー
+  jpn: ランドスケープ・カバーをコピーする
   rus: Копия обложки "пейзаж"
   por: Cópia da capa da Paisagem
   swe: Kopiera landskapsomslag
@@ -1069,7 +1069,7 @@ Copy Small Cover (no preview):
   ita: Copia copertina piccola (nessuna anteprima)
   spa: Copia de la portada pequeña (sin vista previa)
   zho: 复制小封面（无预览）
-  jpn: Copy Small Cover（プレビューなし）
+  jpn: Small Coverをコピーする（プレビューなし）
   rus: Копия Малая обложка (без предпросмотра)
   por: Copiar Pequena Capa (sem pré-visualização)
   swe: Kopiera litet omslag (ingen förhandsgranskning)
@@ -1084,7 +1084,7 @@ Copy Small Landscape Cover  (no preview):
   ita: Copia piccola copertura del paesaggio (nessuna anteprima)
   spa: Copia de la cubierta de un pequeño paisaje (sin vista previa)
   zho: 复制横向小封面（无预览）
-  jpn: Copy Small Landscape Cover (no preview)
+  jpn: Small Landscape Coverをコピーする(プレビューなし)
   rus: Копия малой обложки "пейзаж" (без предпросмотра)
   por: Copiar Pequena Capa de Paisagem (sem pré-visualização)
   swe: Kopiera litet landskapsomslag (ingen förhandsgranskning)
@@ -1099,7 +1099,7 @@ Copy all commands to the clipboard:
   ita: Copiare tutti i comandi negli appunti
   spa: Copia todos los comandos al portapapeles
   zho: 将所有命令复制到剪贴板
-  jpn: すべてのコマンドをクリップボードにコピー
+  jpn: すべてのコマンドをクリップボードにコピーする
   rus: Копирование всех команд в буфер обмена
   por: Copiar todos os comandos para a prancheta
   swe: Kopiera alla kommandon till klippbordet
@@ -1175,7 +1175,7 @@ Could not fix first subtitle track:
   fra: Impossible de réparer la première piste de sous-titres
   ita: Impossibile fissare la prima traccia dei sottotitoli
   spa: No se pudo arreglar la primera pista del subtítulo
-  zho: Could not fix first subtitle track
+  zho: 无法固定第1个字幕
   jpn: 1つ目の字幕トラックを固定できなかった
   rus: Не удалось зафиксировать первую дорожку субтитров
   por: Não foi possível fixar a primeira faixa de legendas
@@ -1265,7 +1265,7 @@ Create Profile:
   fra: Créer un profil
   ita: Crea profilo
   spa: Crear el perfil
-  zho: 创建方案
+  zho: 创建配置
   jpn: プロファイルの作成
   rus: Создать профиль
   por: Criar Perfil
@@ -1310,7 +1310,7 @@ Current Profile Settings:
   fra: Paramètres du profil actuel
   ita: Impostazioni del profilo corrente
   spa: Configuración del perfil actual
-  zho: 当前方案设置
+  zho: 当前配置
   jpn: 現在のプロファイル設定
   rus: Текущие настройки профиля
   por: Definições de perfil actuais
@@ -1464,8 +1464,8 @@ Default is an autodetected count based on the number of CPU cores and whether WP
   fra: 'Par défaut : AQ activé avec auto-variance'
   ita: 'Default: AQ abilitato con auto-varianza'
   spa: 'Por defecto: AQ habilitado con auto-varianza'
-  zho: 默认值为enabled + auto-variance
-  jpn: デフォルト。自動分散でAQを有効にする
+  zho: '默认值为enabled + auto-variance'
+  jpn: 'デフォルトは自動分散でAQを有効にする'
   rus: 'По умолчанию: AQ включен с автоматической дисперсией'
   por: 'Por omissão: AQ activado com auto-variância'
   swe: 'Standard: AQ aktiverad med automatisk variation'
@@ -1509,7 +1509,7 @@ Delete Current Profile:
   fra: Supprimer le profil actuel
   ita: Cancellare il profilo corrente
   spa: Borrar el perfil actual
-  zho: 删除当前方案
+  zho: 删除当前p配置
   jpn: 現在のプロフィールの削除
   rus: Удалить текущий профиль
   por: Apagar perfil actual
@@ -1570,7 +1570,7 @@ Determine HDR details:
   ita: Determinare i dettagli HDR
   spa: Determinar los detalles del HDR
   zho: 检测HDR详情
-  jpn: HDRの詳細を決める
+  jpn: HDRの詳細を検出
   rus: Определите детали HDR
   por: Determinar os detalhes do HDR
   swe: Bestämma HDR-detaljer
@@ -1668,8 +1668,8 @@ Download Cancelled:
   fra: Téléchargement annulé
   ita: Scaricamento annullato
   spa: Descarga cancelada
-  zho: 下载取消
-  jpn: ダウンロード 中止
+  zho: 下载已取消
+  jpn: ダウンロードはキャンセルされた
   rus: Скачивание Отменено
   por: Descarregar Cancelado
   swe: Ladda ner Cancelled
@@ -1684,7 +1684,7 @@ Download Newest FFmpeg:
   ita: Scarica il nuovo FFmpeg
   spa: Descargar el nuevo FFmpeg
   zho: 下载最新版FFmpeg
-  jpn: ダウンロード 最新のFFmpeg
+  jpn: 最新のFFmpegをダウンロードする
   rus: Скачать новейший FFmpeg
   por: Descarregar o mais recente FFmpeg
   swe: Hämta Nyaste FFmpeg
@@ -1699,7 +1699,7 @@ Downloading FFmpeg:
   ita: Scaricare FFmpeg
   spa: Descargar FFmpeg
   zho: 正在下载FFmpeg
-  jpn: FFmpegのダウンロード
+  jpn: FFmpegをダウンロード中
   rus: Загрузка FFmpeg
   por: Descarregar FFmpeg
   swe: Hämta FFmpeg
@@ -1714,7 +1714,7 @@ Dual License:
   ita: Doppia Licenza
   spa: Licencia doble
   zho: 双重许可
-  jpn: デュアルライセンス
+  jpn: 二重ライセンス
   rus: Двойная лицензия
   por: Dupla Licença
   swe: Dubbel licens
@@ -1758,7 +1758,7 @@ Enable strong intra smoothing for 32x32 intra blocks.:
   fra: Permettre un lissage intra fort pour les blocs intra 32x32.
   ita: Abilita una forte lisciatura intra per gli intrablocchi 32x32.
   spa: Habilitar un fuerte alisamiento interno para los bloqueos internos de 32x32.
-  zho: Enable strong intra smoothing for 32x32 intra blocks.
+  zho: 对32x32的内部j块启用强烈的内部舒缓（intra smoothing）。
   jpn: 32x32イントラブロックの強力なイントラ・スムージングを有効にする。
   rus: Включите сильное внутреннее сглаживание для внутренних блоков 32x32.
   por: Permitir um forte alisamento intra para 32x32 intra blocos.
@@ -1789,7 +1789,7 @@ Enabled:
   ita: Abilitato
   spa: Habilitado
   zho: 启用
-  jpn: 有効
+  jpn: 有効化
   rus: Включено
   por: Activado
   swe: Aktiverad
@@ -1861,7 +1861,7 @@ Enabling cover thumbnails on your system:
   ita: Abilita le miniature del coperchio del sistema
   spa: Habilitando las miniaturas de la cubierta en su sistema
   zho: 在系统上启用封面缩略图（英文）
-  jpn: お使いのシステムで表紙のサムネイルを有効にする
+  jpn: お使いのシステムでカバーのサムネイルを有効にする
   rus: Включение эскизов обложек в вашей системе
   por: Habilitação de miniaturas de cobertura no seu sistema
   swe: Aktivera miniatyrbilder på ditt system
@@ -1921,7 +1921,7 @@ Encoding Queue:
   ita: Coda di codifica
   spa: Cola de codificación
   zho: 编码队列
-  jpn: 符号化キュー
+  jpn: 変換キュー
   rus: Очередь кодирования
   por: Fila de Codificação
   swe: Kö för kodning
@@ -1950,7 +1950,7 @@ Encoding command:
   fra: Commande d'encodage
   ita: Comando di codifica
   spa: Comando de codificación
-  zho: 编码命令第
+  zho: 编码命令
   jpn: エンコードコマンド
   rus: Команда кодирования
   por: Comando de codificação
@@ -1979,7 +1979,7 @@ Encoding errored:
   eng: Encoding errored
   fra: Encodage erroné
   ita: Codifica errata
-  spa: ''
+  spa: error de codificación
   zho: 编码错误
   jpn: エンコーディングエラー
   rus: Ошибка кодирования
@@ -2010,7 +2010,7 @@ Enforce an encode profile:
   fra: Faire appliquer un profil codé
   ita: Applicare un profilo di codifica
   spa: Hacer cumplir un perfil de codificación
-  zho: 应用一个编码规格
+  zho: 应用一个编码配置
   jpn: エンコードプロファイルの適用
   rus: Применить профиль кодирования
   por: Forçar um perfil de codificação
@@ -2101,7 +2101,7 @@ Exit:
   ita: Uscita
   spa: Salga de
   zho: 退出
-  jpn: 出口
+  jpn: 退出
   rus: Выход
   por: Saída
   swe: Avsluta
@@ -2131,8 +2131,8 @@ Extra flags or options, cannot modify existing settings:
     existants
   ita: I flag o le opzioni extra, non possono modificare le impostazioni esistenti
   spa: Las banderas u opciones adicionales, no pueden modificar los ajustes existentes
-  zho: 额外的标志或选项，无法修改已有设置。
-  jpn: 既存の設定を変更できない、追加のフラグやオプション
+  zho: 有额外的标志或选项，无法修改已有设置。
+  jpn: 追加のフラグやオプションがあるため既存の設定を変更できない
   rus: Дополнительные флаги или опции, не могут изменять существующие настройки
   por: Bandeiras ou opções extra, não podem modificar as configurações existentes
   swe: Extra flaggor eller alternativ, kan inte ändra befintliga inställningar
@@ -2252,7 +2252,7 @@ FFMPEG AV1 Encoding Guide:
   ita: Guida alla codifica FFMPEG AV1
   spa: Guía de codificación del FFMPEG AV1
   zho: FFMPEG AV1编码指南（英文）
-  jpn: FFMPEG AV1エンコードガイド
+  jpn: FFMPEG AV1エンコードガイド（英語）
   rus: Руководство по кодированию FFMPEG AV1
   por: Guia de Codificação FFMPEG AV1
   swe: FFMPEG AV1 Kodningsguide
@@ -2267,7 +2267,7 @@ FFMPEG AVC / H.264 Encoding Guide:
   ita: Guida alla codifica FFMPEG AVC / H.264
   spa: Guía de codificación FFMPEG AVC / H.264
   zho: FFMPEG AVC / H.264 编码指南（英文）
-  jpn: FFMPEG AVC / H.264エンコードガイド
+  jpn: FFMPEG AVC / H.264エンコードガイド（英語）
   rus: Руководство по кодированию FFMPEG AVC / H.264
   por: Guia de Codificação FFMPEG AVC / H.264
   swe: FFMPEG AVC / H.264 Kodningsguide
@@ -2282,7 +2282,7 @@ FFMPEG HEVC / H.265 Encoding Guide:
   ita: Guida alla codifica FFMPEG HEVC / H.265
   spa: Guía de codificación FFMPEG HEVC / H.265
   zho: FFMPEG HEVC / H.265编码指南（英文）
-  jpn: FFMPEG HEVC / H.265 エンコーディングガイド
+  jpn: FFMPEG HEVC / H.265 エンコーディングガイド（英語）
   rus: Руководство по кодированию FFMPEG HEVC / H.265
   por: FFMPEG HEVC / H.265 Guia de Codificação
   swe: FFMPEG HEVC / H.265 Kodningsguide
@@ -2297,7 +2297,7 @@ FFMPEG VP9 Encoding Guide:
   ita: Guida alla codifica FFMPEG VP9
   spa: Guía de codificación del FFMPEG VP9
   zho: FFMPEG VP9编码指南（英文）
-  jpn: FFMPEG VP9エンコーディングガイド
+  jpn: FFMPEG VP9エンコーディングガイド（英語）
   rus: Руководство по кодированию FFMPEG VP9
   por: Guia de Codificação FFMPEG VP9
   swe: Guide för FFMPEG VP9-kodning
@@ -2311,8 +2311,8 @@ FFmpeg updated - Please restart FastFlix:
   fra: FFmpeg mis à jour - Veuillez redémarrer FastFlix
   ita: FFmpeg aggiornato - Si prega di riavviare FastFlix
   spa: FFmpeg actualizado - Por favor, reinicie FastFlix
-  zho: FFmpeg更新--请重新启动FastFlix。
-  jpn: FFmpegのアップデート - FastFlixを再起動してください。
+  zho: FFmpeg更新完成。请重新启动FastFlix。
+  jpn: FFmpegのアップデートしました。FastFlixを再起動してください。
   rus: FFmpeg обновлен - пожалуйста, перезапустите FastFlix
   por: FFmpeg actualizado - Por favor reinicie FastFlix
   swe: FFmpeg uppdaterad - starta om FastFlix
@@ -2342,7 +2342,7 @@ Fast first pass:
   ita: Primo passaggio veloce
   spa: Primera pasada rápida
   zho: 快速第一遍编码
-  jpn: 高速ファーストパス
+  jpn: 高速1回目
   rus: Быстрый первый проход
   por: Primeira passagem rápida
   swe: Snabb första passage
@@ -2419,7 +2419,7 @@ Force HDR10 signaling:
   ita: Forza segnalazione HDR10
   spa: Señalización de la fuerza HDR10
   zho: 强制发送HDR10信号
-  jpn: フォースHDR10シグナリング
+  jpn: HDR10シグナリングを強制
   rus: Принудительная передача сигнала HDR10
   por: Forçar a sinalização HDR10
   swe: Forcera HDR10-signalering
@@ -2449,7 +2449,7 @@ Frames Per Second:
   ita: Cornici al secondo
   spa: Cuadros por segundo
   zho: 每秒帧数
-  jpn: フレーム・パー・セカンド
+  jpn: 1秒ごとのフレーム数
   rus: Кадров в секунду
   por: Molduras por segundo
   swe: Bildrutor per sekund
@@ -2479,7 +2479,7 @@ GUI Logging Level:
   ita: Livello di registrazione GUI
   spa: Nivel de registro GUI
   zho: GUI日志级别
-  jpn: GUIロギングレベル
+  jpn: GUIログレベル
   rus: Уровень ведения журнала графического интерфейса
   por: Nível de registo GUI
   swe: GUI-loggningsnivå
@@ -2494,7 +2494,7 @@ Gather FFmpeg audio encoders:
   ita: Raccogliere gli encoder audio FFmpeg
   spa: Reúne los codificadores de audio FFmpeg
   zho: 获取FFmpeg音频编码器
-  jpn: FFmpegオーディオエンコーダの収集
+  jpn: FFmpegオーディオエンコーダの取得
   rus: Соберите аудиокодеры FFmpeg
   por: Reunir codificadores de áudio FFmpeg
   swe: Samla FFmpeg-ljudkodare
@@ -2509,7 +2509,7 @@ Gather FFmpeg version:
   ita: Raccogliere la versione FFmpeg
   spa: Reunir la versión FFmpeg
   zho: 获取FFmpeg版本
-  jpn: FFmpegのバージョンを集める
+  jpn: FFmpegのバージョンを取得
   rus: Соберите версию FFmpeg
   por: Reúna a versão FFmpeg
   swe: Samla ihop FFmpeg-versionen
@@ -2524,7 +2524,7 @@ Gather FFprobe version:
   ita: Raccogliere la versione FFprobe
   spa: Reunir la versión FFprobe
   zho: 获取FFprobe版本
-  jpn: FFprobeのバージョンを集める
+  jpn: FFprobeのバージョンを集取得
   rus: Соберите версию FFprobe
   por: Reúna a versão FFprobe
   swe: Samla in FFprobe-versionen
@@ -2554,7 +2554,7 @@ Google's VP9 HDR Encoding Guide:
   ita: Guida alla codifica HDR VP9 di Google
   spa: Guía de codificación HDR VP9 de Google
   zho: 谷歌VP9 HDR编码指南（英文）
-  jpn: GoogleのVP9 HDRエンコーディングガイド
+  jpn: GoogleのVP9 HDRエンコーディングガイド（英語）
   rus: Руководство по кодированию VP9 HDR от Google
   por: Guia de Codificação HDR VP9 do Google
   swe: Googles VP9 HDR-kodningsguide för VP9
@@ -2689,7 +2689,7 @@ Hide NAL unit messages:
   ita: Nascondere i messaggi delle unità NAL (AVC/HEVC Network Abstraction Layer)
   spa: Ocultar los mensajes de la unidad NAL (AVC/HEVC Network Abstraction Layer)
   zho: 隐藏NAL unit（AVC/HEVC网络抽象层）消息
-  jpn: NALユニットのメッセージを隠す
+  jpn: NALユニットのメッセージを非表示にする
   rus: Скрыть сообщения устройства NAL
   por: Ocultar mensagens da unidade NAL
   swe: Dölja meddelanden från NAL-enheter
@@ -2719,7 +2719,7 @@ Init Q:
   ita: Init Q
   spa: Init Q
   zho: 启动Q
-  jpn: Init Q
+  jpn: 初期化Q
   rus: Init Q
   por: Init Q
   swe: Init Q
@@ -2828,7 +2828,7 @@ It saves a few bits and can help performance in the client's tonemapper.:
   spa: Ahorra unos pocos bits y puede ayudar al rendimiento en el mapa de tonos del
     cliente.
   zho: 能够节省一些数据量，并有益于播放端色调映射的性能。
-  jpn: これにより数ビットが節約され、クライアントのトーンマッパーのパフォーマンスが向上します。
+  jpn: これによりビットが少し節約され、クライアントのトーンマッパーのパフォーマンスが向上します。
   rus: Это экономит несколько битов и может повысить производительность клиентского
     тонального маппера.
   por: Poupa alguns bocados e pode ajudar o desempenho no tonemapper do cliente.
@@ -2966,8 +2966,8 @@ Log2 of number of tile columns to encode faster (lesser quality):
   ita: Log2 del numero di colonne di tegole da codificare più velocemente (qualità
     inferiore)
   spa: Log2 del número de columnas de azulejos para codificar más rápido (menor calidad)
-  zho: Log2 of number of tile columns to encode faster (lesser quality)
-  jpn: タイルの列数のLog2で、より高速に（より低品質に）エンコードする。
+  zho: 块的列数的Log2来快速编码（画质降低）
+  jpn: タイルの列数のLog2で、より高速にエンコードする（画質は落ちる）。
   rus: Log2 количества столбцов плитки для более быстрого кодирования (меньшее качество)
   por: Log2 de número de colunas de ladrilhos para codificar mais rapidamente (menor
     qualidade)
@@ -2983,8 +2983,8 @@ Log2 of number of tile rows to encode faster (lesser quality):
   fra: Log2 du nombre de rangées de tuiles pour un encodage plus rapide (qualité moindre)
   ita: Log2 del numero di file di tegole da codificare più velocemente (qualità inferiore)
   spa: Log2 del número de filas de azulejos para codificar más rápido (menor calidad)
-  zho: Log2 of number of tile rows to encode faster (lesser quality)
-  jpn: タイル列数のLog2で、より高速に（より低品質に）エンコードする。
+  zho: 块的行数的Log2来快速编码（画质降低）
+  jpn: タイル列数のLog2で、より高速にエンコードする（画質は落ちる）。
   rus: Log2 числа рядов плиток для более быстрого кодирования (меньшее качество)
   por: Log2 do número de filas de azulejos a codificar mais rapidamente (menor qualidade)
   swe: Log2 av antalet kakelrader för att koda snabbare (sämre kvalitet).
@@ -2999,8 +2999,8 @@ Lookahead:
   fra: Lookahead
   ita: Lookahead
   spa: Lookahead
-  zho: 瞻前顾后
-  jpn: ルックアヘッド
+  zho: 看前面
+  jpn: 前のフレームを参照
   rus: Опережение
   por: Lookahead
   swe: Förhandsgranskning
@@ -3035,7 +3035,7 @@ Lossless encodes implicitly have no rate control, all rate control options are i
   spa: Los códigos sin pérdidas implícitamente no tienen control de la tasa, todas
     las opciones de control de la tasa son ignoradas.
   zho: 无损编码意味着没有码率控制，会忽略所有码率控制选项。
-  jpn: ロスレスエンコードでは、暗黙のうちにレートコントロールが行われず、すべてのレートコントロールオプションは無視されます。
+  jpn: ロスレスエンコードでは、レートコントロールが行われず、すべてのレートコントロールオプションは無視されます。
   rus: Кодирование без потерь неявно не имеет контроля скорости, все опции контроля
     скорости игнорируются.
   por: Os códigos sem perdas não têm implicitamente qualquer controlo de taxa, todas
@@ -3070,8 +3070,8 @@ Max Q:
   fra: Max Q
   ita: Q massimo
   spa: Max Q
-  zho: 最大Q值
-  jpn: マックスQ
+  zho: Q的最大值
+  jpn: Qの最大値
   rus: Макс Q
   por: Máximo Q
   swe: Max Q
@@ -3130,7 +3130,7 @@ Metrics:
   fra: Métriques
   ita: Metriche
   spa: Métricas
-  zho: 衡量标准
+  zho: 统计数据
   jpn: メトリクス
   rus: Метрики
   por: Métricas
@@ -3145,8 +3145,8 @@ Min Q:
   fra: Min Q
   ita: Min Q
   spa: Q mínimo
-  zho: 最小Q
-  jpn: Min Q
+  zho: Q最小值
+  jpn: Qの最小値
   rus: Мин Q
   por: Min Q
   swe: Min Q
@@ -3175,8 +3175,8 @@ Multipass:
   fra: Multipass
   ita: Multipass
   spa: Multipass
-  zho: 多通道
-  jpn: マルチパス
+  zho: 多次
+  jpn: 数回
   rus: Многопроходная
   por: Multipass
   swe: Multipass
@@ -3220,8 +3220,8 @@ New Profile:
   fra: Nouveau profil
   ita: Nuovo profilo
   spa: Nuevo perfil
-  zho: 新建方案
-  jpn: 新着情報
+  zho: 新建配置
+  jpn: プロフィールの新規作成
   rus: Новый профиль
   por: Novo perfil
   swe: Ny profil
@@ -3438,7 +3438,7 @@ Not a valid int for time conversion:
   ita: Non è un int valido per la conversione del tempo
   spa: No es un int válido para la conversión de tiempo
   zho: 不是可用于时间转换的有效整数
-  jpn: 時間変換に有効なintではない
+  jpn: 時間変換に有効な整数値ではない
   rus: Недопустимое значением int для преобразования времени
   por: Não é uma int válida para conversão de tempo
   swe: Inte ett giltigt int för tidskonvertering
@@ -3522,7 +3522,7 @@ Open Directory:
   ita: Elenco aperto
   spa: Directorio Abierto
   zho: 打开目录
-  jpn: オープンディレクトリ
+  jpn: ディレクトリを開く
   rus: Открыть каталог
   por: Directório Aberto
   swe: Öppen katalog
@@ -3537,7 +3537,7 @@ Open Log Directory:
   ita: Aprire l'elenco dei log
   spa: Directorio abierto de registros
   zho: 打开日志目录
-  jpn: オープン・ログ・ディレクトリ
+  jpn: ログのディレクトリを開く
   rus: Открыть каталог журналов
   por: Directório de Registo Aberto
   swe: Öppna loggkatalogen
@@ -3613,7 +3613,7 @@ Override Source FPS:
   ita: Annullare la sorgente FPS
   spa: Anular el FPS de la fuente
   zho: 覆盖源文件帧率
-  jpn: オーバーライド ソースFPS
+  jpn: ソースFPSをオーバーライド
   rus: Переопределение исходного FPS
   por: Substituir Fonte FPS
   swe: åsidosätta källan FPS
@@ -3697,7 +3697,7 @@ Pause Encode:
   ita: Pausa Codificare
   spa: Codificar la pausa
   zho: 暂停编码
-  jpn: ポーズ エンコード
+  jpn: エンコードを一時停止する
   rus: Приостановить кодирование
   por: Codificação de Pausa
   swe: Pausa Kodning
@@ -3712,7 +3712,7 @@ Pause Queue:
   ita: Coda di pausa
   spa: Pausa de la cola
   zho: 暂停队列
-  jpn: キューの一時停止
+  jpn: キューを一時停止する
   rus: Приостановить очередь
   por: Fila de Pausa
   swe: Pausa kö
@@ -3756,7 +3756,7 @@ Please provide a profile name:
   fra: Veuillez fournir un nom de profil
   ita: Si prega di fornire un nome di profilo
   spa: Por favor, proporcione un nombre de perfil
-  zho: 请提供方案名称
+  zho: 请提供配置名称
   jpn: プロフィール名を入力してください
   rus: Пожалуйста, укажите имя профиля
   por: Por favor forneça um nome de perfil
@@ -3817,7 +3817,7 @@ Preserve:
   ita: Conservare
   spa: Preservar
   zho: 保留
-  jpn: Preserve
+  jpn: 保留
   rus: Сохранить
   por: Conservar
   swe: Bevara
@@ -3846,7 +3846,7 @@ Profile Name:
   fra: Nom du profil
   ita: Nome del profilo
   spa: Nombre del perfil
-  zho: 方案名称
+  zho: 配置名称
   jpn: プロフィール名
   rus: Имя профиля
   por: Nome do perfil
@@ -3906,7 +3906,7 @@ Profiles:
   fra: Profils
   ita: Profili
   spa: Perfiles
-  zho: 方案
+  zho: 配置
   jpn: プロフィール
   rus: Профили
   por: Perfis
@@ -3922,7 +3922,7 @@ Python:
   ita: Python
   spa: Python
   zho: Python
-  jpn: パイソン
+  jpn: Python
   rus: Python
   por: Python
   swe: Python
@@ -4058,7 +4058,7 @@ RC Lookahead:
   ita: RC Lookahead
   spa: RC Lookahead
   zho: RC Lookahead
-  jpn: RCルックアヘッド
+  jpn: RC Lookahead
   rus: RC Опережение
   por: RC Lookahead
   swe: RC Lookahead
@@ -4098,8 +4098,8 @@ Rate Control:
   fra: Contrôle des tarifs
   ita: Controllo della velocità
   spa: Control de velocidad
-  zho: 速率控制
-  jpn: レートコントロール
+  zho: 速度控制
+  jpn: レート制御
   rus: Контроль скорости
   por: Controlo da taxa
   swe: Kontroll av hastighet
@@ -4163,8 +4163,8 @@ Ref Frames:
   fra: Ref Frames
   ita: Fotogrammi di rif.
   spa: Fotogramas de referencia
-  zho: 参考框架
-  jpn: レフフレーム
+  zho: 参考帧
+  jpn: リファレンスフレーム
   rus: Реф-кадры
   por: Molduras de Reformas
   swe: Referensramar
@@ -4239,7 +4239,7 @@ Repeat Headers:
   ita: Ripetere le intestazioni
   spa: Repetición de los encabezados
   zho: 重复标头
-  jpn: リピートヘッダー
+  jpn: ヘッダー重複
   rus: Повторяющиеся заголовки
   por: Cabeçalhos de repetição
   swe: Upprepa rubriker
@@ -4254,7 +4254,7 @@ Report Issue:
   ita: Segnala il problema
   spa: Informe
   zho: 报告问题
-  jpn: レポート課題
+  jpn: 問題を報告
   rus: Выпуск отчета
   por: Edição do relatório
   swe: Rapportera frågan
@@ -4269,7 +4269,7 @@ Resume Encode:
   ita: Riprendi Codifica
   spa: Reanudar la codificación
   zho: 恢复编码
-  jpn: レジュームエンコード
+  jpn: エンコード再開
   rus: Возобновить кодирование
   por: Código de currículo
   swe: Återuppta kodning
@@ -4298,8 +4298,8 @@ Reusables:
   fra: Réutilisables
   ita: Riutilizzabili
   spa: Reutilizables
-  zho: Reusables
-  jpn: リユース品
+  zho: 重复利用品
+  jpn: 再利用品
   rus: Многоразовые материалы
   por: Reutilizáveis
   swe: Återanvändbara varor
@@ -4328,8 +4328,8 @@ Row Multi-Threading:
   fra: Rangée Multi-Threading
   ita: Filettatura multi-filettatura
   spa: Fila Multi-Hilo
-  zho: 行多线程
-  jpn: 列のマルチスレッド化
+  zho: 行的多线程
+  jpn: 行のマルチスレッド化
   rus: Многопоточность строк
   por: Linha Multi-Tarefa
   swe: Flertrådig rad
@@ -4343,7 +4343,7 @@ Row multithreading:
   fra: Rangée de fils multiples
   ita: Fila multifilettatura
   spa: Fila multihilo
-  zho: 行多线程
+  zho: 行的多线程
   jpn: 行のマルチスレッド化
   rus: Многопоточность рядов
   por: Multithreading de filas
@@ -4358,8 +4358,8 @@ Row multithreading:
   fra: 'Courir après le commandement fait :'
   ita: 'Esecuzione dopo aver eseguito il comando:'
   spa: 'Corriendo tras el mando hecho:'
-  zho: 在完成命令后运行。
-  jpn: doneコマンドの後に実行。
+  zho: '在完成命令后运行。'
+  jpn: 'コマンド完了後に実行。'
   rus: 'Запуск после выполнения команды:'
   por: 'Correr atrás de comando feito:'
   swe: 'Körs efter kommandot done:'
@@ -4545,7 +4545,7 @@ Set speed to 4 for first pass:
   ita: Imposta la velocità a 4 per il primo passaggio
   spa: Establece la velocidad en 4 para la primera pasada
   zho: 第一遍速度设置为4
-  jpn: 1パス目のスピードを4に設定
+  jpn: 1回目のスピードを4に設定
   rus: Установить скорость на 4 для первого прохода
   por: Definir velocidade para 4 na primeira passagem
   swe: Ställ in hastigheten på 4 för första passet.
@@ -4620,8 +4620,8 @@ Set the level of effort in determining B frame placement.:
   fra: 'Régler après avoir fait la commande à :'
   ita: 'Impostare dopo il comando su:'
   spa: 'Estableciendo después de hacer el comando para:'
-  zho: 设置完成后命令为。
-  jpn: コマンドを実行した後の設定
+  zho: '设置完成后命令为。'
+  jpn: 'コマンドを実行した後の設定'
   rus: 'Установка после выполненной команды на:'
   por: 'Definição após comando feito para:'
   swe: 'Ställ in kommandot efter utfört kommando till:'
@@ -4651,7 +4651,7 @@ Single Pass (Bitrate):
   ita: Passaggio singolo (Bitrato)
   spa: Pase único (Bitrate)
   zho: 一遍编码（比特率）
-  jpn: シングルパス（ビットレート）
+  jpn: 1回のみ（ビットレート）
   rus: Однократный проход (битрейт)
   por: Passe único (Bitrate)
   swe: Enkelpass (Bitrate)
@@ -4666,7 +4666,7 @@ Single Pass (CRF):
   ita: Passaggio singolo (CRF)
   spa: Pase único (CRF)
   zho: 一遍编码（CRF）
-  jpn: シングルパス（CRF）
+  jpn: 1回のみ（CRF）
   rus: Однократный проход (CRF)
   por: Passe Único (CRF)
   swe: Enkel passage (CRF)
@@ -4689,29 +4689,21 @@ Size Estimate:
   ukr: Оцінка розміру
   kor: 크기 견적
   ron: Dimensiune estimată
-Slow is highest personal recommenced, as past that is much smaller gains:
-  deu: Slow ist die maximale persönliche Empfehlung, da die Zugewinne bei noch langsamerem
-    deutlich kleiner sind.
-  eng: Slow is highest personal recommenced, as past that is much smaller gains
-  fra: La lenteur est la plus haute personnelle recommencée, comme passé c'est des
-    gains beaucoup plus petits
-  ita: Lento è più alto personale è ricominciato, come passato che è molto più piccolo
-    guadagni
-  spa: La lentitud es la mayor recomenzada personal, ya que el pasado que es mucho
-    más pequeño gana
-  zho: 不建议使用比slow更慢的档位，因为获得的收益会小得多。
-  jpn: スローは個人的には最高の再開で、過去にはもっと小さな利益がありました。
-  rus: Медленный - это наивысший личный показатель, так как ранее это гораздо меньший
-    прирост
-  por: Lento é o reinício pessoal mais elevado, pois o passado é um ganho muito menor
-  swe: Långsamt är högsta personliga återupptagen, som tidigare är mycket mindre vinster
-  pol: Slow jest najwyższym osobistym wznowieniem, jak minęło to jest znacznie mniejsze
-    zyski.
-  ukr: Повільний - це найвищий особистий приріст, оскільки в минулому це набагато
-    менший приріст
-  kor: 느리게 시작하는 것이 개인적으로 가장 높은 권장 사항이며, 그 이전에는 훨씬 적은 이득을 얻습니다.
-  ron: Încet este cel mai înalt personal a reînceput, ca și trecut care este mult
-    mai mici câștiguri
+'"Slow" is the slowest personally recommended, presets slower this result in much smaller gains':
+  deu: '"Slow" ist die langsamste persönlich empfohlene Einstellung, langsamere Voreinstellungen führen zu viel geringeren Verstärkungen'
+  eng: '"Slow" is the slowest personally recommended, presets slower this result in much smaller gains'
+  fra: '"Slow" est le plus lent personnellement recommandé, les préréglages plus lents entraînent des gains beaucoup plus faibles'
+  ita: '"Slow" è il più lento consigliato personalmente, i preset più lenti si traducono in guadagni molto minori'
+  spa: '"Slow" es el más lento recomendado personalmente, los ajustes preestablecidos más lentos dan como resultado ganancias mucho menores'
+  zho: '个人建议使用slow。比这更慢的设定获得的好处会小得多。'
+  jpn: '個人的にはslowのプリセット設定はおすすめです。それよりも遅いプリセットを使うとメリットが多くないです。'
+  rus: '«Медленный» — самый медленный, рекомендуемый лично, предустановки медленнее, это приводит к гораздо меньшему приросту'
+  por: '"Slow" é o mais lento pessoalmente recomendado, predefinições mais lentas resultam em ganhos muito menores'
+  swe: '"Slow" är den långsammaste personligen rekommenderade, förinställningar långsammare detta resulterar i mycket mindre vinster'
+  pol: '„Slow” jest najwolniejszym osobiście zalecanym ustawieniem, wolniejsze ustawienia wstępne skutkują znacznie mniejszymi wzmocnieniami'
+  ukr: '"Повільний" є найповільнішим, рекомендованим особисто, попередні налаштування повільніше це призводить до набагато менших приростів'
+  kor: '"Slow"는 개인적으로 권장되는 가장 느린 속도이며 사전 설정을 느리게 하면 게인이 훨씬 작아집니다.'
+  ron: '„Slow” este cel mai lent recomandat personal, presetări mai lente, ceea ce duce la câștiguri mult mai mici'
 Slower presets will generally achieve better compression efficiency (and generate smaller bitstreams).:
   deu: Langsamere Voreinstellungen erzielen im Allgemeinen eine bessere Komprimierungseffizienz
     (und erzeugen kleinere Bitströme).
@@ -4880,7 +4872,7 @@ Strength:
   ita: Forza
   spa: Fuerza
   zho: 强度
-  jpn: 強度
+  jpn: 強さ
   rus: Сила
   por: Força
   swe: Styrka
@@ -4955,7 +4947,7 @@ Support FastFlix:
   ita: Supporto FastFlix
   spa: Soporta FastFlix
   zho: 支持FastFlix
-  jpn: FastFlixのサポート
+  jpn: 'FastFlixを応援/寄付'
   rus: Поддержка FastFlix
   por: Apoio FastFlix
   swe: Stöd för FastFlix
@@ -5010,30 +5002,30 @@ The more complex the block, the more quantization is used.:
   kor: 블록이 복잡할수록 더 많은 양자화가 사용됩니다.
   ron: Cu cât blocul este mai complex, cu atât se utilizează mai multă cuantificare.
 The purpose is to prevent blocking or banding artifacts in regions with few/zero AC coefficients.:
-  deu: Der Zweck ist, Blocking- oder Banding-Artefakte in Regionen mit wenigen/keinen
-    AC-Koeffizienten zu verhindern.
-  eng: The purpose is to prevent blocking or banding artifacts in regions with few/zero
-    AC coefficients.
-  fra: L'objectif est d'éviter de bloquer ou de banderoler des artefacts dans des
-    régions où les coefficients AC sont faibles ou nuls.
-  ita: Lo scopo è quello di prevenire il blocco o il banding di artefatti in regioni
-    con pochi/zeri coefficienti AC.
-  spa: El propósito es prevenir el bloqueo o los artefactos de bandas en regiones
-    con coeficientes de CA bajos/cero.
-  zho: 目的是为了防止在AC coefficients较少或为零的区域出现blocking或banding artifacts。
-  jpn: これは、AC係数が少ない/ゼロの領域でのブロッキングやバンディングのアーチファクトを防ぐためです。
-  rus: Цель - предотвратить блокирование или артефакты полосатости в областях с небольшим
-    количеством/нулевыми коэффициентами переменного тока.
-  por: O objectivo é evitar o bloqueio ou a colocação de artefactos de faixas em regiões
-    com poucos/zero coeficientes AC.
-  swe: Syftet är att förhindra blockering eller bandning i områden med få/noll AC-koefficienter.
+  deu: "Der Zweck ist, Blocking- oder Banding-Artefakte in Regionen mit wenigen/keinen
+    AC-Koeffizienten zu verhindern."
+  eng: "The purpose is to prevent blocking or banding artifacts in regions with few/zero
+    AC coefficients."
+  fra: "L'objectif est d'éviter de bloquer ou de banderoler des artefacts dans des
+    régions où les coefficients AC sont faibles ou nuls."
+  ita: "Lo scopo è quello di prevenire il blocco o il banding di artefatti in regioni
+    con pochi/zeri coefficienti AC."
+  spa: "El propósito es prevenir el bloqueo o los artefactos de bandas en regiones
+    con coeficientes de CA bajos/cero."
+  zho: '目的是为了防止在AC coefficients较少或为零的区域出现blocking或banding artifacts。'
+  jpn: 'これは、AC係数が少ない/ゼロの領域でのブロッキングやバンディングのアーチファクトを防ぐためです。'
+  rus: "Цель - предотвратить блокирование или артефакты полосатости в областях с небольшим
+    количеством/нулевыми коэффициентами переменного тока."
+  por: "O objectivo é evitar o bloqueio ou a colocação de artefactos de faixas em regiões
+    com poucos/zero coeficientes AC."
+  swe: "Syftet är att förhindra blockering eller bandning i områden med få/noll AC-koefficienter."
   pol: Ma to na celu zapobieganie powstawaniu artefaktów blokowania lub pasmowania
     w regionach o małej lub zerowej liczbie współczynników AC.
-  ukr: Мета - запобігти артефактам блокування або смуги в регіонах з низькими/нульовими
-    коефіцієнтами змінного струму.
+  ukr: "Мета - запобігти артефактам блокування або смуги в регіонах з низькими/нульовими
+    коефіцієнтами змінного струму."
   kor: 그 목적은 AC 계수가 거의 없거나 0인 영역에서 차단 또는 밴딩 아티팩트를 방지하는 것입니다.
-  ron: Scopul este de a preveni apariția unor artefacte de blocare sau de bandaj în
-    regiunile cu coeficienți AC puțini/zero.
+  ron: "Scopul este de a preveni apariția unor artefacte de blocare sau de bandaj în
+    regiunile cu coeficienți AC puțini/zero."
 There is a conversion in process!:
   deu: Es ist eine Konvertierung am laufen!
   eng: There is a conversion in process!
@@ -5056,7 +5048,7 @@ There is a newer version of FastFlix available!:
   ita: C'è una versione più recente di FastFlix disponibile!
   spa: ¡Hay una nueva versión de FastFlix disponible!
   zho: FastFlix有更新可用
-  jpn: 新しいバージョンのFastFlixが登場しました。
+  jpn: 新しいバージョンのFastFlixがあります。
   rus: Доступна более новая версия FastFlix!
   por: Há uma versão mais recente de FastFlix disponível!
   swe: Det finns en nyare version av FastFlix!
@@ -5067,7 +5059,7 @@ There is a newer version of FastFlix available!:
 There was an error during conversion and the queue has stopped:
   deu: Es gab einen Fehler während der Konvertierung und die Warteschlange wurde angehalten
   eng: There was an error during conversion and the queue has stopped
-  fra: Il y a eu une erreur lors de la conversion et la file d'attente s'est arrêtée
+  fra: "Il y a eu une erreur lors de la conversion et la file d'attente s'est arrêtée"
   ita: C'è stato un errore durante la conversione e la coda si è fermata
   spa: Hubo un error durante la conversión y la cola se ha detenido
   zho: 转换过程中出现错误，队列已经停止
@@ -5175,9 +5167,9 @@ This is used for ultra-high bitrates with zero loss of quality.:
   ukr: Використовується для надвисоких бітрейтів з нульовою втратою якості.
   kor: 품질 손실 없이 초고속 비트레이트에 사용됩니다.
   ron: Acesta este utilizat pentru viteze de biți foarte mari, fără pierderi de calitate.
-'This option is not recommenced unless you need to conform ':
+'This option is not recommended unless you need to conform ':
   deu: 'Diese Option wird nicht empfohlen, es sei denn, Sie müssen konform sein '
-  eng: 'This option is not recommenced unless you need to conform '
+  eng: 'This option is not recommended unless you need to conform '
   fra: "Cette option n'est pas renouvelée, sauf si vous devez vous conformer "
   ita: 'Questa opzione non viene riavviata a meno che non sia necessario conformarsi '
   spa: 'Esta opción no se reinicia a menos que se necesite conformar '
@@ -6424,7 +6416,7 @@ is a default profile and will not be removed:
   fra: est un profil par défaut et ne sera pas supprimé
   ita: è un profilo predefinito e non verrà rimosso
   spa: es un perfil predeterminado y no se eliminará
-  zho: 是默认方案，不会被删除。
+  zho: 是默认配置，不会被删除。
   jpn: はデフォルトのプロファイルであり、削除されることはありません。
   rus: является профилем по умолчанию и не будет удален
   por: é um perfil padrão e não será removido
@@ -7045,7 +7037,7 @@ There is already a video being processed:
   ita: C'è già un video in elaborazione
   spa: Ya hay un vídeo en proceso
   zho: 已经有一个视频正在处理中
-  jpn: すでに処理中の映像がある
+  jpn: すでに処理中の動画がある
   rus: Видео уже обрабатывается
   por: Já há um vídeo a ser processado
   swe: Det finns redan en video som håller på att bearbetas
@@ -7060,7 +7052,7 @@ Are you sure you want to discard it?:
   ita: Sei sicuro di volerlo scartare?
   spa: ¿Estás seguro de que quieres descartarlo?
   zho: 您确定要丢弃它吗？
-  jpn: 本当に捨てていいのか？
+  jpn: 本当に破棄してもいいですか？
   rus: Вы уверены, что хотите отказаться от него?
   por: Tem a certeza de que quer descartá-la?
   swe: Är du säker på att du vill kasta den?
@@ -7075,7 +7067,7 @@ Discard current video:
   ita: Scartare il video corrente
   spa: Descartar el vídeo actual
   zho: 丢弃当前视频
-  jpn: 現在の映像を捨てる
+  jpn: 現在の動画を破棄する
   rus: Удалить текущее видео
   por: Descarte vídeo actual
   swe: Kassera aktuell video
@@ -7209,7 +7201,7 @@ Profile:
   fra: profil
   ita: profilo
   spa: perfil
-  zho: 方案
+  zho: 配置
   jpn: プロフィール
   rus: Профиль
   por: Perfil
@@ -7715,8 +7707,8 @@ Passthrough All:
   fra: Passthrough Tous
   ita: Passthrough Tutti
   spa: Transferencia Todos
-  zho: 穿透式所有
-  jpn: パススルー 全て
+  zho: 所有不更改
+  jpn: 全てパススルー
   rus: Пропускная способность Все
   por: Passagem de tudo
   swe: Genomströmning Alla
@@ -7776,7 +7768,7 @@ Select By:
   ita: Seleziona per
   spa: Seleccionar por
   zho: 选择方式
-  jpn: セレクト・バイ
+  jpn: で選ぶ
   rus: Выбрать по
   por: Selecione por
   swe: Välj efter
@@ -7791,7 +7783,7 @@ Advanced Options:
   ita: Opzioni avanzate
   spa: Opciones avanzadas
   zho: 高级选项
-  jpn: 詳細オプション
+  jpn: 高度な設定
   rus: Дополнительные параметры
   por: Opções avançadas
   swe: Avancerade alternativ
@@ -7970,7 +7962,7 @@ Verifier:
   ita: Verificatore
   spa: Verificador
   zho: 验证人
-  jpn: ベリファイア
+  jpn: 確認者
   rus: Верификатор
   por: Verificador
   swe: Kontrollör
@@ -8015,7 +8007,7 @@ Determine OpenCL Support:
   ita: Determinare il supporto OpenCL
   spa: Determinar la compatibilidad con OpenCL
   zho: 确定OpenCL支持
-  jpn: OpenCLのサポートを決定
+  jpn: OpenCLのサポートを検出
   rus: Определить поддержку OpenCL
   por: Determinar o suporte do OpenCL
   swe: Fastställa stöd för OpenCL
@@ -8030,7 +8022,7 @@ Please load in a video to configure a new profile:
   ita: Si prega di caricare un video per configurare un nuovo profilo
   spa: Por favor, cargue un vídeo para configurar un nuevo perfil
   zho: 请加载一个视频来配置一个新的配置文件
-  jpn: 新しいプロファイルを設定するためのビデオを読み込んでください。
+  jpn: 新しいプロファイルを設定するための動画をロードしてください。
   rus: Пожалуйста, загрузите видео для настройке нового профиля
   por: Por favor, carregue em um vídeo para configurar um novo perfil
   swe: Ladda in en video för att konfigurera en ny profil
@@ -8084,7 +8076,7 @@ Not supported by rigaya's hardware encoders:
   ita: Non supportato dagli encoder hardware di rigaya
   spa: No es compatible con los codificadores de hardware de Rigaya
   zho: 不被Rigaya的硬件编码器所支持
-  jpn: リガヤのハードウェアエンコーダには対応していません。
+  jpn: Rigayaのハードウェアエンコーダには対応していません。
   rus: Не поддерживается аппаратными кодерами rigaya
   por: Não suportado pelos codificadores de hardware da rigaya
   swe: Stöds inte av Rigayas hårdvarukodare
@@ -8129,7 +8121,7 @@ Require Software Encoding:
   ita: Richiedere la codifica del software
   spa: Requiere codificación de software
   zho: 要求软件编码
-  jpn: ソフトウェアエンコードを要求する
+  jpn: ソフトウェアエンコードは必要
   rus: Требуется программное кодирование
   por: Exigir codificação de software
   swe: Kräver kodning av programvara
@@ -8160,7 +8152,7 @@ Hint that encoding should happen in real-time if not faster:
   spa: Indicación de que la codificación debe realizarse en tiempo real, si no más
     rápido
   zho: 提示编码应该实时发生，如果不是更快的话
-  jpn: エンコードをリアルタイムで行うことを推奨します。
+  jpn: ヒント：エンコードはリアルタイムで実行すべきです。（それよりも速くなければ）
   rus: Подсказка, что кодирование должно происходить в режиме реального времени, если
     не быстрее
   por: Dica de que a codificação deve acontecer em tempo real, se não mais rápido
@@ -10311,8 +10303,8 @@ Single Pass:
   fra: Passe unique
   ita: Passaggio singolo
   spa: Pase único
-  zho: 单次通过
-  jpn: シングルパス
+  zho: 1次
+  jpn: 1回のみ
   rus: Одиночный проход
   por: Passe único
   swe: Enkelt pass
@@ -10326,8 +10318,8 @@ Single Pass Encoding:
   fra: Encodage à passage unique
   ita: Codifica a passaggio singolo
   spa: Codificación de una sola pasada
-  zho: 单程编码
-  jpn: シングルパスエンコード
+  zho: 1次编码
+  jpn: 1回のみのエンコード
   rus: Однопроходное кодирование
   por: Codificação de passagem única
   swe: Kodning i ett enda steg

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -9,7 +9,7 @@
     ancora maggiore sulla qualità.
   spa: 4 o 5 desactivarán la optimización de la tasa de distorsión, lo que tendrá
     un impacto aún mayor en la calidad.
-  zho: 4或5会关闭rate distortion optimization，对质量的影响会更大。
+  chs: 4或5会关闭rate distortion optimization，对质量的影响会更大。
   jpn: 4または5を選択すると、レート歪みの最適化がオフになり、画質への影響がさらに大きくなります。
   rus: 4 или 5 отключает оптимизацию искажений скорости, что еще больше влияет на
     качество.
@@ -30,7 +30,7 @@ AQ Strength:
   fra: AQ Force
   ita: Forza AQ
   spa: Fuerza de AQ
-  zho: AQ强度
+  chs: AQ强度
   jpn: AQの強さ
   rus: Сила AQ
   por: Força de AQ
@@ -45,7 +45,7 @@ About:
   fra: À propos de
   ita: Informazioni su
   spa: Acerca de
-  zho: 关于
+  chs: 关于
   jpn: Fastflixのバージョン情報
   rus: О программе
   por: Sobre
@@ -60,7 +60,7 @@ Adaptive Quantization:
   fra: Quantification adaptative
   ita: Quantizzazione adattiva
   spa: Cuantificación adaptativa
-  zho: 自适应量化
+  chs: 自适应量化
   jpn: 適応型量子化
   rus: Адаптивное Квантование
   por: Quantização adaptativa
@@ -75,7 +75,7 @@ Add current video to queue?:
   fra: Ajouter la vidéo actuelle à la file d'attente?
   ita: Aggiungere il video corrente alla coda?
   spa: ¿Añadir el vídeo actual a la cola?
-  zho: 将当前视频添加到队列中？
+  chs: 将当前视频添加到队列中？
   jpn: 現在のビデオをキューに追加しますか？
   rus: Добавить текущее видео в очередь?
   por: Adicionar vídeo actual à fila de espera?
@@ -90,7 +90,7 @@ Add to Queue:
   fra: Ajouter à la file d'attente
   ita: Aggiungi alla coda
   spa: Añadir a la cola
-  zho: 添加到队列
+  chs: 添加到队列
   jpn: キューに追加
   rus: Добавить в очередь
   por: Adicionar à Fila de espera
@@ -105,7 +105,7 @@ Adding commands to the queue:
   fra: Ajout de commandes à la file d'attente
   ita: Aggiungere comandi alla coda
   spa: Añadiendo comandos a la cola
-  zho: 正在将命令添加到队列中
+  chs: 正在将命令添加到队列中
   jpn: キューにコマンドを追加する
   rus: Добавление команд в очередь
   por: Acrescentar comandos à fila
@@ -120,7 +120,7 @@ Additional x265 params:
   fra: Paramètres x265 supplémentaires
   ita: Parametri aggiuntivi x265
   spa: Parámetros adicionales x265
-  zho: 额外的x265参数
+  chs: 额外的x265参数
   jpn: 追加のx265パラメータ
   rus: Дополнительные параметры x265
   por: Parâmetros adicionais x265
@@ -135,8 +135,8 @@ Advanced:
   fra: Avancé
   ita: Avanzato
   spa: Avanzado
-  zho: 高级
-  jpn: 高度な
+  chs: 高级
+  jpn: 高度な設定
   rus: Расширенный
   por: Avançado
   swe: Avancerad
@@ -150,7 +150,7 @@ After Conversion:
   fra: Après la conversion
   ita: Dopo la conversione
   spa: Después de la conversión
-  zho: 转换后
+  chs: 转换后
   jpn: 変換後
   rus: После преобразования
   por: Após a Conversão
@@ -165,7 +165,7 @@ All:
   fra: Tous
   ita: Tutti
   spa: Todos
-  zho: 全部
+  chs: 全部
   jpn: すべて
   rus: Все
   por: Todos
@@ -180,7 +180,7 @@ All queue items have completed:
   fra: Tous les éléments de la file d'attente sont terminés
   ita: Tutte le voci della coda sono state completate
   spa: Todos los artículos de la cola se han completado
-  zho: 所有排队项目已完成
+  chs: 所有排队项目已完成
   jpn: キューにあるアイテムが全て完了しました
   rus: Все пункты очереди завершены
   por: Todos os itens da fila foram completados
@@ -195,7 +195,7 @@ Audio:
   fra: Audio
   ita: Audio
   spa: Audio
-  zho: 音频
+  chs: 音频
   jpn: オーディオ
   rus: Аудио
   por: Áudio
@@ -210,7 +210,7 @@ Audio Tracks:
   fra: Pistes audio
   ita: Tracce audio
   spa: Pistas de audio
-  zho: 音轨
+  chs: 音轨
   jpn: オーディオトラック
   rus: Аудиодорожки
   por: Pistas de áudio
@@ -225,7 +225,7 @@ Audio select language:
   fra: Audio choisir la langue
   ita: Audio seleziona la lingua
   spa: Audio seleccionar idioma
-  zho: 选择音频语言
+  chs: 选择音频语言
   jpn: オーディオ言語の選択
   rus: Выбор языка аудио
   por: Seleccione a língua do áudio
@@ -240,7 +240,7 @@ Author:
   fra: Auteur
   ita: Autore
   spa: Autor
-  zho: 作者
+  chs: 作者
   jpn: 著者
   rus: Автор
   por: Autor
@@ -255,7 +255,7 @@ Auto:
   fra: Auto
   ita: Auto
   spa: Auto
-  zho: 自动
+  chs: 自动
   jpn: 自動的
   rus: Авто
   por: Auto
@@ -270,7 +270,7 @@ Auto Burn-in first forced or default subtitle track:
   fra: Auto Burn-in première piste de sous-titres forcée ou par défaut
   ita: Auto Burn-in prima traccia sottotitoli forzata o predefinita
   spa: Auto Burn-in primera pista de subtítulos forzados o por defecto
-  zho: 自动内嵌第一条分配为forced或default的字幕
+  chs: 自动内嵌第一条分配为forced或default的字幕
   jpn: 最初の強制またはデフォルトの字幕トラックを自動的にバーンインする
   rus: Автоматическое включение первой принудительной дорожки субтитров или дорожки
     субтитров по умолчанию
@@ -287,7 +287,7 @@ Auto Crop:
   fra: Auto Crop
   ita: Auto Crop
   spa: Auto Crop
-  zho: 自动裁切
+  chs: 自动裁切
   jpn: 自動クロップ
   rus: Автообрезка
   por: Cultura Automóvel
@@ -302,7 +302,7 @@ Auto Crop - Finding black bars at:
   fra: Auto Crop - Trouver des barres noires à
   ita: Auto Crop - Trovare barre nere a
   spa: Auto Crop - Encontrar barras negras en
-  zho: 自动裁切 - 寻找位于此时刻的黑边：
+  chs: 自动裁切 - 寻找位于此时刻的黑边：
   jpn: 自動クロップ - 黒いバーを見つける
   rus: Автообрезка - Нахождение черных полос в
   por: Auto Crop - Encontrar barras pretas em
@@ -317,7 +317,7 @@ Automatically detect black borders:
   fra: Detectar automáticamente los bordes negros
   ita: Rilevamento automatico dei bordi neri
   spa: Detectar automáticamente los bordes negros
-  zho: 自动检测黑边
+  chs: 自动检测黑边
   jpn: 黒枠を自動的に検出
   rus: Автоматическое определение черных границ
   por: Detectar automaticamente as bordas negras
@@ -332,7 +332,7 @@ Automatically enabled when an interlaced video is detected:
   fra: Automatiquement activé lorsqu'une vidéo entrelacée est détectée
   ita: Abilitato automaticamente quando viene rilevato un video interlacciato
   spa: Se activa automáticamente cuando se detecta un vídeo entrelazado
-  zho: 当检测到隔行扫描视频时自动启用此项。
+  chs: 当检测到隔行扫描视频时自动启用此项。
   jpn: インターレース動画が検出されると自動的に有効になります。
   rus: Автоматически включается при обнаружении чересстрочного видео
   por: Activado automaticamente quando um vídeo entrelaçado é detectado
@@ -347,7 +347,7 @@ B Adapt:
   fra: B Adapter
   ita: B Adattare
   spa: B Adaptar
-  zho: B Adapt
+  chs: B Adapt
   jpn: Bアダプト
   rus: B Адаптация
   por: B Adaptar
@@ -362,7 +362,7 @@ B Frames:
   fra: B Cadres
   ita: B Frames
   spa: Fotogramas B
-  zho: B帧
+  chs: B帧
   jpn: Bフレーム
   rus: B Рамки
   por: Molduras B
@@ -377,7 +377,7 @@ B Ref Mode:
   fra: B Mode Ref
   ita: Modalità B Ref
   spa: Modo B Ref
-  zho: B Ref模式
+  chs: B Ref模式
   jpn: B リファレンスモード
   rus: B Реф режим
   por: B Modo Ref
@@ -392,7 +392,7 @@ Bit Depth:
   fra: Profondeur de bit
   ita: Profondità della punta
   spa: Profundidad de bits
-  zho: 位深度
+  chs: 位深度
   jpn: ビット深度
   rus: Битовая глубина
   por: Profundidade de bits
@@ -407,7 +407,7 @@ Bitrate:
   fra: Bitrate
   ita: Bitrate
   spa: Bitrate
-  zho: 比特率
+  chs: 比特率
   jpn: ビットレート
   rus: Битрейт
   por: Taxa de bits
@@ -422,7 +422,7 @@ Block Size:
   fra: Taille du bloc
   ita: Dimensione del blocco
   spa: Tamaño del bloque
-  zho: 块大小
+  chs: 块大小
   jpn: ブロックサイズ
   rus: Размер блока
   por: Tamanho do bloco
@@ -437,7 +437,7 @@ Both Passes:
   fra: Les deux passages
   ita: Entrambi i Pass
   spa: Ambos pases
-  zho: 两遍均应用
+  chs: 两遍均应用
   jpn: 1回目と2回目両方
   rus: Оба прохода
   por: Ambos os Passes
@@ -452,7 +452,7 @@ Bottom:
   fra: Abajo
   ita: In basso
   spa: Abajo
-  zho: 下端
+  chs: 下端
   jpn: 下
   rus: Дно
   por: Fundo
@@ -467,7 +467,7 @@ Break the video into columns to encode faster (lesser quality):
   fra: Diviser la vidéo en colonnes pour un encodage plus rapide (qualité moindre)
   ita: Rompere il video in colonne per codificare più velocemente (qualità inferiore)
   spa: Dividir el video en columnas para codificar más rápido (menor calidad)
-  zho: 将视频按列分割，以更快地进行编码（质量较差）。
+  chs: 将视频按列分割，以更快地进行编码（质量较差）。
   jpn: 速くエンコードするために動画を列に分割する（画質は落ちる）
   rus: Разбейте видео на колонки для более быстрого кодирования (с меньшим качеством)
   por: Quebrar o vídeo em colunas para codificar mais rapidamente (menor qualidade)
@@ -483,7 +483,7 @@ Break the video into rows to encode faster (lesser quality):
   fra: Diviser la vidéo en lignes pour un encodage plus rapide (qualité moindre)
   ita: Suddividere il video in righe per codificare più velocemente (qualità inferiore)
   spa: Dividir el video en filas para codificar más rápido (menor calidad)
-  zho: 将视频按行分割，以更快地进行编码（质量较差）。
+  chs: 将视频按行分割，以更快地进行编码（质量较差）。
   jpn: 速くエンコードするためにビデオを列に分割する（画質は落ちる）
   rus: Разбейте видео на строки для более быстрого кодирования (с меньшим качеством)
   por: Quebrar o vídeo em filas para codificar mais rapidamente (menor qualidade)
@@ -499,7 +499,7 @@ Bufsize:
   fra: Bufsize
   ita: Bufsize
   spa: Bufsize
-  zho: Bufsize
+  chs: Bufsize
   jpn: Bufsize
   rus: Bufsize
   por: Bufsize
@@ -514,7 +514,7 @@ Build:
   fra: Construire
   ita: Costruire
   spa: Construye
-  zho: 构建
+  chs: 构建
   jpn: ビルド
   rus: Построить
   por: Construir
@@ -529,7 +529,7 @@ Burn In:
   fra: Burn In
   ita: Bruciare in
   spa: Quemar en
-  zho: 内嵌
+  chs: 内嵌
   jpn: バーンイン
   rus: Записать на
   por: Queimar em
@@ -544,7 +544,7 @@ CPU Used:
   fra: CPU utilisé
   ita: CPU usata
   spa: CPU utilizado
-  zho: CPU使用率
+  chs: CPU使用率
   jpn: CPU使用率
   rus: Используемый процессор
   por: CPU utilizada
@@ -559,7 +559,7 @@ Calculate PSNR and SSIM and show in the encoder output:
   fra: Calculer PSNR et SSIM et afficher dans la sortie du codeur
   ita: Calcolare PSNR e SSIM e mostrare nell'output del codificatore
   spa: Calcular PSNR y SSIM y mostrar en la salida del codificador
-  zho: 计算PSNR和SSIM，并显示在编码器输出中。
+  chs: 计算PSNR和SSIM，并显示在编码器输出中。
   jpn: PSNRとSSIMを計算し、エンコーダの出力に表示する
   rus: Вычислить PSNR и SSIM и показать на выходе кодера
   por: Calcular a PSNR e SSIM e mostrar na saída do codificador
@@ -574,7 +574,7 @@ Cancel:
   fra: Annuler
   ita: Annulla
   spa: Cancelar
-  zho: 取消
+  chs: 取消
   jpn: キャンセル
   rus: Отмена
   por: Cancelar
@@ -589,7 +589,7 @@ Cancel Conversion:
   fra: Annuler la conversion
   ita: Annullare la conversione
   spa: Cancelar la conversión
-  zho: 取消转换
+  chs: 取消转换
   jpn: 変換をキャンセルする
   rus: Отменить преобразование
   por: Cancelar Conversão
@@ -604,7 +604,7 @@ Cancel has been requested, killing encoding:
   fra: L'annulation a été demandée, tuant l'encodage
   ita: È stata richiesta la cancellazione, uccidendo la codifica
   spa: Se ha solicitado la cancelación, matando la codificación
-  zho: 已请求取消，正在终止编码
+  chs: 已请求取消，正在终止编码
   jpn: キャンセルが要求されました、エンコーディングを終了中
   rus: Была запрошена отмена, прекращающая кодирование
   por: Foi pedido o cancelamento, codificação de mortes
@@ -619,7 +619,7 @@ Canceling current encode:
   fra: Cancelar la codificación actual
   ita: Annullamento della corrente di codifica
   spa: Cancelar la codificación actual
-  zho: 正在取消当前编码
+  chs: 正在取消当前编码
   jpn: 現在のエンコードをキャンセルする
   rus: Отмена текущего кодирования
   por: Cancelamento do código de corrente
@@ -634,7 +634,7 @@ Cancelled:
   fra: Annulé
   ita: Cancellato
   spa: Cancelado
-  zho: 已取消
+  chs: 已取消
   jpn: キャンセルされた
   rus: Отменено
   por: Cancelado
@@ -649,7 +649,7 @@ Cancelled - Ready to try again:
   fra: Annulé - Prêt à réessayer
   ita: Annullato - Pronto a riprovare
   spa: Cancelado - Listo para intentarlo de nuevo
-  zho: 已取消 - 已准备好重试
+  chs: 已取消 - 已准备好重试
   jpn: キャンセルされました - 再試行できます
   rus: Отменено - готовы повторить попытку
   por: Cancelado - Pronto para tentar novamente
@@ -664,7 +664,7 @@ Cannot remove afterwards!:
   fra: Ne peut pas être retiré par la suite !
   ita: Non può essere rimosso dopo!
   spa: No se puede quitar después!
-  zho: 字幕内嵌之后无法去除！
+  chs: 字幕内嵌之后无法去除！
   jpn: バーンインした字幕は後から削除できない！
   rus: Невозможно потом удалить!
   por: Não é possível remover depois!
@@ -679,7 +679,7 @@ Check for Newer Version of FastFlix:
   fra: Consultez la nouvelle version de FastFlix
   ita: Verifica la presenza di una versione più recente di FastFlix
   spa: Busca la nueva versión de FastFlix
-  zho: 检查FastFlix更新
+  chs: 检查FastFlix更新
   jpn: 新しいバージョンのFastFlixをチェックする
   rus: Проверьте наличие новой версии FastFlix
   por: Verificar a existência de uma versão mais recente de FastFlix
@@ -694,7 +694,7 @@ Clean Old Logs:
   fra: Nettoyer les vieilles bûches
   ita: Pulire i vecchi tronchi
   spa: Limpiar los viejos troncos
-  zho: 清理旧日志
+  chs: 清理旧日志
   jpn: 古いログを削除する
   rus: Очистить старые журналы
   por: Toros antigos limpos
@@ -709,8 +709,8 @@ Clear Completed:
   fra: Clair Terminé
   ita: Chiaro Completato
   spa: Claro Completado
-  zho: 清理已完成。
-  jpn: 削除が完了しました。
+  chs: 清理已完成的项目
+  jpn: 完了したタスクを削除
   rus: Очистка завершена
   por: Limpar Completado
   swe: Klart slutfört
@@ -724,7 +724,7 @@ Close GUI Only:
   fra: Fermer uniquement l'interface graphique
   ita: Chiudi solo GUI
   spa: Cerrar sólo el GUI
-  zho: 只关闭GUI
+  chs: 只关闭GUI
   jpn: GUIのみを閉じる
   rus: Закрыть только графический интерфейс
   por: Fechar apenas GUI
@@ -739,7 +739,7 @@ CodeCalamity UHD HDR Encoding Guide:
   fra: Guide d'encodage CodeCalamity UHD HDR
   ita: Guida alla codifica CodeCalamity UHD HDR
   spa: CodeCalamity UHD Guía de codificación HDR
-  zho: CodeCalamity的UHD HDR编码指南（英文）
+  chs: CodeCalamity的UHD HDR编码指南（英文）
   jpn: CodeCalamity UHD HDRエンコーディングガイド（英語）
   rus: CodeCalamity Руководство по кодированию UHD HDR
   por: CodeCalamity UHD Guia de Codificação de HDR
@@ -754,7 +754,7 @@ Color Primaries:
   fra: Les couleurs primaires
   ita: Primarie di colore
   spa: Primarias de color
-  zho: 原色
+  chs: 原色
   jpn: カラープライマリー
   rus: Основные цвета
   por: Primários de cor
@@ -769,7 +769,7 @@ Color Space:
   fra: Espace de couleur
   ita: Spazio di colore
   spa: Espacio de color
-  zho: 色彩空间
+  chs: 色彩空间
   jpn: カラースペース
   rus: Цветовое пространство
   por: Espaço de cor
@@ -784,7 +784,7 @@ Color Transfer:
   fra: Transfert de couleur
   ita: Trasferimento del colore
   spa: Transferencia de color
-  zho: 色彩转换
+  chs: 色彩转换
   jpn: カラートランスファー
   rus: Передача цвета
   por: Transferência de cor
@@ -799,7 +799,7 @@ Command has completed:
   fra: Le commandement a terminé
   ita: Il comando ha completato
   spa: El comando ha completado
-  zho: 命令已完成。
+  chs: 命令已完成。
   jpn: コマンドが完了しました。
   rus: Команда выполнена
   por: Comando completado
@@ -816,7 +816,7 @@ Command worker received request to pause current encode:
     corrente
   spa: El trabajador del comando recibió una solicitud para pausar la codificación
     actual
-  zho: 命令执行程序收到了暂停当前编码的请求
+  chs: 命令执行程序收到了暂停当前编码的请求
   jpn: コマンドワーカーが現在のエンコードを一時停止するリクエストを受信しました
   rus: Оператор получил запрос на приостановку текущего кодирования
   por: Comando operário recebeu pedido para pausar a codificação de corrente
@@ -835,7 +835,7 @@ Command worker received request to pause encoding after the current item complet
     dopo il completamento della voce corrente
   spa: El trabajador del comando recibió la solicitud de pausar la codificación después
     de que el elemento actual complete
-  zho: 命令执行程序收到了在当前项目完成后暂停编码的请求
+  chs: 命令执行程序收到了在当前项目完成后暂停编码的请求
   jpn: コマンドワーカーが、現在のアイテムが完了した後にエンコードを一時停止するリクエストを受信しました
   rus: Оператор получил запрос на приостановку кодирования после завершения текущего
     элемента
@@ -856,7 +856,7 @@ Command worker received request to resume encoding:
   fra: Le commandant a reçu une demande de reprise de l'encodage
   ita: L'operatore di comando ha ricevuto la richiesta di riprendere la codifica
   spa: El comandante recibió la solicitud de reanudar la codificación
-  zho: 命令执行程序收到了恢复编码的请求
+  chs: 命令执行程序收到了恢复编码的请求
   jpn: コマンドワーカーがエンコード再開のリクエストを受信しました
   rus: Оператор получил запрос на возобновление кодирования
   por: O trabalhador de comando recebeu um pedido para retomar a codificação
@@ -873,7 +873,7 @@ Command worker received request to resume paused encode:
   ita: Operatore di comando ha ricevuto la richiesta di riprendere la pausa codificare
   spa: El trabajador del comando recibió la solicitud de reanudar la codificación
     en pausa
-  zho: 命令执行程序收到了恢复已暂停编码的请求
+  chs: 命令执行程序收到了恢复已暂停编码的请求
   jpn: コマンドワーカーが一時停止したエンコードの再開要求を受信しました
   rus: Оператор получил запрос на возобновление приостановленного кодирования
   por: O trabalhador de comando recebeu pedido para retomar o codigo pausado
@@ -888,7 +888,7 @@ Commands to execute:
   fra: Commandes à exécuter
   ita: Comandi da eseguire
   spa: Comandos para ejecutar
-  zho: 待执行命令
+  chs: 待执行命令
   jpn: 実行するコマンド
   rus: Команды для выполнения
   por: Comandos a executar
@@ -903,7 +903,7 @@ Config File:
   fra: Fichier Config
   ita: File di configurazione
   spa: Archivo de configuración
-  zho: 配置文件
+  chs: 配置文件
   jpn: 設定ファイル
   rus: Файл конфигурации
   por: Config File
@@ -918,7 +918,7 @@ Constant:
   fra: Constant
   ita: Costante
   spa: Constante
-  zho: 恒定
+  chs: 恒定
   jpn: 一定の
   rus: Постоянная
   por: Constante
@@ -933,7 +933,7 @@ Conversion:
   fra: Conversion
   ita: Conversione
   spa: Conversión
-  zho: 转换
+  chs: 转换
   jpn: 変換
   rus: Конвертация
   por: Conversão
@@ -948,7 +948,7 @@ Conversion cancelled, delete incomplete file:
   fra: Conversion annulée, suppression du dossier incomplet
   ita: Conversione annullata, cancellare il file incompleto
   spa: Conversión cancelada, borrar archivo incompleto
-  zho: 转换已取消，删除不完整的文件
+  chs: 转换已取消，删除不完整的文件
   jpn: 変換がキャンセルされ、不完全なファイルを削除する
   rus: Преобразование отменено, удалите незавершенный файл
   por: Conversão cancelada, apagar ficheiro incompleto
@@ -963,7 +963,7 @@ Conversion worker shutting down:
   fra: Fermeture d'une entreprise de reconversion
   ita: Operaio di conversione in chiusura
   spa: El cierre del trabajador de conversión
-  zho: 正在关闭转换程序
+  chs: 正在关闭转换程序
   jpn: コンバージョンワーカーのシャットダウンしている
   rus: Выключение конвертера
   por: Encerramento do trabalhador de conversão
@@ -978,7 +978,7 @@ Convert:
   fra: Convertir
   ita: Convertire
   spa: Convierte
-  zho: 转换
+  chs: 转换
   jpn: 変換
   rus: Конвертировать
   por: Converta
@@ -993,7 +993,7 @@ Convert BT2020 colorspace into bt709:
   fra: Convertir l'espace colorimétrique BT.2020 en BT.709
   ita: Convertire lo spazio di colore BT.2020 in BT.709
   spa: Convierte el espacio de color BT.2020 en BT.709
-  zho: 将BT.2020色彩空间转换为BT.709
+  chs: 将BT.2020色彩空间转换为BT.709
   jpn: BT2020色空間をbt709色空間に変換
   rus: Преобразование цветового пространства BT2020 в bt709
   por: Converter o espaço de cor BT2020 em bt709
@@ -1008,7 +1008,7 @@ Copy Chapters:
   fra: Copier les chapitres
   ita: Copiare i capitoli
   spa: Copiar capítulos
-  zho: 复制章节
+  chs: 复制章节
   jpn: チャプターをコピーする
   rus: Копирование глав
   por: Copiar Capítulos
@@ -1023,7 +1023,7 @@ Copy Commands:
   fra: Commandes de copie
   ita: Comandi di copia
   spa: Copiar comandos
-  zho: 复制命令
+  chs: 复制命令
   jpn: コピーコマンド
   rus: Команды копирования
   por: Comandos de cópia
@@ -1038,7 +1038,7 @@ Copy Cover:
   fra: Copie de la couverture
   ita: Copia di copertina
   spa: Copia de la portada
-  zho: 复制封面
+  chs: 复制封面
   jpn: コピーカバー
   rus: Копия обложки
   por: Capa de cópia
@@ -1053,7 +1053,7 @@ Copy Landscape Cover:
   fra: Copie de la couverture paysage
   ita: Copiare la copertura del paesaggio
   spa: Copia de la portada del paisaje
-  zho: 复制横向封面
+  chs: 复制横向封面
   jpn: ランドスケープ・カバーをコピーする
   rus: Копия обложки "пейзаж"
   por: Cópia da capa da Paisagem
@@ -1068,7 +1068,7 @@ Copy Small Cover (no preview):
   fra: Copie de la petite couverture (pas de prévisualisation)
   ita: Copia copertina piccola (nessuna anteprima)
   spa: Copia de la portada pequeña (sin vista previa)
-  zho: 复制小封面（无预览）
+  chs: 复制小封面（无预览）
   jpn: Small Coverをコピーする（プレビューなし）
   rus: Копия Малая обложка (без предпросмотра)
   por: Copiar Pequena Capa (sem pré-visualização)
@@ -1083,7 +1083,7 @@ Copy Small Landscape Cover  (no preview):
   fra: Copie de la petite couverture paysagère (pas de prévisualisation)
   ita: Copia piccola copertura del paesaggio (nessuna anteprima)
   spa: Copia de la cubierta de un pequeño paisaje (sin vista previa)
-  zho: 复制横向小封面（无预览）
+  chs: 复制横向小封面（无预览）
   jpn: Small Landscape Coverをコピーする(プレビューなし)
   rus: Копия малой обложки "пейзаж" (без предпросмотра)
   por: Copiar Pequena Capa de Paisagem (sem pré-visualização)
@@ -1098,7 +1098,7 @@ Copy all commands to the clipboard:
   fra: Copier toutes les commandes dans le presse-papiers
   ita: Copiare tutti i comandi negli appunti
   spa: Copia todos los comandos al portapapeles
-  zho: 将所有命令复制到剪贴板
+  chs: 将所有命令复制到剪贴板
   jpn: すべてのコマンドをクリップボードにコピーする
   rus: Копирование всех команд в буфер обмена
   por: Copiar todos os comandos para a prancheta
@@ -1113,7 +1113,7 @@ Copy the chapter markers as is from incoming source.:
   fra: Copiez les marqueurs de chapitre tels quels à partir de la source entrante.
   ita: Copiare i marcatori dei capitoli come da sorgente in entrata.
   spa: Copie los marcadores de capítulo tal como están de la fuente entrante.
-  zho: 将章节标记按原样从输入源复制。
+  chs: 将章节标记按原样从输入源复制。
   jpn: 入力ソースからチャプターマーカーをそのままコピーします。
   rus: Копирование маркеров глав как есть из входящего источника.
   por: Copiar os marcadores de capítulo tal como são da fonte de entrada.
@@ -1128,7 +1128,7 @@ Could not compress old logs:
   fra: Impossible de comprimer les vieilles bûches
   ita: Non riusciva a comprimere i vecchi tronchi
   spa: No podía comprimir los troncos viejos
-  zho: 无法压缩旧日志
+  chs: 无法压缩旧日志
   jpn: 古いログを圧縮できなかった
   rus: Не удалось сжать старые журналы
   por: Não conseguia comprimir troncos velhos
@@ -1145,7 +1145,7 @@ Could not connect to github to check for newer versions:
   ita: Impossibile connettersi a github per verificare la presenza di versioni più
     recenti
   spa: No se pudo conectar a github para comprobar las nuevas versiones
-  zho: 无法连接到github检查更新
+  chs: 无法连接到github检查更新
   jpn: 新しいバージョンを確認するためにgithubに接続できませんでした。
   rus: Не удалось подключиться к github для проверки наличия новых версий
   por: Não foi possível ligar ao github para verificar versões mais recentes
@@ -1160,7 +1160,7 @@ Could not create / access work directory:
   fra: Impossible de créer / d'accéder au répertoire de travail
   ita: Impossibile creare / accedere alla directory di lavoro
   spa: No pudo crear / acceder al directorio de trabajo
-  zho: 无法创建/访问工作目录
+  chs: 无法创建/访问工作目录
   jpn: 作業用ディレクトリを作成できない／アクセスできない
   rus: Не удалось создать / получить доступ к рабочему каталогу
   por: Não foi possível criar / aceder ao directório de trabalho
@@ -1175,7 +1175,7 @@ Could not fix first subtitle track:
   fra: Impossible de réparer la première piste de sous-titres
   ita: Impossibile fissare la prima traccia dei sottotitoli
   spa: No se pudo arreglar la primera pista del subtítulo
-  zho: 无法固定第1个字幕
+  chs: 无法固定第1个字幕
   jpn: 1つ目の字幕トラックを固定できなかった
   rus: Не удалось зафиксировать первую дорожку субтитров
   por: Não foi possível fixar a primeira faixa de legendas
@@ -1190,7 +1190,7 @@ Could not generate thumbnail:
   fra: N'a pas pu générer de vignette
   ita: Impossibile generare un'immagine in miniatura
   spa: No pudo generar la miniatura
-  zho: 无法生成缩略图
+  chs: 无法生成缩略图
   jpn: サムネイルを生成できませんでした
   rus: Не удалось создать миниатюру
   por: Não pôde gerar miniaturas
@@ -1205,7 +1205,7 @@ Could not load config file!:
   fra: Impossible de charger le fichier de configuration !
   ita: Impossibile caricare il file di configurazione!
   spa: ¡No pude cargar el archivo de configuración!
-  zho: 无法加载配置文件!
+  chs: 无法加载配置文件!
   jpn: 設定ファイルの読み込みができませんでした。
   rus: Не удалось загрузить файл конфигурации!
   por: Não foi possível carregar o ficheiro de configuração!
@@ -1220,8 +1220,8 @@ Could not set language to:
   fra: Impossible de régler la langue sur
   ita: Non è stato possibile impostare la lingua su
   spa: No se pudo establecer el idioma a
-  zho: 无法将语言设置为
-  jpn: に言語を設定できませんでした。
+  chs: 无法将语言设置为
+  jpn: 次の言語は設定できませんでした：
   rus: Не удалось установить язык на
   por: Não foi possível definir a linguagem para
   swe: Kunde inte ställa in språket till
@@ -1235,7 +1235,7 @@ Could not start FastFlix:
   fra: N'a pas pu démarrer FastFlix
   ita: Impossibile avviare FastFlix
   spa: No pudo iniciar FastFlix
-  zho: 无法启动FastFlix
+  chs: 无法启动FastFlix
   jpn: FastFlixを起動できませんでした。
   rus: Не удалось запустить FastFlix
   por: Não foi possível iniciar FastFlix
@@ -1250,7 +1250,7 @@ Cover:
   fra: Couverture
   ita: Coprire
   spa: Cubre
-  zho: 封面
+  chs: 封面
   jpn: カバー
   rus: Обложка
   por: Capa
@@ -1265,7 +1265,7 @@ Create Profile:
   fra: Créer un profil
   ita: Crea profilo
   spa: Crear el perfil
-  zho: 创建配置
+  chs: 创建配置
   jpn: プロファイルの作成
   rus: Создать профиль
   por: Criar Perfil
@@ -1280,7 +1280,7 @@ Crop:
   fra: Culture
   ita: Ritaglio
   spa: Crop
-  zho: 裁切
+  chs: 裁切
   jpn: クロップ
   rus: Обрезка
   por: Cultura
@@ -1295,7 +1295,7 @@ Crop Detect Points:
   fra: Points de détection des cultures
   ita: Ritagliare i punti di rilevamento
   spa: Puntos de detección de cultivos
-  zho: 裁切检测点
+  chs: 裁切检测点
   jpn: クロップ検知ポイント
   rus: Точки обнаружения обрезки
   por: Pontos de Detecção de Culturas
@@ -1310,7 +1310,7 @@ Current Profile Settings:
   fra: Paramètres du profil actuel
   ita: Impostazioni del profilo corrente
   spa: Configuración del perfil actual
-  zho: 当前配置
+  chs: 当前配置
   jpn: 現在のプロファイル設定
   rus: Текущие настройки профиля
   por: Definições de perfil actuais
@@ -1325,7 +1325,7 @@ Currently only works for image based subtitles.:
   fra: Actuellement, il ne fonctionne que pour les sous-titres basés sur l'image.
   ita: Attualmente funziona solo per i sottotitoli basati su immagini.
   spa: Actualmente sólo funciona para subtítulos basados en imágenes.
-  zho: 目前只适用于基于图像的字幕。
+  chs: 目前只适用于基于图像的字幕。
   jpn: 現在のところ、画像ベースの字幕にしか対応していません。
   rus: В настоящее время работает только для субтитров на основе изображений.
   por: Actualmente só funciona para legendas baseadas em imagens.
@@ -1340,7 +1340,7 @@ Custom NVEncC options:
   fra: Options NVEncC personnalisées
   ita: Opzioni NVEncC personalizzate
   spa: Opciones personalizadas de NVEncC
-  zho: 自定义NVEncC选项
+  chs: 自定义NVEncC选项
   jpn: NVEncCのカスタムオプション
   rus: Пользовательские опции NVEncC
   por: Opções NVEncC personalizadas
@@ -1355,7 +1355,7 @@ Custom ffmpeg options:
   fra: Options ffmpeg personnalisées
   ita: Opzioni ffmpeg personalizzate
   spa: Opciones personalizadas de ffmpeg
-  zho: 自定义ffmpeg选项
+  chs: 自定义ffmpeg选项
   jpn: ffmpegのカスタムオプション
   rus: Пользовательские параметры ffmpeg
   por: Opções ffmpeg personalizadas
@@ -1370,7 +1370,7 @@ Deblock:
   fra: Deblock
   ita: Deblock
   spa: Deblock
-  zho: 去块
+  chs: 去块
   jpn: デブロック
   rus: Разблокировка
   por: Desbloqueio
@@ -1388,7 +1388,7 @@ Default 4. This parameter has a quadratic effect on the amount of memory allocat
     memoria allocata
   spa: Por defecto 4. Este parámetro tiene un efecto cuadrático en la cantidad de
     memoria asignada
-  zho: 默认值为4。此参数对于所分配的内存量和--b-adapt
+  chs: 默认值为4。此参数对于所分配的内存量和--b-adapt
   jpn: デフォルトは4です。このパラメータは、割り当てられたメモリの量に二次的な影響を与えます。
   rus: По умолчанию 4. Этот параметр оказывает квадратичное влияние на объем выделяемой
     памяти
@@ -1408,7 +1408,7 @@ Default disabled.:
   fra: Désactivé par défaut.
   ita: Predefinito disabilitato.
   spa: Desactivado por defecto.
-  zho: 默认禁用。
+  chs: 默认禁用。
   jpn: デフォルトは無効です。
   rus: По умолчанию отключено.
   por: Default disabled.
@@ -1423,7 +1423,7 @@ Default enabled.:
   fra: Activé par défaut.
   ita: Predefinito abilitato.
   spa: Por defecto habilitado.
-  zho: 默认启用。
+  chs: 默认启用。
   jpn: デフォルトでは有効です。
   rus: По умолчанию включено.
   por: Predefinição activada.
@@ -1443,7 +1443,7 @@ Default is an autodetected count based on the number of CPU cores and whether WP
     fatto che WPP sia abilitato o meno.
   spa: Por defecto es un conteo autodetectado basado en el número de núcleos de la
     CPU y si WPP está habilitado o no.
-  zho: WPP（Wavefront Parallel Processing）自动确定。
+  chs: WPP（Wavefront Parallel Processing）自动确定。
   jpn: デフォルトでは、CPUコア数とWPPが有効かどうかに基づいて自動検出されたカウントです。
   rus: По умолчанию это автоопределяемый подсчет, основанный на количестве ядер ЦП
     и на том, включен или нет WPP.
@@ -1464,7 +1464,7 @@ Default is an autodetected count based on the number of CPU cores and whether WP
   fra: 'Par défaut : AQ activé avec auto-variance'
   ita: 'Default: AQ abilitato con auto-varianza'
   spa: 'Por defecto: AQ habilitado con auto-varianza'
-  zho: '默认值为enabled + auto-variance'
+  chs: '默认值为enabled + auto-variance'
   jpn: 'デフォルトは自動分散でAQを有効にする'
   rus: 'По умолчанию: AQ включен с автоматической дисперсией'
   por: 'Por omissão: AQ activado com auto-variância'
@@ -1479,7 +1479,7 @@ Deinterlace:
   fra: Deinterlace
   ita: Deinterlace
   spa: Deinterlace
-  zho: 反交错
+  chs: 反交错
   jpn: デインタレース
   rus: Деинтерлейс
   por: Deinterlace
@@ -1494,7 +1494,7 @@ Delete:
   fra: Supprimer
   ita: Cancellare
   spa: Eliminar
-  zho: 删除
+  chs: 删除
   jpn: 削除
   rus: Удалить
   por: Eliminar
@@ -1509,8 +1509,8 @@ Delete Current Profile:
   fra: Supprimer le profil actuel
   ita: Cancellare il profilo corrente
   spa: Borrar el perfil actual
-  zho: 删除当前p配置
-  jpn: 現在のプロフィールの削除
+  chs: 删除当前配置
+  jpn: 現在のプロフィールを削除
   rus: Удалить текущий профиль
   por: Apagar perfil actual
   swe: Ta bort aktuell profil
@@ -1524,7 +1524,7 @@ Denoise:
   fra: Denoise
   ita: Denoise
   spa: Denoise
-  zho: 降噪
+  chs: 降噪
   jpn: デノアス
   rus: Шумоподавление
   por: Denoise
@@ -1539,7 +1539,7 @@ Detect HDR10+:
   fra: Détecter le HDR10+
   ita: Rileva HDR10
   spa: Detectar HDR10+
-  zho: 检测HDR10+
+  chs: 检测HDR10+
   jpn: HDR10+の検出
   rus: Обнаружение HDR10+
   por: Detectar HDR10+
@@ -1554,7 +1554,7 @@ Detecting Interlace:
   fra: Détection d'entrelacs
   ita: Rilevamento dell'interlacciamento
   spa: Detección del entrelazado
-  zho: 正在检测隔行扫描
+  chs: 正在检测隔行扫描
   jpn: インターレースの検出
   rus: Обнаружение чересстрочной развертки
   por: Detectar a Interlace
@@ -1569,7 +1569,7 @@ Determine HDR details:
   fra: Déterminer les détails du RDH
   ita: Determinare i dettagli HDR
   spa: Determinar los detalles del HDR
-  zho: 检测HDR详情
+  chs: 检测HDR详情
   jpn: HDRの詳細を検出
   rus: Определите детали HDR
   por: Determinar os detalhes do HDR
@@ -1584,7 +1584,7 @@ Disable update check on startup:
   fra: Désactiver la vérification de la mise à jour au démarrage
   ita: Disattivare il controllo di aggiornamento all'avvio
   spa: Desactivar la comprobación de actualización al inicio
-  zho: 禁用启动时的更新检查
+  chs: 禁用启动时的更新检查
   jpn: 起動時のアップデートチェックを無効にする
   rus: Отключить проверку обновлений при запуске
   por: Desactivar a verificação de actualização ao arrancar
@@ -1599,7 +1599,7 @@ Disposition:
   fra: Disposition
   ita: Disposizione
   spa: Disposición
-  zho: 分配
+  chs: 分配
   jpn: 処分
   rus: Расположение
   por: Disposição
@@ -1614,7 +1614,7 @@ Dither:
   fra: Soit
   ita: Dither
   spa: Dither
-  zho: 抖动
+  chs: 抖动
   jpn: ディザ
   rus: Дизеринг
   por: Ou
@@ -1634,7 +1634,7 @@ Dither is an intentionally applied form of noise used to randomize quantization 
     l'errore di quantizzazione,
   spa: El Dither es una forma de ruido aplicada intencionalmente que se utiliza para
     aleatorizar el error de cuantificación,
-  zho: 抖动（Dither）是一种为了随机化量化误差（quantization error）而有意添加的噪声，
+  chs: 抖动（Dither）是一种为了随机化量化误差（quantization error）而有意添加的噪声，
   jpn: ディザとは、量子化誤差をランダムにするために意図的にかけるノイズのことです。
   rus: Дизеринг - это намеренно применяемая форма шума, используемая для рандомизации
     ошибки квантования,
@@ -1653,7 +1653,7 @@ Download:
   fra: Télécharger
   ita: Scaricare
   spa: Descargar
-  zho: 下载
+  chs: 下载
   jpn: ダウンロード
   rus: Скачать
   por: Descarregar
@@ -1668,7 +1668,7 @@ Download Cancelled:
   fra: Téléchargement annulé
   ita: Scaricamento annullato
   spa: Descarga cancelada
-  zho: 下载已取消
+  chs: 下载已取消
   jpn: ダウンロードはキャンセルされた
   rus: Скачивание Отменено
   por: Descarregar Cancelado
@@ -1683,7 +1683,7 @@ Download Newest FFmpeg:
   fra: Télécharger le dernier FFmpeg
   ita: Scarica il nuovo FFmpeg
   spa: Descargar el nuevo FFmpeg
-  zho: 下载最新版FFmpeg
+  chs: 下载最新版FFmpeg
   jpn: 最新のFFmpegをダウンロードする
   rus: Скачать новейший FFmpeg
   por: Descarregar o mais recente FFmpeg
@@ -1698,7 +1698,7 @@ Downloading FFmpeg:
   fra: Télécharger FFmpeg
   ita: Scaricare FFmpeg
   spa: Descargar FFmpeg
-  zho: 正在下载FFmpeg
+  chs: 正在下载FFmpeg
   jpn: FFmpegをダウンロード中
   rus: Загрузка FFmpeg
   por: Descarregar FFmpeg
@@ -1713,7 +1713,7 @@ Dual License:
   fra: Double licence
   ita: Doppia Licenza
   spa: Licencia doble
-  zho: 双重许可
+  chs: 双重许可
   jpn: 二重ライセンス
   rus: Двойная лицензия
   por: Dupla Licença
@@ -1728,7 +1728,7 @@ Enable VBV:
   fra: Activer la VBV
   ita: Attivare VBV
   spa: Activar VBV
-  zho: 启用VBV
+  chs: 启用VBV
   jpn: VBVを有効にする
   rus: Включить VBV
   por: Activar VBV
@@ -1743,7 +1743,7 @@ Enable row based multi-threading:
   fra: Activer le multi-threading basé sur les lignes
   ita: Abilita il multi-threading basato sulle righe
   spa: Habilitar el multihilo basado en filas
-  zho: 启用基于行的多线程
+  chs: 启用基于行的多线程
   jpn: 行ベースのマルチスレッド化
   rus: Включить многопоточность на основе строк
   por: Habilitar multi-tarefas baseadas em filas
@@ -1758,7 +1758,7 @@ Enable strong intra smoothing for 32x32 intra blocks.:
   fra: Permettre un lissage intra fort pour les blocs intra 32x32.
   ita: Abilita una forte lisciatura intra per gli intrablocchi 32x32.
   spa: Habilitar un fuerte alisamiento interno para los bloqueos internos de 32x32.
-  zho: 对32x32的内部j块启用强烈的内部舒缓（intra smoothing）。
+  chs: 对32x32的内部j块启用强烈的内部舒缓（intra smoothing）。
   jpn: 32x32イントラブロックの強力なイントラ・スムージングを有効にする。
   rus: Включите сильное внутреннее сглаживание для внутренних блоков 32x32.
   por: Permitir um forte alisamento intra para 32x32 intra blocos.
@@ -1773,7 +1773,7 @@ Enable the yadif filter:
   fra: Activer le filtre yadif
   ita: Attivare il filtro yadif
   spa: Habilitar el filtro yadif
-  zho: 启用yadif滤镜
+  chs: 启用yadif滤镜
   jpn: yadifフィルターを有効にする
   rus: Включите фильтр yadif
   por: Activar o filtro yadif
@@ -1788,7 +1788,7 @@ Enabled:
   fra: Activé
   ita: Abilitato
   spa: Habilitado
-  zho: 启用
+  chs: 启用
   jpn: 有効化
   rus: Включено
   por: Activado
@@ -1804,7 +1804,7 @@ Enabled automatically when --master-display or --max-cll is specified.:
   fra: Activé automatiquement lorsque --master-display ou --max-cll est spécifié.
   ita: Abilitato automaticamente quando viene specificato --master-display o --max-cll.
   spa: Se activa automáticamente cuando se especifica --master-display o --max-cll.
-  zho: 当指定--master-display或--max-cll时自动启用。
+  chs: 当指定--master-display或--max-cll时自动启用。
   jpn: --master-displayまたは--max-cllが指定された場合、自動的に有効になります。
   rus: Включается автоматически, если указано --master-display или --max-cll.
   por: Activado automaticamente quando --master-display ou --max-cll é especificado.
@@ -1819,7 +1819,7 @@ Enables the yadif filter.:
   fra: Active le filtre yadif.
   ita: Abilita il filtro yadif.
   spa: Habilita el filtro yadif.
-  zho: 启用yadif滤镜。
+  chs: 启用yadif滤镜。
   jpn: yadifフィルターを有効にします。
   rus: Включает фильтр yadif.
   por: Possibilita o filtro yadif.
@@ -1839,7 +1839,7 @@ Enables true lossless coding by bypassing scaling, transform, quantization and i
     trasformazione, la quantizzazione e il filtraggio in loop.
   spa: Habilita la verdadera codificación sin pérdidas evitando el escalado, la transformación,
     la cuantificación y el filtrado en bucle.
-  zho: 绕过缩放、变换、量化和in-loop filtering，从而实现真正的无损编码。
+  chs: 绕过缩放、变换、量化和in-loop filtering，从而实现真正的无损编码。
   jpn: スケーリング、トランスフォーム、量子化、インループフィルタリングをバイパスすることで、真のロスレスコーディングを可能にします。
   rus: Обеспечивает прямое кодирование без потерь, минуя масштабирование, преобразование,
     квантование и фильтрацию в контуре.
@@ -1860,7 +1860,7 @@ Enabling cover thumbnails on your system:
   fra: Activation des vignettes de couverture sur votre système
   ita: Abilita le miniature del coperchio del sistema
   spa: Habilitando las miniaturas de la cubierta en su sistema
-  zho: 在系统上启用封面缩略图（英文）
+  chs: 在系统上启用封面缩略图（英文）
   jpn: お使いのシステムでカバーのサムネイルを有効にする
   rus: Включение эскизов обложек в вашей системе
   por: Habilitação de miniaturas de cobertura no seu sistema
@@ -1875,7 +1875,7 @@ Encoder:
   fra: Encodeur
   ita: Encoder
   spa: Codificador
-  zho: 编码器
+  chs: 编码器
   jpn: エンコーダ
   rus: Энкодер
   por: Codificador
@@ -1890,7 +1890,7 @@ Encoder Output:
   fra: Sortie de l'encodeur
   ita: Uscita encoder
   spa: Salida del codificador
-  zho: 编码器输出
+  chs: 编码器输出
   jpn: エンコーダ出力
   rus: Выход кодера
   por: Saída do codificador
@@ -1905,7 +1905,7 @@ Encoder Settings:
   fra: Réglage du codeur
   ita: Impostazione dell'encoder
   spa: Configuración del codificador
-  zho: 编码器设置
+  chs: 编码器设置
   jpn: エンコーダの設定
   rus: Настройки энкодера
   por: Definições do codificador
@@ -1920,7 +1920,7 @@ Encoding Queue:
   fra: File d'attente d'encodage
   ita: Coda di codifica
   spa: Cola de codificación
-  zho: 编码队列
+  chs: 编码队列
   jpn: 変換キュー
   rus: Очередь кодирования
   por: Fila de Codificação
@@ -1935,7 +1935,7 @@ Encoding Status:
   fra: Statut d'encodage
   ita: Stato di codifica
   spa: Estado de la codificación
-  zho: 编码状态
+  chs: 编码状态
   jpn: エンコードステータス
   rus: Статус кодирования
   por: Estado de Codificação
@@ -1950,7 +1950,7 @@ Encoding command:
   fra: Commande d'encodage
   ita: Comando di codifica
   spa: Comando de codificación
-  zho: 编码命令
+  chs: 编码命令
   jpn: エンコードコマンド
   rus: Команда кодирования
   por: Comando de codificação
@@ -1965,7 +1965,7 @@ Encoding complete:
   fra: Encodage complet
   ita: Codifica completa
   spa: Codificación completa
-  zho: 编码完成
+  chs: 编码完成
   jpn: エンコード完了
   rus: Кодирование завершено
   por: Codificação completa
@@ -1980,7 +1980,7 @@ Encoding errored:
   fra: Encodage erroné
   ita: Codifica errata
   spa: error de codificación
-  zho: 编码错误
+  chs: 编码错误
   jpn: エンコーディングエラー
   rus: Ошибка кодирования
   por: Codificação erradamente codificada
@@ -1995,7 +1995,7 @@ End:
   fra: Fin
   ita: Fine
   spa: Fin
-  zho: 结束
+  chs: 结束
   jpn: 終了
   rus: Конец
   por: Fim
@@ -2010,7 +2010,7 @@ Enforce an encode profile:
   fra: Faire appliquer un profil codé
   ita: Applicare un profilo di codifica
   spa: Hacer cumplir un perfil de codificación
-  zho: 应用一个编码配置
+  chs: 应用一个编码配置
   jpn: エンコードプロファイルの適用
   rus: Применить профиль кодирования
   por: Forçar um perfil de codificação
@@ -2025,7 +2025,7 @@ Error:
   fra: Erreur
   ita: Errore
   spa: Error
-  zho: 错误
+  chs: 错误
   jpn: エラー
   rus: Ошибка
   por: Erro
@@ -2040,7 +2040,7 @@ Error Updating Thumbnail:
   fra: Erreur de mise à jour de la vignette
   ita: Errore aggiornamento miniatura
   spa: Error de actualización de la miniatura
-  zho: 缩略图更新错误
+  chs: 缩略图更新错误
   jpn: サムネイルの更新エラー
   rus: Ошибка обновления миниатюры
   por: Actualização de miniaturas de erro
@@ -2055,7 +2055,7 @@ Error detected while converting:
   fra: Erreur détectée lors de la conversion
   ita: Errore rilevato durante la conversione
   spa: Error detectado durante la conversión
-  zho: 转换时检测到错误
+  chs: 转换时检测到错误
   jpn: 変換中にエラーが発生
   rus: Обнаружена ошибка при конвертации
   por: Erro detectado durante a conversão
@@ -2070,7 +2070,7 @@ Estimated file size based on bitrate:
   fra: Estimation de la taille du fichier en fonction du débit binaire
   ita: Dimensione stimata del file in base al bitrate
   spa: Tamaño estimado del archivo basado en la tasa de bits
-  zho: 基于比特率的估计文件大小
+  chs: 基于比特率的估计文件大小
   jpn: ビットレートに応じたファイルサイズの目安
   rus: Расчетный размер файла на основе битрейта
   por: Tamanho de ficheiro estimado com base na taxa de bits
@@ -2085,7 +2085,7 @@ Estimated time left for current command:
   fra: Estimation du temps restant pour le commandement en cours
   ita: Tempo stimato rimasto per il comando corrente
   spa: Tiempo estimado para el comando actual
-  zho: 当前命令的估计剩余时间
+  chs: 当前命令的估计剩余时间
   jpn: 現在のコマンドの残り時間の目安
   rus: Расчетное время, оставшееся до завершения текущей команды
   por: Tempo restante estimado para o comando actual
@@ -2100,7 +2100,7 @@ Exit:
   fra: Sortie
   ita: Uscita
   spa: Salga de
-  zho: 退出
+  chs: 退出
   jpn: 退出
   rus: Выход
   por: Saída
@@ -2115,7 +2115,7 @@ Exit application:
   fra: Demande de sortie
   ita: Applicazione di uscita
   spa: Aplicación de salida
-  zho: 退出应用
+  chs: 退出应用
   jpn: アプリケーションの終了
   rus: Выход из приложения
   por: Aplicação de saída
@@ -2131,7 +2131,7 @@ Extra flags or options, cannot modify existing settings:
     existants
   ita: I flag o le opzioni extra, non possono modificare le impostazioni esistenti
   spa: Las banderas u opciones adicionales, no pueden modificar los ajustes existentes
-  zho: 有额外的标志或选项，无法修改已有设置。
+  chs: 有额外的标志或选项，无法修改已有设置。
   jpn: 追加のフラグやオプションがあるため既存の設定を変更できない
   rus: Дополнительные флаги или опции, не могут изменять существующие настройки
   por: Bandeiras ou opções extra, não podem modificar as configurações existentes
@@ -2146,7 +2146,7 @@ Extra x265 params in opt=1:opt2=0 format:
   fra: Paramètres x265 supplémentaires au format opt=1:opt2=0
   ita: Parametri extra x265 nel formato opt=1:opt2=0
   spa: Parámetros extra x265 en formato opt=1:opt2=0
-  zho: 额外的x265参数，格式为opt=1:opt2=0
+  chs: 额外的x265参数，格式为opt=1:opt2=0
   jpn: opt=1:opt2=0形式のx265パラメータが追加されました。
   rus: Дополнительные параметры x265 в формате opt=1:opt2=0
   por: Parâmetros extra x265 no formato opt=1:opt2=0
@@ -2161,7 +2161,7 @@ Extract:
   fra: Extrait
   ita: Estratto
   spa: Extracto
-  zho: 提取
+  chs: 提取
   jpn: エクストラクト
   rus: Извлечение
   por: Extracto
@@ -2176,7 +2176,7 @@ Extract HDR10+:
   fra: Extrait HDR10+
   ita: Estrarre HDR10
   spa: Extraer HDR10+
-  zho: 提取HDR10+
+  chs: 提取HDR10+
   jpn: HDR10+の抽出
   rus: Извлечение HDR10+
   por: Extracto HDR10+
@@ -2191,7 +2191,7 @@ Extract covers:
   fra: Extrait couvre
   ita: Coperture per l'estrazione
   spa: Extraer las cubiertas
-  zho: 提取封面
+  chs: 提取封面
   jpn: 抽出物のカバー
   rus: Извлечение обложек
   por: Capas de extractos
@@ -2206,7 +2206,7 @@ Extracted subtitles successfully:
   fra: Sous-titres extraits avec succès
   ita: Sottotitoli estratti con successo
   spa: Subtítulos extraídos con éxito
-  zho: 成功提取字幕
+  chs: 成功提取字幕
   jpn: 字幕の抽出に成功
   rus: Успешное извлечение субтитров
   por: Legendas extraídas com sucesso
@@ -2221,7 +2221,7 @@ Extracting HDR10+ metadata:
   fra: Extraction des métadonnées HDR10+.
   ita: Estrarre i metadati HDR10
   spa: Extracción de metadatos HDR10+
-  zho: 提取HDR10+元数据
+  chs: 提取HDR10+元数据
   jpn: HDR10+メタデータの抽出
   rus: Извлечение метаданных HDR10+
   por: Extracção de metadados HDR10+
@@ -2236,7 +2236,7 @@ Extracting subtitles to:
   fra: Extraction des sous-titres de
   ita: Estrazione dei sottotitoli a
   spa: Extracción de subtítulos a
-  zho: 提取字幕到
+  chs: 提取字幕到
   jpn: に字幕を抽出します。
   rus: Извлечение субтитров в
   por: Extrair subtítulos para
@@ -2251,7 +2251,7 @@ FFMPEG AV1 Encoding Guide:
   fra: Guide d'encodage FFMPEG AV1
   ita: Guida alla codifica FFMPEG AV1
   spa: Guía de codificación del FFMPEG AV1
-  zho: FFMPEG AV1编码指南（英文）
+  chs: FFMPEG AV1编码指南（英文）
   jpn: FFMPEG AV1エンコードガイド（英語）
   rus: Руководство по кодированию FFMPEG AV1
   por: Guia de Codificação FFMPEG AV1
@@ -2266,7 +2266,7 @@ FFMPEG AVC / H.264 Encoding Guide:
   fra: FFMPEG AVC / Guide d'encodage H.264
   ita: Guida alla codifica FFMPEG AVC / H.264
   spa: Guía de codificación FFMPEG AVC / H.264
-  zho: FFMPEG AVC / H.264 编码指南（英文）
+  chs: FFMPEG AVC / H.264 编码指南（英文）
   jpn: FFMPEG AVC / H.264エンコードガイド（英語）
   rus: Руководство по кодированию FFMPEG AVC / H.264
   por: Guia de Codificação FFMPEG AVC / H.264
@@ -2281,7 +2281,7 @@ FFMPEG HEVC / H.265 Encoding Guide:
   fra: FFMPEG HEVC / Guide d'encodage H.265
   ita: Guida alla codifica FFMPEG HEVC / H.265
   spa: Guía de codificación FFMPEG HEVC / H.265
-  zho: FFMPEG HEVC / H.265编码指南（英文）
+  chs: FFMPEG HEVC / H.265编码指南（英文）
   jpn: FFMPEG HEVC / H.265 エンコーディングガイド（英語）
   rus: Руководство по кодированию FFMPEG HEVC / H.265
   por: FFMPEG HEVC / H.265 Guia de Codificação
@@ -2296,7 +2296,7 @@ FFMPEG VP9 Encoding Guide:
   fra: FFMPEG Guide d'encodage VP9
   ita: Guida alla codifica FFMPEG VP9
   spa: Guía de codificación del FFMPEG VP9
-  zho: FFMPEG VP9编码指南（英文）
+  chs: FFMPEG VP9编码指南（英文）
   jpn: FFMPEG VP9エンコーディングガイド（英語）
   rus: Руководство по кодированию FFMPEG VP9
   por: Guia de Codificação FFMPEG VP9
@@ -2311,7 +2311,7 @@ FFmpeg updated - Please restart FastFlix:
   fra: FFmpeg mis à jour - Veuillez redémarrer FastFlix
   ita: FFmpeg aggiornato - Si prega di riavviare FastFlix
   spa: FFmpeg actualizado - Por favor, reinicie FastFlix
-  zho: FFmpeg更新完成。请重新启动FastFlix。
+  chs: FFmpeg更新完成。请重新启动FastFlix。
   jpn: FFmpegのアップデートしました。FastFlixを再起動してください。
   rus: FFmpeg обновлен - пожалуйста, перезапустите FastFlix
   por: FFmpeg actualizado - Por favor reinicie FastFlix
@@ -2326,7 +2326,7 @@ FPS:
   fra: FPS
   ita: FPS
   spa: FPS
-  zho: FPS
+  chs: FPS
   jpn: FPS
   rus: FPS
   por: FPS
@@ -2341,7 +2341,7 @@ Fast first pass:
   fra: Première passe rapide
   ita: Primo passaggio veloce
   spa: Primera pasada rápida
-  zho: 快速第一遍编码
+  chs: 快速第一遍编码
   jpn: 高速1回目
   rus: Быстрый первый проход
   por: Primeira passagem rápida
@@ -2356,7 +2356,7 @@ File:
   fra: Fichier
   ita: Archivio
   spa: Archivo
-  zho: 文件
+  chs: 文件
   jpn: ファイル
   rus: Файл
   por: Ficheiro
@@ -2371,7 +2371,7 @@ Flat UI:
   fra: interface graphique à plat
   ita: GUI piatta
   spa: GUI plana
-  zho: 扁平化GUI
+  chs: 扁平化GUI
   jpn: フラットUI
   rus: Плоский интерфейс
   por: IU plana
@@ -2386,7 +2386,7 @@ For lossless, this is a size/speed tradeoff.:
   fra: Pour les moins fortunés, il s'agit d'un compromis taille/vitesse.
   ita: Per i lossless, questo è un compromesso tra dimensioni e velocità.
   spa: Para los que no tienen pérdidas, esto es un intercambio de tamaño/velocidad.
-  zho: 在无损编码时，此选项在大小与速度之间权衡。
+  chs: 在无损编码时，此选项在大小与速度之间权衡。
   jpn: ロスレスの場合、これはサイズとスピードのトレードオフになります。
   rus: Для lossless это компромисс между размером и скоростью.
   por: Para um sem perdas, esta é uma troca de tamanho/velocidade.
@@ -2403,7 +2403,7 @@ For lossy, this is a quality/speed tradeoff.:
   fra: Pour les perdants, il s'agit d'un compromis qualité/vitesse.
   ita: Per le perdite, si tratta di un compromesso qualità/velocità.
   spa: Para los que tienen pérdidas, es una compensación de calidad/velocidad.
-  zho: 在有损编码时，此选项在质量与速度之间权衡。
+  chs: 在有损编码时，此选项在质量与速度之间权衡。
   jpn: ロッシーの場合、これは品質と速度のトレードオフになります。
   rus: Для lossy это компромисс между качеством и скоростью.
   por: Para os perdedores, esta é uma troca qualidade/velocidade.
@@ -2418,7 +2418,7 @@ Force HDR10 signaling:
   fra: Forcer la signalisation HDR10
   ita: Forza segnalazione HDR10
   spa: Señalización de la fuerza HDR10
-  zho: 强制发送HDR10信号
+  chs: 强制发送HDR10信号
   jpn: HDR10シグナリングを強制
   rus: Принудительная передача сигнала HDR10
   por: Forçar a sinalização HDR10
@@ -2433,7 +2433,7 @@ Frame Threads:
   fra: Fils de trame
   ita: Filettature del telaio
   spa: Hilos del marco
-  zho: 帧线程
+  chs: 帧线程
   jpn: フレーム スレッド
   rus: Кадровые потоки
   por: Roscas da moldura
@@ -2448,7 +2448,7 @@ Frames Per Second:
   fra: Images par seconde
   ita: Cornici al secondo
   spa: Cuadros por segundo
-  zho: 每秒帧数
+  chs: 每秒帧数
   jpn: 1秒ごとのフレーム数
   rus: Кадров в секунду
   por: Molduras por segundo
@@ -2463,7 +2463,7 @@ GPU:
   fra: GPU
   ita: GPU
   spa: GPU
-  zho: GPU
+  chs: GPU
   jpn: GPU
   rus: GPU
   por: GPU
@@ -2478,7 +2478,7 @@ GUI Logging Level:
   fra: Niveau d'exploitation forestière
   ita: Livello di registrazione GUI
   spa: Nivel de registro GUI
-  zho: GUI日志级别
+  chs: GUI日志级别
   jpn: GUIログレベル
   rus: Уровень ведения журнала графического интерфейса
   por: Nível de registo GUI
@@ -2493,7 +2493,7 @@ Gather FFmpeg audio encoders:
   fra: Rassembler les encodeurs audio FFmpeg
   ita: Raccogliere gli encoder audio FFmpeg
   spa: Reúne los codificadores de audio FFmpeg
-  zho: 获取FFmpeg音频编码器
+  chs: 获取FFmpeg音频编码器
   jpn: FFmpegオーディオエンコーダの取得
   rus: Соберите аудиокодеры FFmpeg
   por: Reunir codificadores de áudio FFmpeg
@@ -2508,7 +2508,7 @@ Gather FFmpeg version:
   fra: Rassembler la version FFmpeg
   ita: Raccogliere la versione FFmpeg
   spa: Reunir la versión FFmpeg
-  zho: 获取FFmpeg版本
+  chs: 获取FFmpeg版本
   jpn: FFmpegのバージョンを取得
   rus: Соберите версию FFmpeg
   por: Reúna a versão FFmpeg
@@ -2523,7 +2523,7 @@ Gather FFprobe version:
   fra: Rassembler la version FFprobe
   ita: Raccogliere la versione FFprobe
   spa: Reunir la versión FFprobe
-  zho: 获取FFprobe版本
+  chs: 获取FFprobe版本
   jpn: FFprobeのバージョンを集取得
   rus: Соберите версию FFprobe
   por: Reúna a versão FFprobe
@@ -2538,7 +2538,7 @@ Generating thumbnail:
   fra: Générer une vignette
   ita: Generazione di miniature
   spa: Generando la miniatura
-  zho: 正在生成缩略图
+  chs: 正在生成缩略图
   jpn: サムネイルの生成
   rus: Создание миниатюры
   por: Gerar miniatura
@@ -2553,7 +2553,7 @@ Google's VP9 HDR Encoding Guide:
   fra: Guide d'encodage HDR VP9 de Google
   ita: Guida alla codifica HDR VP9 di Google
   spa: Guía de codificación HDR VP9 de Google
-  zho: 谷歌VP9 HDR编码指南（英文）
+  chs: 谷歌VP9 HDR编码指南（英文）
   jpn: GoogleのVP9 HDRエンコーディングガイド（英語）
   rus: Руководство по кодированию VP9 HDR от Google
   por: Guia de Codificação HDR VP9 do Google
@@ -2568,7 +2568,7 @@ HDR -> SDR Tone Map:
   fra: HDR -> SDR Carte des tons
   ita: HDR -> Mappa dei toni SDR
   spa: HDR -> Mapa de tonos SDR
-  zho: HDR -> SDR色调映射
+  chs: HDR -> SDR色调映射
   jpn: HDR→SDRトーンマップ
   rus: HDR -> SDR Карта тонов
   por: HDR -> Mapa de Tom SDR
@@ -2583,7 +2583,7 @@ HDR10 Optimizations:
   fra: Optimisations du HDR10
   ita: Ottimizzazioni HDR10
   spa: Optimizaciones del HDR10
-  zho: HDR10优化
+  chs: HDR10优化
   jpn: HDR10の最適化
   rus: Оптимизация HDR10
   por: Otimizações HDR10
@@ -2598,7 +2598,7 @@ HDR10+ Metadata:
   fra: Métadonnées HDR10
   ita: HDR10+ Metadati
   spa: Metadatos HDR10+
-  zho: HDR10+元数据
+  chs: HDR10+元数据
   jpn: HDR10+メタデータ
   rus: Метаданные HDR10+
   por: HDR10+ Metadados
@@ -2613,7 +2613,7 @@ HDR10+ Metadata Extraction:
   fra: Extraction de métadonnées HDR10+.
   ita: Estrazione di metadati HDR10+
   spa: Extracción de metadatos HDR10+
-  zho: HDR10+元数据提取指南（英文）
+  chs: HDR10+元数据提取指南（英文）
   jpn: HDR10+メタデータの抽出
   rus: Извлечение метаданных HDR10+
   por: HDR10+ Extracção de Metadados
@@ -2628,7 +2628,7 @@ HDR10+ Optimizations:
   fra: Optimisations du HDR10
   ita: Ottimizzazioni HDR10+
   spa: Optimizaciones del HDR10+
-  zho: HDR10+优化
+  chs: HDR10+优化
   jpn: HDR10+の最適化
   rus: Оптимизация HDR10+
   por: HDR10+ Optimizações
@@ -2643,7 +2643,7 @@ Have to select a video first:
   fra: Il faut d'abord sélectionner une vidéo
   ita: Devi prima selezionare un video
   spa: Primero hay que seleccionar un video.
-  zho: 需要先选择一个视频
+  chs: 需要先选择一个视频
   jpn: 最初に動画を選択する必要があります。
   rus: Сначала нужно выбрать видео
   por: Ter de seleccionar primeiro um vídeo
@@ -2658,7 +2658,7 @@ Height:
   fra: Hauteur
   ita: Altezza
   spa: Altura
-  zho: 高度
+  chs: 高度
   jpn: 高さ
   rus: Высота
   por: Altura
@@ -2673,7 +2673,7 @@ Help:
   fra: Aide
   ita: Aiuto
   spa: Ayuda
-  zho: 帮助
+  chs: 帮助
   jpn: ヘルプ
   rus: Помощь
   por: Ajuda
@@ -2688,7 +2688,7 @@ Hide NAL unit messages:
   fra: Cacher les messages de l'unité NAL (AVC/HEVC Network Abstraction Layer)
   ita: Nascondere i messaggi delle unità NAL (AVC/HEVC Network Abstraction Layer)
   spa: Ocultar los mensajes de la unidad NAL (AVC/HEVC Network Abstraction Layer)
-  zho: 隐藏NAL unit（AVC/HEVC网络抽象层）消息
+  chs: 隐藏NAL unit（AVC/HEVC网络抽象层）消息
   jpn: NALユニットのメッセージを非表示にする
   rus: Скрыть сообщения устройства NAL
   por: Ocultar mensagens da unidade NAL
@@ -2703,7 +2703,7 @@ Horizontal Flip:
   fra: Renvoi horizontal
   ita: Capovolgimento orizzontale
   spa: Volteo horizontal
-  zho: 水平翻转
+  chs: 水平翻转
   jpn: 水平反転
   rus: Отражение по горизонтали
   por: Horizontal Flip
@@ -2718,7 +2718,7 @@ Init Q:
   fra: Init Q
   ita: Init Q
   spa: Init Q
-  zho: 启动Q
+  chs: 启动Q
   jpn: 初期化Q
   rus: Init Q
   por: Init Q
@@ -2733,7 +2733,7 @@ Initialize Encoders:
   fra: Initialiser les codeurs
   ita: Inizializzare gli encoder
   spa: Iniciar los codificadores
-  zho: 初始化编码器
+  chs: 初始化编码器
   jpn: エンコーダーの初期化
   rus: Инициализация энкодеров
   por: Inicializar codificadores
@@ -2748,7 +2748,7 @@ Intra-Encoding:
   fra: Intra-encodage
   ita: Intra-Encoding
   spa: Intracodificación
-  zho: Intra-Encoding
+  chs: Intra-Encoding
   jpn: イントラエンコーディング
   rus: Внутреннее кодирование
   por: Codificação Intra-Encodificação
@@ -2763,7 +2763,7 @@ Intra-Smoothing:
   fra: Intra-Lissage
   ita: Intra-Smoothing
   spa: Intra-Smoothing
-  zho: Intra-Smoothing
+  chs: Intra-Smoothing
   jpn: イントラ・スムージング
   rus: Внутреннее сглаживание
   por: Intra-Suave
@@ -2778,7 +2778,7 @@ Intra-refresh:
   fra: Intra-refresh
   ita: Intra-refresh
   spa: Intra-refresco
-  zho: 帧内刷新
+  chs: 帧内刷新
   jpn: イントラリフレシュ
   rus: Внутреннее обновление
   por: Intra-refresco
@@ -2793,7 +2793,7 @@ Invalid Crop:
   fra: Récolte non valable
   ita: Raccolto non valido
   spa: Cultivo inválido
-  zho: 无效裁切
+  chs: 无效裁切
   jpn: 無効なクロップ
   rus: Неверная обрезка
   por: Cultura inválida
@@ -2809,7 +2809,7 @@ It is recommended that AQ-mode be enabled along with this feature:
   fra: Il est recommandé d'activer le mode AQ en même temps que cette fonction
   ita: Si raccomanda di abilitare la modalità AQ insieme a questa funzione
   spa: Se recomienda que el modo AQ se active junto con esta función
-  zho: 使用该功能时建议同时启用自适应量化。
+  chs: 使用该功能时建议同时启用自适应量化。
   jpn: この機能と併せてAQモードを有効にすることを推奨します。
   rus: Рекомендуется включить режим AQ вместе с этой функцией
   por: Recomenda-se que o AQ-mode seja activado juntamente com esta funcionalidade
@@ -2827,7 +2827,7 @@ It saves a few bits and can help performance in the client's tonemapper.:
     del cliente.
   spa: Ahorra unos pocos bits y puede ayudar al rendimiento en el mapa de tonos del
     cliente.
-  zho: 能够节省一些数据量，并有益于播放端色调映射的性能。
+  chs: 能够节省一些数据量，并有益于播放端色调映射的性能。
   jpn: これによりビットが少し節約され、クライアントのトーンマッパーのパフォーマンスが向上します。
   rus: Это экономит несколько битов и может повысить производительность клиентского
     тонального маппера.
@@ -2844,7 +2844,7 @@ Keep:
   fra: Conservez
   ita: Conservare
   spa: Manténgase en
-  zho: 保留
+  chs: 保留
   jpn: キープ
   rus: Сохранить
   por: Guarde
@@ -2859,7 +2859,7 @@ Keep FastFlix Open:
   fra: Gardez FastFlix ouvert
   ita: Tenere aperto FastFlix
   spa: Mantener FastFlix abierto
-  zho: 保持FastFlix运行
+  chs: 保持FastFlix运行
   jpn: FastFlixのオープンを維持する
   rus: Держите FastFlix открытым
   por: Manter FastFlix aberto
@@ -2874,7 +2874,7 @@ Keep aspect ratio:
   fra: Conserver le rapport d'aspect
   ita: Mantenere il rapporto di aspetto
   spa: Mantener la relación de aspecto
-  zho: 保持纵横比
+  chs: 保持纵横比
   jpn: アスペクト比を保つ
   rus: Сохранять соотношение сторон
   por: Manter relação de aspecto
@@ -2889,7 +2889,7 @@ LICENSES:
   fra: LICENCES
   ita: LICENZE
   spa: LICENCIAS
-  zho: 许可
+  chs: 许可
   jpn: ライセンス
   rus: ЛИЦЕНЗИИ
   por: LICENÇAS
@@ -2904,7 +2904,7 @@ Landscape Cover:
   fra: Couverture du paysage
   ita: Copertura del paesaggio
   spa: Cubierta del paisaje
-  zho: 横向封面
+  chs: 横向封面
   jpn: ランドスケープカバー
   rus: Пейзажная обложка
   por: Cobertura paisagística
@@ -2919,7 +2919,7 @@ Language:
   fra: Langue
   ita: Lingua
   spa: Idioma
-  zho: 语言
+  chs: 语言
   jpn: 言語
   rus: Язык
   por: Idioma
@@ -2934,7 +2934,7 @@ Left:
   fra: Gauche
   ita: Sinistra
   spa: Izquierda
-  zho: 左侧
+  chs: 左侧
   jpn: 左
   rus: Слева
   por: Esquerda
@@ -2949,7 +2949,7 @@ Level:
   fra: Niveau
   ita: Livello
   spa: Nivel
-  zho: 级别
+  chs: 级别
   jpn: レベル
   rus: Уровень
   por: Nível
@@ -2966,7 +2966,7 @@ Log2 of number of tile columns to encode faster (lesser quality):
   ita: Log2 del numero di colonne di tegole da codificare più velocemente (qualità
     inferiore)
   spa: Log2 del número de columnas de azulejos para codificar más rápido (menor calidad)
-  zho: 块的列数的Log2来快速编码（画质降低）
+  chs: 块的列数的Log2来快速编码（画质降低）
   jpn: タイルの列数のLog2で、より高速にエンコードする（画質は落ちる）。
   rus: Log2 количества столбцов плитки для более быстрого кодирования (меньшее качество)
   por: Log2 de número de colunas de ladrilhos para codificar mais rapidamente (menor
@@ -2983,7 +2983,7 @@ Log2 of number of tile rows to encode faster (lesser quality):
   fra: Log2 du nombre de rangées de tuiles pour un encodage plus rapide (qualité moindre)
   ita: Log2 del numero di file di tegole da codificare più velocemente (qualità inferiore)
   spa: Log2 del número de filas de azulejos para codificar más rápido (menor calidad)
-  zho: 块的行数的Log2来快速编码（画质降低）
+  chs: 块的行数的Log2来快速编码（画质降低）
   jpn: タイル列数のLog2で、より高速にエンコードする（画質は落ちる）。
   rus: Log2 числа рядов плиток для более быстрого кодирования (меньшее качество)
   por: Log2 do número de filas de azulejos a codificar mais rapidamente (menor qualidade)
@@ -2999,7 +2999,7 @@ Lookahead:
   fra: Lookahead
   ita: Lookahead
   spa: Lookahead
-  zho: 看前面
+  chs: 看前面
   jpn: 前のフレームを参照
   rus: Опережение
   por: Lookahead
@@ -3014,7 +3014,7 @@ Lossless:
   fra: Sans Perte
   ita: Senza Perdite
   spa: Lossless
-  zho: 无损编码
+  chs: 无损编码
   jpn: ロスレス
   rus: Без потерь
   por: Sem perdas
@@ -3034,7 +3034,7 @@ Lossless encodes implicitly have no rate control, all rate control options are i
     le opzioni di controllo del tasso sono ignorate.
   spa: Los códigos sin pérdidas implícitamente no tienen control de la tasa, todas
     las opciones de control de la tasa son ignoradas.
-  zho: 无损编码意味着没有码率控制，会忽略所有码率控制选项。
+  chs: 无损编码意味着没有码率控制，会忽略所有码率控制选项。
   jpn: ロスレスエンコードでは、レートコントロールが行われず、すべてのレートコントロールオプションは無視されます。
   rus: Кодирование без потерь неявно не имеет контроля скорости, все опции контроля
     скорости игнорируются.
@@ -3055,7 +3055,7 @@ Max Muxing Queue Size:
   fra: Taille maximale de la file d'attente
   ita: Dimensione massima della coda di Muxing
   spa: Tamaño máximo de la cola Muxing
-  zho: 最大混流队列大小
+  chs: 最大混流队列大小
   jpn: 最大ミキシングキューサイズ
   rus: Максимальный размер очереди мультиплексирования
   por: Tamanho Máximo da Fila de Muxing
@@ -3070,7 +3070,7 @@ Max Q:
   fra: Max Q
   ita: Q massimo
   spa: Max Q
-  zho: Q的最大值
+  chs: Q的最大值
   jpn: Qの最大値
   rus: Макс Q
   por: Máximo Q
@@ -3085,7 +3085,7 @@ Maximum B frames:
   fra: Cadres B maximum
   ita: Telaio massimo B
   spa: Máximo de cuadros B
-  zho: 最大B帧数量
+  chs: 最大B帧数量
   jpn: 最大Bフレーム
   rus: Максимум кадров B
   por: Máximo de armações B
@@ -3100,7 +3100,7 @@ Maximum B frames:
   fra: "Nombre maximum d'images B consécutives. "
   ita: 'Numero massimo di b-frame consecutivi. '
   spa: 'Número máximo de fotogramas B consecutivos. '
-  zho: 连续b帧的最大数量。
+  chs: 连续b帧的最大数量。
   jpn: 連続するb-フレームの最大数。
   rus: Максимальное количество последовательных b-кадров.
   por: Número máximo de b-frames consecutivos.
@@ -3115,7 +3115,7 @@ Maxrate:
   fra: Maxrate
   ita: Maxrate
   spa: Maxrate
-  zho: Maxrate
+  chs: Maxrate
   jpn: マックスレート
   rus: Максимальная скорость
   por: Maxrate
@@ -3130,7 +3130,7 @@ Metrics:
   fra: Métriques
   ita: Metriche
   spa: Métricas
-  zho: 统计数据
+  chs: 统计数据
   jpn: メトリクス
   rus: Метрики
   por: Métricas
@@ -3145,7 +3145,7 @@ Min Q:
   fra: Min Q
   ita: Min Q
   spa: Q mínimo
-  zho: Q最小值
+  chs: Q最小值
   jpn: Qの最小値
   rus: Мин Q
   por: Min Q
@@ -3160,7 +3160,7 @@ Motion vector accuracy:
   fra: Précision du vecteur de mouvement
   ita: Precisione del vettore di movimento
   spa: Precisión del vector de movimiento
-  zho: 运动矢量精度
+  chs: 运动矢量精度
   jpn: モーションベクトルの精度
   rus: Точность вектора движения
   por: Precisão do vector de movimento
@@ -3175,7 +3175,7 @@ Multipass:
   fra: Multipass
   ita: Multipass
   spa: Multipass
-  zho: 多次
+  chs: 多次
   jpn: 数回
   rus: Многопроходная
   por: Multipass
@@ -3190,7 +3190,7 @@ NVEncC Encoder support is still experimental!:
   fra: Le support des encodeurs NVEncC est encore expérimental !
   ita: Il supporto NVEncC Encoder è ancora sperimentale!
   spa: La compatibilidad con el codificador NVEncC es todavía experimental.
-  zho: NVEncC编码器支持仍然是实验性的!
+  chs: NVEncC编码器支持仍然是实验性的!
   jpn: NVEncCエンコーダのサポートはまだ実験的なものです。
   rus: Поддержка NVEncC Encoder все еще является экспериментальной!
   por: O suporte do codificador NVEncC ainda é experimental!
@@ -3205,7 +3205,7 @@ NVEncC Options:
   fra: Options NVEncC
   ita: Opzioni NVEncC
   spa: Opciones de NVEncC
-  zho: NVEncC选项
+  chs: NVEncC选项
   jpn: NVEncCオプション
   rus: Опции NVEncC
   por: Opções NVEncC
@@ -3220,7 +3220,7 @@ New Profile:
   fra: Nouveau profil
   ita: Nuovo profilo
   spa: Nuevo perfil
-  zho: 新建配置
+  chs: 新建配置
   jpn: プロフィールの新規作成
   rus: Новый профиль
   por: Novo perfil
@@ -3235,7 +3235,7 @@ New Version:
   fra: Nouvelle version
   ita: Nuova versione
   spa: Nueva versión
-  zho: 新版本
+  chs: 新版本
   jpn: 新バージョン
   rus: Новая версия
   por: Nova versão
@@ -3250,7 +3250,7 @@ No:
   fra: Non
   ita: No
   spa: No
-  zho: 否
+  chs: 否
   jpn: いいえ
   rus: Нет
   por: Não
@@ -3265,7 +3265,7 @@ No Downmix:
   fra: Pas de Downmix
   ita: No Downmix
   spa: No hay Downmix
-  zho: 无缩混
+  chs: 无缩混
   jpn: ダウンミックスなし
   rus: Без понижающего микширования
   por: Sem Downmix
@@ -3280,7 +3280,7 @@ No Flip:
   fra: Pas de retournement
   ita: Senza capovolgere
   spa: No hay vuelta atrás
-  zho: 无翻转
+  chs: 无翻转
   jpn: 反転なし
   rus: Без поворота
   por: Sem Flip
@@ -3295,7 +3295,7 @@ No Rotation:
   fra: Pas de rotation
   ita: Nessuna rotazione
   spa: No hay rotación
-  zho: 无旋转
+  chs: 无旋转
   jpn: 回転なし
   rus: Без вращения
   por: Sem Rotação
@@ -3310,7 +3310,7 @@ No Source Selected:
   fra: Aucune source sélectionnée
   ita: Nessuna fonte selezionata
   spa: No se ha seleccionado ninguna fuente
-  zho: 未选择源文件
+  chs: 未选择源文件
   jpn: ソース選択されていない
   rus: Источник не выбран
   por: Nenhuma Fonte Seleccionada
@@ -3325,7 +3325,7 @@ No Video File:
   fra: Pas de fichier vidéo
   ita: Nessun file video
   spa: No hay archivo de video
-  zho: 没有视频文件
+  chs: 没有视频文件
   jpn: 動画ファイルなし
   rus: Нет видеофайла
   por: Nenhum ficheiro de vídeo
@@ -3340,7 +3340,7 @@ No command found for:
   fra: Aucune commande trouvée pour
   ita: Nessun comando trovato per
   spa: No se encontró ningún comando para
-  zho: 没有找到命令
+  chs: 没有找到命令
   jpn: のコマンドが見つかりません。
   rus: Не найдена команда для
   por: Nenhum comando encontrado para
@@ -3359,7 +3359,7 @@ No crop, scale, rotation, flip nor any other filters will be applied.:
     o altri filtri.
   spa: No se aplicará ningún filtro de cultivo, de escala, de rotación, de volteo
     ni ningún otro.
-  zho: 不会应用裁切、缩放、旋转、翻转或任何其他滤镜。
+  chs: 不会应用裁切、缩放、旋转、翻转或任何其他滤镜。
   jpn: 切り抜き、拡大縮小、回転、反転などのフィルターはかけられません。
   rus: Обрезка, масштабирование, вращение, переворот и другие фильтры не применяются.
   por: Não se aplicarão culturas, escamas, rotação, flip nem quaisquer outros filtros.
@@ -3377,7 +3377,7 @@ No encoding is currently in process, starting encode:
   fra: Aucun codage n'est actuellement en cours, le codage de départ
   ita: Nessuna codifica è attualmente in corso, iniziando a codificare
   spa: Ninguna codificación está actualmente en proceso, comenzando a codificar
-  zho: 目前没有正在进行的编码，编码开始。
+  chs: 目前没有正在进行的编码，编码开始。
   jpn: 現在エンコード中のものはない。エンコード開始
   rus: В настоящее время кодирование не выполняется, начинаем кодирование
   por: Nenhuma codificação está actualmente em processo, começando a codificação
@@ -3392,7 +3392,7 @@ No new items in queue to convert:
   fra: Pas de nouveaux éléments à convertir dans la file d'attente
   ita: Nessun nuovo elemento in coda per la conversione
   spa: No hay nuevos elementos en la cola para convertir
-  zho: 队列中没有新项目要转换
+  chs: 队列中没有新项目要转换
   jpn: 変換するためのキューに新しいアイテムがない
   rus: Нет новых элементов в очереди на конвертацию
   por: Não há artigos novos em fila de espera para converter
@@ -3407,7 +3407,7 @@ No video found for:
   fra: Aucune vidéo trouvée pour
   ita: Nessun video trovato per
   spa: No se ha encontrado ningún vídeo para
-  zho: 没有找到视频
+  chs: 没有找到视频
   jpn: のビデオは見つかりませんでした。
   rus: Не найдено видео для
   por: Nenhum vídeo encontrado para
@@ -3422,7 +3422,7 @@ None:
   fra: Aucune
   ita: Nessuno
   spa: Ninguno
-  zho: 无
+  chs: 无
   jpn: なし
   rus: Нет
   por: Nenhum
@@ -3437,7 +3437,7 @@ Not a valid int for time conversion:
   fra: Pas d'int valable pour la conversion du temps
   ita: Non è un int valido per la conversione del tempo
   spa: No es un int válido para la conversión de tiempo
-  zho: 不是可用于时间转换的有效整数
+  chs: 不是可用于时间转换的有效整数
   jpn: 時間変換に有効な整数値ではない
   rus: Недопустимое значением int для преобразования времени
   por: Não é uma int válida para conversão de tempo
@@ -3452,7 +3452,7 @@ Not a video file:
   fra: Pas un fichier vidéo
   ita: Non un file video
   spa: No es un archivo de video
-  zho: 不是视频文件
+  chs: 不是视频文件
   jpn: 動画ファイルではありません
   rus: Не видеофайл
   por: Não é um ficheiro de vídeo
@@ -3472,7 +3472,7 @@ Only put the HDR10+ dynamic metadata in the IDR and frames where the values have
     sono cambiati.
   spa: Sólo pon los metadatos dinámicos HDR10+ en el IDR y los cuadros donde los valores
     han cambiado.
-  zho: 仅将HDR10+动态元数据置于其值发生改变的帧及IDR帧。
+  chs: 仅将HDR10+动态元数据置于其值发生改变的帧及IDR帧。
   jpn: HDR10+のダイナミックメタデータは、IDRと値が変化したフレームにのみ入れます。
   rus: Поместите динамические метаданные HDR10+ только в IDR и кадры, где значения
     изменились.
@@ -3491,7 +3491,7 @@ Only select first matching Audio Track:
   fra: Ne sélectionnez que la première piste audio correspondante
   ita: Selezionare solo la prima traccia audio corrispondente
   spa: Sólo seleccione la primera pista de audio que coincida
-  zho: 只选择第一条匹配的音轨
+  chs: 只选择第一条匹配的音轨
   jpn: 最初に一致したオーディオトラックのみを選択
   rus: Выберите только первую подходящую звуковую дорожку
   por: Seleccionar apenas a primeira faixa de áudio correspondente
@@ -3506,7 +3506,7 @@ Only select first matching Subtitle Track:
   fra: Ne sélectionnez que la première piste de sous-titres correspondante
   ita: Selezionare solo la prima traccia di sottotitoli corrispondente
   spa: Sólo seleccione la primera pista de subtítulos que coincida
-  zho: 只选择第一条匹配的字幕轨
+  chs: 只选择第一条匹配的字幕轨
   jpn: 最初にマッチした字幕トラックのみを選択
   rus: Выберите только первую подходящую дорожку субтитров
   por: Seleccionar apenas a primeira faixa de subtítulos correspondente
@@ -3521,7 +3521,7 @@ Open Directory:
   fra: Open Directory
   ita: Elenco aperto
   spa: Directorio Abierto
-  zho: 打开目录
+  chs: 打开目录
   jpn: ディレクトリを開く
   rus: Открыть каталог
   por: Directório Aberto
@@ -3536,7 +3536,7 @@ Open Log Directory:
   fra: Répertoire des journaux ouverts
   ita: Aprire l'elenco dei log
   spa: Directorio abierto de registros
-  zho: 打开日志目录
+  chs: 打开日志目录
   jpn: ログのディレクトリを開く
   rus: Открыть каталог журналов
   por: Directório de Registo Aberto
@@ -3551,7 +3551,7 @@ Output:
   fra: Sortie
   ita: Uscita
   spa: Salida
-  zho: 输出文件
+  chs: 输出文件
   jpn: 出力
   rus: Результат
   por: Saída
@@ -3566,7 +3566,7 @@ Output FPS:
   fra: Sortie SPF
   ita: Uscita FPS
   spa: Salida FPS
-  zho: 输出帧率
+  chs: 输出帧率
   jpn: 出力FPS
   rus: Выходной FPS
   por: FPS de saída
@@ -3582,7 +3582,7 @@ Over-allocation of frame threads will not improve performance,:
   fra: Une allocation excessive des fils de trame n'améliorera pas les performances,
   ita: La sovra-assegnazione delle filettature del telaio non migliorerà le prestazioni,
   spa: La sobreasignación de hilos del marco no mejorará el rendimiento,
-  zho: 过多分配帧线程无法提高性能，
+  chs: 过多分配帧线程无法提高性能，
   jpn: フレームスレッドを過剰に割り当てても、パフォーマンスは向上しません。
   rus: Избыточное распределение потоков кадров не улучшит производительность,
   por: A sobre-atribuição de fios de moldura não melhorará o desempenho,
@@ -3597,7 +3597,7 @@ Overlay this subtitle track onto the video during conversion.:
   fra: Superposez cette piste de sous-titres sur la vidéo pendant la conversion.
   ita: Sovrapponete questa traccia di sottotitoli al video durante la conversione.
   spa: Superponga esta pista de subtítulos en el vídeo durante la conversión.
-  zho: 在转换时将此字幕轨叠加到视频上。
+  chs: 在转换时将此字幕轨叠加到视频上。
   jpn: 変換時にこの字幕トラックを映像に重ねて表示します。
   rus: Наложить эту дорожку субтитров на видео во время конвертирования.
   por: Sobreponha esta faixa de legendas no vídeo durante a conversão.
@@ -3612,7 +3612,7 @@ Override Source FPS:
   fra: Annuler la source FPS
   ita: Annullare la sorgente FPS
   spa: Anular el FPS de la fuente
-  zho: 覆盖源文件帧率
+  chs: 覆盖源文件帧率
   jpn: ソースFPSをオーバーライド
   rus: Переопределение исходного FPS
   por: Substituir Fonte FPS
@@ -3627,7 +3627,7 @@ Override the preset rate-control:
   fra: Annuler le contrôle des taux préétablis
   ita: Sovrascrivere il controllo del tasso preimpostato
   spa: Anula el control de velocidad preestablecido
-  zho: 覆盖预设的速率控制
+  chs: 覆盖预设的速率控制
   jpn: プリセットレートコントロールのオーバーライド
   rus: Отмена предустановленного регулирования скорости
   por: Anular o controlo da taxa pré-definida
@@ -3646,7 +3646,7 @@ PIR can replace keyframes by inserting a column of intra blocks in non-keyframes
     non-keyframe,
   spa: PIR puede reemplazar los fotogramas clave insertando una columna de intrabloques
     en los fotogramas no clave,
-  zho: PIR可以在非关键帧中插入一列intra blocks，从而替代关键帧。
+  chs: PIR可以在非关键帧中插入一列intra blocks，从而替代关键帧。
   jpn: PIRは、非キーフレームにイントラブロックの列を挿入することで、キーフレームを置き換えることができます。
   rus: PIR может заменить ключевые кадры, вставляя колонку внутренних блоков в неключевые
     кадры,
@@ -3666,7 +3666,7 @@ Parse Video details:
   fra: Détails de la vidéo de Parse
   ita: Dettagli Parse Video
   spa: Detalles del video de análisis
-  zho: 解析视频详情
+  chs: 解析视频详情
   jpn: ビデオの詳細を解析する
   rus: Разбор деталей видео
   por: Detalhes do vídeo de Parse
@@ -3681,7 +3681,7 @@ Pause / Resume the current command:
   fra: Pause / Reprise de la commande en cours
   ita: Pausa / Riprendere il comando corrente
   spa: Pausa / Reanudar el comando actual
-  zho: 暂停/恢复当前命令
+  chs: 暂停/恢复当前命令
   jpn: 現在のコマンドを一時停止／再開する
   rus: Приостановить / возобновить выполнение текущей команды
   por: Pausa / Retomar o comando actual
@@ -3696,7 +3696,7 @@ Pause Encode:
   fra: Pause Encode
   ita: Pausa Codificare
   spa: Codificar la pausa
-  zho: 暂停编码
+  chs: 暂停编码
   jpn: エンコードを一時停止する
   rus: Приостановить кодирование
   por: Codificação de Pausa
@@ -3711,7 +3711,7 @@ Pause Queue:
   fra: Pause
   ita: Coda di pausa
   spa: Pausa de la cola
-  zho: 暂停队列
+  chs: 暂停队列
   jpn: キューを一時停止する
   rus: Приостановить очередь
   por: Fila de Pausa
@@ -3726,7 +3726,7 @@ Pixel Format (requires at least 10-bit for HDR):
   fra: Format Pixel (nécessite au moins 10 bits pour le HDR)
   ita: Formato pixel (richiede almeno 10 bit per HDR)
   spa: Formato de píxeles (requiere al menos 10 bits para el HDR)
-  zho: 像素格式（HDR要求至少10-bit）
+  chs: 像素格式（HDR要求至少10-bit）
   jpn: ピクセルフォーマット（HDRでは10ビット以上が必要）
   rus: Формат пикселей (для HDR требуется не менее 10 бит)
   por: Formato Pixel (requer pelo menos 10 bits para HDR)
@@ -3741,7 +3741,7 @@ Please make sure seek method is set to exact:
   fra: Veuillez vous assurer que la méthode de recherche est réglée sur l'exacte
   ita: Si prega di assicurarsi che il metodo di ricerca sia impostato su
   spa: Por favor, asegúrese de que el método de búsqueda se establece con exactitud
-  zho: 请确保检索方式已设置为exact
+  chs: 请确保检索方式已设置为exact
   jpn: seek methodがexactに設定されていることを確認してください。
   rus: Пожалуйста, убедитесь, что метод поиска установлен на точный
   por: Por favor, certifique-se de que o método de busca está definido de forma exacta
@@ -3756,7 +3756,7 @@ Please provide a profile name:
   fra: Veuillez fournir un nom de profil
   ita: Si prega di fornire un nome di profilo
   spa: Por favor, proporcione un nombre de perfil
-  zho: 请提供配置名称
+  chs: 请提供配置名称
   jpn: プロフィール名を入力してください
   rus: Пожалуйста, укажите имя профиля
   por: Por favor forneça um nome de perfil
@@ -3771,7 +3771,7 @@ Please report this issue:
   fra: Veuillez signaler ce problème
   ita: Si prega di segnalare questo problema
   spa: Por favor, informe de este asunto
-  zho: 请报告这个问题
+  chs: 请报告这个问题
   jpn: この問題を報告してください
   rus: Пожалуйста, сообщите об этой проблеме
   por: Por favor, informe este número
@@ -3786,7 +3786,7 @@ Please restart FastFlix to apply settings:
   fra: Por favor, reinicie FastFlix para aplicar la configuración
   ita: Riavviare FastFlix per applicare le impostazioni
   spa: Por favor, reinicie FastFlix para aplicar la configuración
-  zho: 请重新启动FastFlix以应用设置
+  chs: 请重新启动FastFlix以应用设置
   jpn: 設定を適用するには、FastFlixを再起動してください。
   rus: Пожалуйста, перезапустите FastFlix для применения настроек
   por: Por favor reinicie FastFlix para aplicar definições
@@ -3801,7 +3801,7 @@ Poster Cover:
   fra: Couverture de l'affiche
   ita: Copertina per poster
   spa: Cubierta del cartel
-  zho: 纵向封面
+  chs: 纵向封面
   jpn: ポスターカバー
   rus: Обложка плаката
   por: Capa do cartaz
@@ -3816,7 +3816,7 @@ Preserve:
   fra: Préserver
   ita: Conservare
   spa: Preservar
-  zho: 保留
+  chs: 保留
   jpn: 保留
   rus: Сохранить
   por: Conservar
@@ -3831,7 +3831,7 @@ Preset:
   fra: Préréglage
   ita: Preset
   spa: Preset
-  zho: 预设
+  chs: 预设
   jpn: プリセット
   rus: Предустановка
   por: Predefinição
@@ -3846,13 +3846,13 @@ Profile Name:
   fra: Nom du profil
   ita: Nome del profilo
   spa: Nombre del perfil
-  zho: 配置名称
+  chs: 配置名称
   jpn: プロフィール名
   rus: Имя профиля
   por: Nome do perfil
   swe: Profilnamn
   pol: Nazwa profilu
-  ukr: 'Ім'я профілю Ім'я профілю'
+  ukr: Імя профілю
   kor: 프로필 이름
   ron: Numele profilului
 Profile_encoderopt:
@@ -3861,7 +3861,7 @@ Profile_encoderopt:
   fra: Profil
   ita: Profilo
   spa: Perfil
-  zho: 配置
+  chs: 配置
   jpn: プロフィール
   rus: Профиль_опции_энкодера
   por: Perfil
@@ -3876,7 +3876,7 @@ Profile_newprofiletooltip:
   fra: Profil
   ita: Profilo
   spa: Perfil
-  zho: 配置
+  chs: 配置
   jpn: プロフィール
   rus: Профиль_подсказка_нового_профиля
   por: Perfil
@@ -3891,7 +3891,7 @@ Profile_window:
   fra: Profil
   ita: Profilo
   spa: Perfil
-  zho: 配置
+  chs: 配置
   jpn: プロフィール
   rus: Профиль_окно
   por: Perfil
@@ -3906,7 +3906,7 @@ Profiles:
   fra: Profils
   ita: Profili
   spa: Perfiles
-  zho: 配置
+  chs: 配置
   jpn: プロフィール
   rus: Профили
   por: Perfis
@@ -3921,7 +3921,7 @@ Python:
   fra: Python
   ita: Python
   spa: Python
-  zho: Python
+  chs: Python
   jpn: Python
   rus: Python
   por: Python
@@ -3936,7 +3936,7 @@ Q-pel is highest precision:
   fra: Le Q-pel est de la plus haute précision
   ita: Q-pel è la massima precisione
   spa: Q-pel es la máxima precisión
-  zho: Q-pel是最高精度
+  chs: Q-pel是最高精度
   jpn: Q-pelは最高精度
   rus: Q-pel - высочайшая точность
   por: Q-pel é da mais alta precisão
@@ -3951,7 +3951,7 @@ Quality:
   fra: Qualité
   ita: Qualità
   spa: Calidad
-  zho: 质量
+  chs: 质量
   jpn: 品質
   rus: Качество
   por: Qualidade
@@ -3967,7 +3967,7 @@ Quality and compression efficiency vs speed trade-off:
   ita: Qualità ed efficienza di compressione rispetto al compromesso velocità
   spa: La calidad y la eficiencia de la compresión frente a la compensación de la
     velocidad
-  zho: 在质量及压缩效率与速度之间进行权衡
+  chs: 在质量及压缩效率与速度之间进行权衡
   jpn: 画質と圧縮効率と速度のトレードオフ
   rus: Компромисс между качеством и эффективностью сжатия и скоростью
   por: Qualidade e eficiência de compressão vs. compromisso de velocidade
@@ -3982,7 +3982,7 @@ Quality/Speed ratio modifier:
   fra: Modificateur du rapport qualité/vitesse
   ita: Modificatore rapporto qualità/velocità
   spa: Modificador de la relación calidad/velocidad
-  zho: 调整质量与速度之比
+  chs: 调整质量与速度之比
   jpn: 画質・速度の調整
   rus: Регулятор соотношения качества и скорости
   por: Modificador da relação qualidade/velocidade
@@ -3997,7 +3997,7 @@ Quality/Speed ratio modifier (defaults to -1):
   fra: Modificateur du rapport qualité/vitesse (par défaut à -1)
   ita: Modificatore del rapporto qualità/velocità (valori predefiniti a -1)
   spa: Modificador de la relación calidad/velocidad (por defecto a -1)
-  zho: 调整质量与速度之比（默认值为-1)
+  chs: 调整质量与速度之比（默认值为-1)
   jpn: 品質／速度比の修正（デフォルトは-1）
   rus: Регулятор соотношения качества и скорости (по умолчанию -1)
   por: Modificador da relação qualidade/velocidade (valores por defeito para -1)
@@ -4012,7 +4012,7 @@ Quality/Speed ratio modifier (defaults to 4):
   fra: Modificateur du rapport qualité/vitesse (par défaut à 4)
   ita: Modificatore del rapporto qualità/velocità (valori predefiniti a 4)
   spa: Modificador de la relación calidad/velocidad (por defecto a 4)
-  zho: 调整质量与速度之比（默认值为4）
+  chs: 调整质量与速度之比（默认值为4）
   jpn: Quality/Speed ratio modifier (デフォルトは4)
   rus: Регулятор соотношения качества и скорости (по умолчанию равен 4)
   por: Modificador da relação qualidade/velocidade (padrão para 4)
@@ -4027,7 +4027,7 @@ Queue:
   fra: Queue
   ita: Coda
   spa: Cola
-  zho: 队列
+  chs: 队列
   jpn: キュー
   rus: Очередь
   por: Fila
@@ -4042,7 +4042,7 @@ Queue has been paused:
   fra: La cola se ha detenido
   ita: La coda è stata messa in pausa
   spa: La cola se ha detenido
-  zho: 队列已暂停
+  chs: 队列已暂停
   jpn: キューは一時停止している
   rus: Очередь была приостановлена
   por: A fila foi interrompida
@@ -4057,7 +4057,7 @@ RC Lookahead:
   fra: RC Lookahead
   ita: RC Lookahead
   spa: RC Lookahead
-  zho: RC Lookahead
+  chs: RC Lookahead
   jpn: RC Lookahead
   rus: RC Опережение
   por: RC Lookahead
@@ -4077,7 +4077,7 @@ Raise or lower per-block quantization based on complexity analysis of the source
     complessità dell'immagine sorgente.
   spa: Aumentar o disminuir la cuantificación por bloque basada en el análisis de
     la complejidad de la imagen de origen.
-  zho: 根据对源图像的复杂度分析，提升或降低各个块的量化。
+  chs: 根据对源图像的复杂度分析，提升或降低各个块的量化。
   jpn: ソース画像の複雑さの分析に基づいて、ブロックごとの量子化率を上げるか下げる。
   rus: Повышение или понижение блочного квантования на основе анализа сложности исходного
     изображения.
@@ -4098,7 +4098,7 @@ Rate Control:
   fra: Contrôle des tarifs
   ita: Controllo della velocità
   spa: Control de velocidad
-  zho: 速度控制
+  chs: 速度控制
   jpn: レート制御
   rus: Контроль скорости
   por: Controlo da taxa
@@ -4113,7 +4113,7 @@ Raw Commands:
   fra: Commandes brutes
   ita: Comandi grezzi
   spa: Comandos en bruto
-  zho: 原始命令
+  chs: 原始命令
   jpn: 生コマンド
   rus: Необработанные команды
   por: Comandos em bruto
@@ -4128,7 +4128,7 @@ Ready to encode:
   fra: Prêt à encoder
   ita: Pronto a codificare
   spa: Listo para codificar
-  zho: 准备好编码
+  chs: 准备好编码
   jpn: エンコードの準備できました
   rus: Готовность к кодированию
   por: Pronto a codificar
@@ -4145,7 +4145,7 @@ Reconstructed output pictures are bit-exact to the input pictures.:
   ita: Le immagini di uscita ricostruite sono bit-esatte alle immagini di ingresso.
   spa: Las imágenes de salida reconstruidas son un poco exactas a las imágenes de
     entrada.
-  zho: 重建后的输出图像与输入图像是逐位一致（bit-exact）的。
+  chs: 重建后的输出图像与输入图像是逐位一致（bit-exact）的。
   jpn: 再構成された出力画像は、入力画像とビットが一致しています。
   rus: Реконструированные выходные изображения являются битово-точными по отношению
     к входным изображениям.
@@ -4163,7 +4163,7 @@ Ref Frames:
   fra: Ref Frames
   ita: Fotogrammi di rif.
   spa: Fotogramas de referencia
-  zho: 参考帧
+  chs: 参考帧
   jpn: リファレンスフレーム
   rus: Реф-кадры
   por: Molduras de Reformas
@@ -4178,8 +4178,8 @@ Remove HDR:
   fra: Supprimer le HDR
   ita: Rimuovere HDR
   spa: Eliminar HDR
-  zho: 去除HDR
-  jpn: HDRの削除
+  chs: 去除HDR
+  jpn: HDRを削除
   rus: Удалить HDR
   por: Retirar o HDR
   swe: Ta bort HDR
@@ -4193,8 +4193,8 @@ Remove Metadata:
   fra: Supprimer les métadonnées
   ita: Rimuovere i metadati
   spa: Eliminar los metadatos
-  zho: 去除元数据
-  jpn: メタデータの削除
+  chs: 去除元数据
+  jpn: メタデータを削除
   rus: Удалить метаданные
   por: Remover Metadados
   swe: Ta bort metadata
@@ -4208,7 +4208,7 @@ Remove completed tasks:
   fra: Supprimer les tâches terminées
   ita: Rimuovere i compiti completati
   spa: Eliminar las tareas completadas
-  zho: 删除已完成的任务
+  chs: 删除已完成的任务
   jpn: 完了したタスクを削除する
   rus: Удалить выполненные задания
   por: Retirar tarefas concluídas
@@ -4223,7 +4223,7 @@ Removing after done command:
   fra: Suppression après commande
   ita: Rimozione dopo aver eseguito il comando
   spa: Retirar después de la orden hecha
-  zho: 在完成命令后删除
+  chs: 在完成命令后删除
   jpn: 完了したコマンドの後に削除する
   rus: Удаление после выполнения команды
   por: Remoção após comando feito
@@ -4238,7 +4238,7 @@ Repeat Headers:
   fra: Répéter les en-têtes
   ita: Ripetere le intestazioni
   spa: Repetición de los encabezados
-  zho: 重复标头
+  chs: 重复标头
   jpn: ヘッダー重複
   rus: Повторяющиеся заголовки
   por: Cabeçalhos de repetição
@@ -4253,7 +4253,7 @@ Report Issue:
   fra: Numéro du rapport
   ita: Segnala il problema
   spa: Informe
-  zho: 报告问题
+  chs: 报告问题
   jpn: 問題を報告
   rus: Выпуск отчета
   por: Edição do relatório
@@ -4268,7 +4268,7 @@ Resume Encode:
   fra: Encodage des CV
   ita: Riprendi Codifica
   spa: Reanudar la codificación
-  zho: 恢复编码
+  chs: 恢复编码
   jpn: エンコード再開
   rus: Возобновить кодирование
   por: Código de currículo
@@ -4283,7 +4283,7 @@ Resume Queue:
   fra: File d'attente pour les CV
   ita: Coda di ripresa
   spa: Cola de reanudación
-  zho: 恢复队列
+  chs: 恢复队列
   jpn: キューの再開
   rus: Возобновить очередь
   por: Fila de currículos
@@ -4293,27 +4293,27 @@ Resume Queue:
   kor: 대기열 재개
   ron: Reîncepeți coada de așteptare
 Reusables:
-  deu: Wiederverwendbare Daten
+  deu: Reusables
   eng: Reusables
-  fra: Réutilisables
-  ita: Riutilizzabili
-  spa: Reutilizables
-  zho: 重复利用品
-  jpn: 再利用品
-  rus: Многоразовые материалы
-  por: Reutilizáveis
-  swe: Återanvändbara varor
-  pol: Materiały wielokrotnego użytku
-  ukr: Багаторазове використання
-  kor: 재사용 가능
-  ron: Materiale refolosibile
+  fra: Reusables
+  ita: Reusables
+  spa: Reusables
+  chs: Reusables
+  jpn: Reusables
+  rus: Reusables
+  por: Reusables
+  swe: Reusables
+  pol: Reusables
+  ukr: Reusables
+  kor: Reusables
+  ron: Reusables
 Right:
   deu: Rechts
   eng: Right
   fra: Droit
   ita: Destra
   spa: Derecho
-  zho: 右侧
+  chs: 右侧
   jpn: 右
   rus: Справа
   por: Certo
@@ -4328,7 +4328,7 @@ Row Multi-Threading:
   fra: Rangée Multi-Threading
   ita: Filettatura multi-filettatura
   spa: Fila Multi-Hilo
-  zho: 行的多线程
+  chs: 行的多线程
   jpn: 行のマルチスレッド化
   rus: Многопоточность строк
   por: Linha Multi-Tarefa
@@ -4343,7 +4343,7 @@ Row multithreading:
   fra: Rangée de fils multiples
   ita: Fila multifilettatura
   spa: Fila multihilo
-  zho: 行的多线程
+  chs: 行的多线程
   jpn: 行のマルチスレッド化
   rus: Многопоточность рядов
   por: Multithreading de filas
@@ -4358,7 +4358,7 @@ Row multithreading:
   fra: 'Courir après le commandement fait :'
   ita: 'Esecuzione dopo aver eseguito il comando:'
   spa: 'Corriendo tras el mando hecho:'
-  zho: '在完成命令后运行。'
+  chs: '在完成命令后运行。'
   jpn: 'コマンド完了後に実行。'
   rus: 'Запуск после выполнения команды:'
   por: 'Correr atrás de comando feito:'
@@ -4373,7 +4373,7 @@ Running command:
   fra: Commande en cours d'exécution
   ita: Comando in esecuzione
   spa: Comando de ejecución
-  zho: 运行命令
+  chs: 运行命令
   jpn: 実行中のコマンド
   rus: Выполнение команды
   por: Comando de execução
@@ -4388,7 +4388,7 @@ SVT-AV1 Encoding Guide:
   fra: Guide d'encodage SVT-AV1
   ita: Guida alla codifica SVT-AV1
   spa: Guía de codificación del SVT-AV1
-  zho: SVT-AV1编码指南
+  chs: SVT-AV1编码指南
   jpn: SVT-AV1 エンコーディングガイド
   rus: Руководство по кодированию SVT-AV1
   por: Guia de Codificação SVT-AV1
@@ -4403,7 +4403,7 @@ Same as Source:
   fra: Même que la source
   ita: Uguale alla fonte
   spa: Igual que la fuente
-  zho: 与源文件相同
+  chs: 与源文件相同
   jpn: ソースと同じ
   rus: То же, что и источник
   por: O mesmo que a Fonte
@@ -4418,7 +4418,7 @@ Save:
   fra: Sauvegarder
   ita: Salva
   spa: Guardar
-  zho: 保存
+  chs: 保存
   jpn: 保存
   rus: Сохранить
   por: Guardar
@@ -4433,7 +4433,7 @@ Save Commands:
   fra: Commandes de sauvegarde
   ita: Comandi di salvataggio
   spa: Salvar los comandos
-  zho: 保存命令
+  chs: 保存命令
   jpn: コマンドの保存
   rus: Сохранить команды
   por: Salvar Comandos
@@ -4448,7 +4448,7 @@ Save File:
   fra: Enregistrer le fichier
   ita: Salva file
   spa: Guardar archivo
-  zho: 保存文件
+  chs: 保存文件
   jpn: ファイルの保存
   rus: Сохранить файл
   por: Guardar ficheiro
@@ -4463,7 +4463,7 @@ Save commands to file:
   fra: Enregistrer les commandes dans un fichier
   ita: Salvare i comandi su file
   spa: Guardar los comandos en un archivo
-  zho: 保存命令到文件
+  chs: 保存命令到文件
   jpn: コマンドをファイルに保存
   rus: Сохранить команды в файл
   por: Guardar comandos em ficheiro
@@ -4478,7 +4478,7 @@ Scale:
   fra: Échelle
   ita: Scala
   spa: Escala
-  zho: 缩放
+  chs: 缩放
   jpn: スケール
   rus: Масштаб
   por: Balança
@@ -4498,7 +4498,7 @@ Scrub away all incoming metadata, like video titles, unique markings and so on.:
     uniche e così via.
   spa: Borra todos los metadatos entrantes, como títulos de video, marcas únicas y
     demás.
-  zho: 擦除输入文件中所有的元数据，如视频标题、唯一标记等。
+  chs: 擦除输入文件中所有的元数据，如视频标题、唯一标记等。
   jpn: 動画のタイトルやユニークなマークなど、元のメタデータをすべて消去します。
   rus: Удалите все входящие метаданные, такие как названия видео, уникальные метки
     и так далее.
@@ -4523,7 +4523,7 @@ Selects which NVENC capable GPU to use. First GPU is 0, second is 1, and so on:
     è 1, e così via
   spa: Selecciona qué GPU con capacidad NVENC se va a utilizar. La primera GPU es
     0, la segunda es 1, y así sucesivamente
-  zho: 选择使用哪个有NVENC功能的GPU。第一个GPU为0，第二个为1，以此类推。
+  chs: 选择使用哪个有NVENC功能的GPU。第一个GPU为0，第二个为1，以此类推。
   jpn: どのNVENC対応GPUを使用するか選択してください。最初のGPUは0、2番目は1。
   rus: Выбрать, какой GPU с поддержкой NVENC будет использоваться. Первый GPU - 0,
     второй - 1 и так далее.
@@ -4544,7 +4544,7 @@ Set speed to 4 for first pass:
   fra: Régler la vitesse à 4 pour le premier passage
   ita: Imposta la velocità a 4 per il primo passaggio
   spa: Establece la velocidad en 4 para la primera pasada
-  zho: 第一遍速度设置为4
+  chs: 第一遍速度设置为4
   jpn: 1回目のスピードを4に設定
   rus: Установить скорость на 4 для первого прохода
   por: Definir velocidade para 4 na primeira passagem
@@ -4559,7 +4559,7 @@ Set the "title" tag, sometimes shown as "Movie Name":
   fra: Poner la etiqueta "título", a veces se muestra como "Nombre de la película"
   ita: Impostare il tag "title", a volte mostrato come "Movie Name" (nome del film)
   spa: Poner la etiqueta "título", a veces se muestra como "Nombre de la película"
-  zho: 设置“标题”（title，有时显示为“电影名称”（Movie Name））标签
+  chs: 设置“标题”（title，有时显示为“电影名称”（Movie Name））标签
   jpn: '"title"タグを設定します。"Movie Name"と表示されることもあります。'
   rus: Установить тег "title", который иногда отображается как "Название фильма".
   por: Definir a etiqueta "título", por vezes exibida como "Nome do filme".
@@ -4574,7 +4574,7 @@ Set the encoding level restriction:
   fra: Définir la restriction du niveau d'encodage
   ita: Imposta la restrizione del livello di codifica
   spa: Establezca la restricción del nivel de codificación
-  zho: 设置编码级别限制
+  chs: 设置编码级别限制
   jpn: エンコードレベル制限の設定
   rus: Установить ограничение уровня кодирования
   por: Definir a restrição do nível de codificação
@@ -4589,7 +4589,7 @@ Set the encoding tier:
   fra: Définir le niveau d'encodage
   ita: Imposta il livello di codifica
   spa: Establecer el nivel de codificación
-  zho: 设置编码层
+  chs: 设置编码层
   jpn: エンコーディング層の設定
   rus: Установить уровень кодировки
   por: Definir o nível de codificação
@@ -4605,7 +4605,7 @@ Set the level of effort in determining B frame placement.:
   ita: Impostare il livello di sforzo nel determinare il posizionamento del fotogramma
     B.
   spa: Establezca el nivel de esfuerzo para determinar la ubicación del cuadro B.
-  zho: 对决定B帧位置时的工作量水平进行调整。
+  chs: 对决定B帧位置时的工作量水平进行调整。
   jpn: Bフレームの配置を決める際の努力の度合いを設定します。
   rus: Установить уровень усилий при определении размещения B кадра.
   por: Estabelecer o nível de esforço na determinação da colocação da moldura B.
@@ -4620,7 +4620,7 @@ Set the level of effort in determining B frame placement.:
   fra: 'Régler après avoir fait la commande à :'
   ita: 'Impostare dopo il comando su:'
   spa: 'Estableciendo después de hacer el comando para:'
-  zho: '设置完成后命令为。'
+  chs: '设置完成后命令为'
   jpn: 'コマンドを実行した後の設定'
   rus: 'Установка после выполненной команды на:'
   por: 'Definição após comando feito para:'
@@ -4635,7 +4635,7 @@ Settings:
   fra: Paramètres
   ita: Impostazioni
   spa: Ajustes
-  zho: 设置
+  chs: 设置
   jpn: 設定
   rus: Настройки
   por: Definições
@@ -4650,7 +4650,7 @@ Single Pass (Bitrate):
   fra: Passage unique (Bitrate)
   ita: Passaggio singolo (Bitrato)
   spa: Pase único (Bitrate)
-  zho: 一遍编码（比特率）
+  chs: 一遍编码（比特率）
   jpn: 1回のみ（ビットレート）
   rus: Однократный проход (битрейт)
   por: Passe único (Bitrate)
@@ -4665,7 +4665,7 @@ Single Pass (CRF):
   fra: Laissez-passer unique (CRF)
   ita: Passaggio singolo (CRF)
   spa: Pase único (CRF)
-  zho: 一遍编码（CRF）
+  chs: 一遍编码（CRF）
   jpn: 1回のみ（CRF）
   rus: Однократный проход (CRF)
   por: Passe Único (CRF)
@@ -4680,7 +4680,7 @@ Size Estimate:
   fra: Estimation de la taille
   ita: Stima delle dimensioni
   spa: Estimación del tamaño
-  zho: 预计文件大小
+  chs: 预计文件大小
   jpn: サイズの目安
   rus: Оценка размера
   por: Estimativa de tamanho
@@ -4689,21 +4689,36 @@ Size Estimate:
   ukr: Оцінка розміру
   kor: 크기 견적
   ron: Dimensiune estimată
-'"Slow" is the slowest preset personally recommended, presets slower than this result in much smaller gains':
-  deu: '„Slow“ ist die langsamste persönlich empfohlene Voreinstellung, langsamere Voreinstellungen als diese führen zu viel geringeren Verstärkungen'
-  eng: '"Slow" is the slowest preset personally recommended, presets slower than this result in much smaller gains'
-  fra: '"Slow" est le préréglage le plus lent personnellement recommandé, les préréglages plus lents que cela entraînent des gains beaucoup plus faibles'
-  ita: '"Slow" è il preset più lento consigliato personalmente, i preset più lenti di questo si traducono in guadagni molto minori'
-  spa: '"Lento" es el preajuste más lento recomendado personalmente, los preajustes más lentos que este dan como resultado ganancias mucho más pequeñas'
-  zho: '个人建议使用slow。比这更慢的设定获得的好处会小得多。'
-  jpn: '個人的にはslowのプリセット設定はおすすめです。それよりも遅いプリセットを使うとメリットが多くないです。'
-  rus: '«Slow» — самая медленная предустановка, рекомендуемая лично, более медленные предустановки дают гораздо меньший прирост'
-  por: '"Slow" é a predefinição mais lenta recomendada pessoalmente, predefinições mais lentas do que esta resultam em ganhos muito menores'
-  swe: '"Slow" är den långsammaste förinställningen som personligen rekommenderas, förinställningar långsammare än detta resulterar i mycket mindre vinster'
-  pol: '„Slow” to najwolniejsze ustawienie wstępne, które osobiście zalecamy, ustawienia wolniejsze od tego powodują znacznie mniejsze wzmocnienia'
-  ukr: '«Slow» — це найповільніший пресет, рекомендований особисто, пресети, повільніші за цей, призводять до значно менших посилень'
-  kor: '"Slow"는 개인적으로 권장되는 가장 느린 사전 설정이며, 이보다 느린 사전 설정은 게인이 훨씬 적습니다.'
-  ron: '„Slow” este cea mai lentă presetare recomandată personal, presetări mai lente decât aceasta duc la câștiguri mult mai mici'
+Slow is the slowest preset personally recommended,:
+  deu: Slow ist die langsamste persönlich empfohlene Voreinstellung,
+  eng: Slow is the slowest preset personally recommended,
+  fra: Slow est le préréglage le plus lent personnellement recommandé,
+  ita: Slow è il preset più lento consigliato personalmente,
+  spa: Slow es el preajuste más lento recomendado personalmente,
+  chs: 个人建议使用slow。
+  jpn: 個人的にはslowのプリセット設定はおすすめです。
+  rus: Slow — самая медленная предустановка, рекомендуемая лично,
+  por: Slow é a predefinição mais lenta recomendada pessoalmente,
+  swe: Slow är den långsammaste förinställningen som personligen rekommenderas,
+  pol: Slow to najwolniejsze ustawienie wstępne, które osobiście zalecamy,
+  ukr: Slow — це найповільніший пресет, рекомендований особисто, пресети,
+  kor: Slow는 개인적으로 권장되는 가장 느린 사전 설정이며,
+  ron: Slow este cea mai lentă presetare recomandată personal,
+presets slower than this result in much smaller gains:
+  deu: langsamere Voreinstellungen als diese führen zu viel geringeren Verstärkungen
+  eng: presets slower than this result in much smaller gains
+  fra: les préréglages plus lents que cela entraînent des gains beaucoup plus faibles
+  ita: i preset più lenti di questo si traducono in guadagni molto minori
+  spa: los preajustes más lentos que este dan como resultado ganancias mucho más pequeñas
+  chs: 比这更慢的设定获得的好处会小得多。
+  jpn: それよりも遅いプリセットを使ってもメリットが多くないです。
+  rus: более медленные предустановки дают гораздо меньший прирост
+  por: predefinições mais lentas do que esta resultam em ganhos muito menores
+  swe: förinställningar långsammare än detta resulterar i mycket mindre vinster
+  pol: ustawienia wolniejsze od tego powodują znacznie mniejsze wzmocnienia
+  ukr: повільніші за цей, призводять до значно менших посилень
+  kor: 이보다 느린 사전 설정은 게인이 훨씬 적습니다.
+  ron: presetări mai lente decât aceasta duc la câștiguri mult mai mici
 Slower presets will generally achieve better compression efficiency (and generate smaller bitstreams).:
   deu: Langsamere Voreinstellungen erzielen im Allgemeinen eine bessere Komprimierungseffizienz
     (und erzeugen kleinere Bitströme).
@@ -4715,7 +4730,7 @@ Slower presets will generally achieve better compression efficiency (and generat
     di compressione (e generano flussi di bit più piccoli).
   spa: Los preajustes más lentos generalmente lograrán una mejor eficiencia de compresión
     (y generarán flujos de bits más pequeños).
-  zho: 较慢的预设通常会达成更好的压缩效率（并生成较小的码流）。
+  chs: 较慢的预设通常会达成更好的压缩效率（并生成较小的码流）。
   jpn: 一般的には、遅いプリセットの方が圧縮効率が良くなります（より小さなビットストリームを生成します）。
   rus: Более медленные пресеты обычно обеспечивают лучшую эффективность сжатия (и
     генерируют меньшие битовые потоки).
@@ -4736,7 +4751,7 @@ Source:
   fra: Source
   ita: Fonte
   spa: Fuente
-  zho: 源文件
+  chs: 源文件
   jpn: ソース
   rus: Источник
   por: Fonte
@@ -4751,7 +4766,7 @@ Source Details:
   fra: Détails de la source
   ita: Dettagli della fonte
   spa: Detalles de la fuente
-  zho: 源文件详情
+  chs: 源文件详情
   jpn: ソースの詳細
   rus: Детали источника
   por: Detalhes da fonte
@@ -4766,7 +4781,7 @@ Source Frame Rate:
   fra: Taux de trame source
   ita: Frame Rate della fonte
   spa: Velocidad de cuadro de la fuente
-  zho: 源帧率
+  chs: 源帧率
   jpn: ソースフレームレート
   rus: Частота кадров источника
   por: Taxa da moldura de origem
@@ -4781,7 +4796,7 @@ Source height:
   fra: Hauteur de la source
   ita: Altezza della sorgente
   spa: Altura de la fuente
-  zho: 源文件高度
+  chs: 源文件高度
   jpn: ソースの高さ
   rus: Высота источника
   por: Altura da fonte
@@ -4796,7 +4811,7 @@ Source width:
   fra: Largeur de la source
   ita: Larghezza della fonte
   spa: Ancho de la fuente
-  zho: 源文件宽度
+  chs: 源文件宽度
   jpn: ソースの幅
   rus: Ширина источника
   por: Largura da fonte
@@ -4811,7 +4826,7 @@ Spatial AQ:
   fra: QA spatiale
   ita: AQ spaziale
   spa: AQ espacial
-  zho: 空间自适应量化
+  chs: 空间自适应量化
   jpn: Spatial AQ
   rus: Пространственный AQ
   por: AQ Espacial
@@ -4826,7 +4841,7 @@ Speed:
   fra: Vitesse
   ita: Velocità
   spa: Velocidad
-  zho: 速度
+  chs: 速度
   jpn: スピード
   rus: Скорость
   por: Velocidade
@@ -4841,7 +4856,7 @@ Start:
   fra: Démarrer
   ita: Iniziare
   spa: Comienza
-  zho: 开始
+  chs: 开始
   jpn: 開始
   rus: Начать
   por: Início
@@ -4856,7 +4871,7 @@ Starting conversion process:
   fra: Iniciando el proceso de conversión
   ita: Avvio del processo di conversione
   spa: Iniciando el proceso de conversión
-  zho: 开始转换过程
+  chs: 开始转换过程
   jpn: 変換処理の開始
   rus: Начало процесса преобразования
   por: Início do processo de conversão
@@ -4871,7 +4886,7 @@ Strength:
   fra: Force
   ita: Forza
   spa: Fuerza
-  zho: 强度
+  chs: 强度
   jpn: 強さ
   rus: Сила
   por: Força
@@ -4886,7 +4901,7 @@ Subtitle Tracks:
   fra: Pistes de sous-titres
   ita: Tracce dei sottotitoli
   spa: Pistas de subtítulos
-  zho: 字幕轨
+  chs: 字幕轨
   jpn: 字幕トラック
   rus: Дорожки субтитров
   por: Faixas de subtítulos
@@ -4901,7 +4916,7 @@ Subtitle select language:
   fra: Sous-titre choisir la langue
   ita: Sottotitolo selezionare la lingua
   spa: Subtítulo seleccionar idioma
-  zho: 选择字幕语言
+  chs: 选择字幕语言
   jpn: 字幕選択言語
   rus: Выбор языка субтитров
   por: Subtítulo seleccionar idioma
@@ -4916,7 +4931,7 @@ Subtitles:
   fra: Sous-titres
   ita: Sottotitoli
   spa: 'Subtítulos:'
-  zho: 字幕
+  chs: 字幕
   jpn: 字幕
   rus: Субтитры
   por: Subtítulos
@@ -4931,7 +4946,7 @@ Success:
   fra: Succès
   ita: Successo
   spa: Éxito
-  zho: 成功
+  chs: 成功
   jpn: 成功
   rus: Успех
   por: Sucesso
@@ -4946,7 +4961,7 @@ Support FastFlix:
   fra: Soutenez FastFlix
   ita: Supporto FastFlix
   spa: Soporta FastFlix
-  zho: 支持FastFlix
+  chs: 支持FastFlix
   jpn: 'FastFlixを応援/寄付'
   rus: Поддержка FastFlix
   por: Apoio FastFlix
@@ -4961,7 +4976,7 @@ Supported Image Files:
   fra: Fichiers d'images pris en charge
   ita: File immagine supportati
   spa: Archivos de imagen soportados
-  zho: 支持的图像文件
+  chs: 支持的图像文件
   jpn: 対応画像ファイル
   rus: Поддерживаемые файлы изображений
   por: Ficheiros de Imagem Suportados
@@ -4977,7 +4992,7 @@ The GUI might have died, but I'm going to keep converting!:
     !
   ita: L'interfaccia grafica sarà anche morta, ma continuerò a convertirmi!
   spa: ¡El GUI puede haber muerto, pero voy a seguir convirtiendo!
-  zho: 图形界面可能已经崩溃，但转换将继续进行！
+  chs: 图形界面可能已经崩溃，但转换将继续进行！
   jpn: GUIは固まってしまったかもしれませんが、私は変換し続けるつもりです!
   rus: Возможно, графический интерфейс умер, но конвертация продолжится!
   por: A GUI pode ter morrido, mas eu vou continuar a converter-me!
@@ -4992,7 +5007,7 @@ The more complex the block, the more quantization is used.:
   fra: Plus le bloc est complexe, plus on utilise la quantification.
   ita: Più complesso è il blocco, più si usa la quantizzazione.
   spa: Cuanto más complejo es el bloque, más cuantificación se utiliza.
-  zho: 越复杂的块，使用的量化也越高。
+  chs: 越复杂的块，使用的量化也越高。
   jpn: ブロックが複雑になるほど、量子化の量が増えます。
   rus: Чем сложнее блок, тем больше используется квантование.
   por: Quanto mais complexo for o bloco, mais quantização é utilizada.
@@ -5002,37 +5017,37 @@ The more complex the block, the more quantization is used.:
   kor: 블록이 복잡할수록 더 많은 양자화가 사용됩니다.
   ron: Cu cât blocul este mai complex, cu atât se utilizează mai multă cuantificare.
 The purpose is to prevent blocking or banding artifacts in regions with few/zero AC coefficients.:
-  deu: "Der Zweck ist, Blocking- oder Banding-Artefakte in Regionen mit wenigen/keinen
-    AC-Koeffizienten zu verhindern."
-  eng: "The purpose is to prevent blocking or banding artifacts in regions with few/zero
-    AC coefficients."
-  fra: "L'objectif est d'éviter de bloquer ou de banderoler des artefacts dans des
-    régions où les coefficients AC sont faibles ou nuls."
-  ita: "Lo scopo è quello di prevenire il blocco o il banding di artefatti in regioni
-    con pochi/zeri coefficienti AC."
-  spa: "El propósito es prevenir el bloqueo o los artefactos de bandas en regiones
-    con coeficientes de CA bajos/cero."
-  zho: '目的是为了防止在AC coefficients较少或为零的区域出现blocking或banding artifacts。'
-  jpn: 'これは、AC係数が少ない/ゼロの領域でのブロッキングやバンディングのアーチファクトを防ぐためです。'
-  rus: "Цель - предотвратить блокирование или артефакты полосатости в областях с небольшим
-    количеством/нулевыми коэффициентами переменного тока."
+  deu: Der Zweck ist, Blocking- oder Banding-Artefakte in Regionen mit wenigen/keinen
+    AC-Koeffizienten zu verhindern.
+  eng: The purpose is to prevent blocking or banding artifacts in regions with few/zero
+    AC coefficients.
+  fra: L'objectif est d'éviter de bloquer ou de banderoler des artefacts dans des
+    régions où les coefficients AC sont faibles ou nuls.
+  ita: Lo scopo è quello di prevenire il blocco o il banding di artefatti in regioni
+    con pochi/zeri coefficienti AC.
+  spa: El propósito es prevenir el bloqueo o los artefactos de bandas en regiones
+    con coeficientes de CA bajos/cero.
+  chs: 目的是为了防止在AC coefficients较少或为零的区域出现blocking或banding artifacts。
+  jpn: これは、AC係数が少ない/ゼロの領域でのブロッキングやバンディングのアーチファクトを防ぐためです。
+  rus: Цель - предотвратить блокирование или артефакты полосатости в областях с небольшим
+    количеством/нулевыми коэффициентами переменного тока.
   por: "O objectivo é evitar o bloqueio ou a colocação de artefactos de faixas em regiões
     com poucos/zero coeficientes AC."
-  swe: "Syftet är att förhindra blockering eller bandning i områden med få/noll AC-koefficienter."
+  swe: Syftet är att förhindra blockering eller bandning i områden med få/noll AC-koefficienter.
   pol: Ma to na celu zapobieganie powstawaniu artefaktów blokowania lub pasmowania
     w regionach o małej lub zerowej liczbie współczynników AC.
-  ukr: "Мета - запобігти артефактам блокування або смуги в регіонах з низькими/нульовими
-    коефіцієнтами змінного струму."
+  ukr: Мета - запобігти артефактам блокування або смуги в регіонах з низькими/нульовими
+    коефіцієнтами змінного струму.
   kor: 그 목적은 AC 계수가 거의 없거나 0인 영역에서 차단 또는 밴딩 아티팩트를 방지하는 것입니다.
-  ron: "Scopul este de a preveni apariția unor artefacte de blocare sau de bandaj în
-    regiunile cu coeficienți AC puțini/zero."
+  ron: Scopul este de a preveni apariția unor artefacte de blocare sau de bandaj în
+    regiunile cu coeficienți AC puțini/zero.
 There is a conversion in process!:
   deu: Es ist eine Konvertierung am laufen!
   eng: There is a conversion in process!
   fra: Il y a une conversion en cours !
   ita: C'è una conversione in corso!
   spa: ¡Hay una conversión en proceso!
-  zho: 有一个转换任务正在进行！
+  chs: 有一个转换任务正在进行！
   jpn: 転換中です。
   rus: Идет процесс преобразования!
   por: Há uma conversão em processo!
@@ -5047,7 +5062,7 @@ There is a newer version of FastFlix available!:
   fra: Une nouvelle version de FastFlix est disponible!
   ita: C'è una versione più recente di FastFlix disponibile!
   spa: ¡Hay una nueva versión de FastFlix disponible!
-  zho: FastFlix有更新可用
+  chs: FastFlix有更新可用
   jpn: 新しいバージョンのFastFlixがあります。
   rus: Доступна более новая версия FastFlix!
   por: Há uma versão mais recente de FastFlix disponível!
@@ -5059,10 +5074,10 @@ There is a newer version of FastFlix available!:
 There was an error during conversion and the queue has stopped:
   deu: Es gab einen Fehler während der Konvertierung und die Warteschlange wurde angehalten
   eng: There was an error during conversion and the queue has stopped
-  fra: "Il y a eu une erreur lors de la conversion et la file d'attente s'est arrêtée"
+  fra: Il y a eu une erreur lors de la conversion et la file d'attente s'est arrêtée
   ita: C'è stato un errore durante la conversione e la coda si è fermata
   spa: Hubo un error durante la conversión y la cola se ha detenido
-  zho: 转换过程中出现错误，队列已经停止
+  chs: 转换过程中出现错误，队列已经停止
   jpn: 変換中にエラーが発生し、キューが停止されました
   rus: Во время преобразования произошла ошибка, и очередь остановилась
   por: Houve um erro durante a conversão e a fila parou
@@ -5082,7 +5097,7 @@ This flag performs bi-linear interpolation of the corner reference samples for a
     d'angolo per un forte effetto levigante.
   spa: Este banderín realiza una interpolación bi-línea de las muestras de referencia
     de las esquinas para un fuerte efecto de suavizado.
-  zho: 这个选项对corner reference samples进行双线性插值，以获得强平滑效果。
+  chs: 这个选项对corner reference samples进行双线性插值，以获得强平滑效果。
   jpn: このフラグは、強力なスムージング効果を得るために、コーナーリファレンスサンプルのバイリニア補間を行います。
   rus: Этот флаг выполняет билинейную интерполяцию угловых опорных образцов для сильного
     эффекта сглаживания.
@@ -5108,7 +5123,7 @@ This improves encoding speed significantly on systems that are otherwise underut
     sono altrimenti sottoutilizzati durante la codifica VP9.
   spa: Esto mejora significativamente la velocidad de codificación en los sistemas
     que de otra manera son subutilizados al codificar el VP9.
-  zho: 在编码VP9时资源利用不足的系统上，此选项能够显著提升编码速度。
+  chs: 在编码VP9时资源利用不足的系统上，此选项能够显著提升编码速度。
   jpn: これにより、VP9をエンコードする際に十分に利用されていないシステムにおいて、エンコード速度が大幅に向上します。
   rus: Это значительно повышает скорость кодирования на системах, которые по-другому
     недостаточно используются при кодировании VP9.
@@ -5134,7 +5149,7 @@ This is intended for use when you do not have a container to keep the stream hea
     le intestazioni dello stream per voi
   spa: Está pensado para ser utilizado cuando no se dispone de un contenedor para
     guardar los encabezados de la corriente para usted
-  zho: This is intended for use when you do not have a container to keep the stream
+  chs: This is intended for use when you do not have a container to keep the stream
     headers for you.
   jpn: ストリームヘッダーを保持してくれるコンテナがない場合に使用することを想定しています。
   rus: Это предназначено для использования, когда у вас нет контейнера для хранения
@@ -5158,7 +5173,7 @@ This is used for ultra-high bitrates with zero loss of quality.:
     a zero.
   spa: Se utiliza para velocidades de transmisión ultra altas con cero pérdida de
     calidad.
-  zho: 用于实现无质量损失的超高比特率编码。
+  chs: 用于实现无质量损失的超高比特率编码。
   jpn: これは、超高ビットレートで品質を損なうことなく使用されます。
   rus: Используется для сверхвысоких битрейтов с нулевой потерей качества.
   por: Isto é utilizado para taxas de bits ultra-elevadas com perda de qualidade zero.
@@ -5173,7 +5188,7 @@ This is used for ultra-high bitrates with zero loss of quality.:
   fra: "Cette option n'est pas renouvelée, sauf si vous devez vous conformer "
   ita: 'Questa opzione non viene riavviata a meno che non sia necessario conformarsi '
   spa: 'Esta opción no se reinicia a menos que se necesite conformar '
-  zho: 除非您需要为了刻录到物理光盘而遵守蓝光标准，
+  chs: 除非您需要为了刻录到物理光盘而遵守蓝光标准，
   jpn: このオプションは、以下の場合でない限り、推奨されません。
   rus: Этот вариант не рекомендуется использовать, если не требуется соответствие
   por: Esta opção não é reiniciada a menos que precise de se conformar
@@ -5188,7 +5203,7 @@ This will just copy the video track as is.:
   fra: Il suffit de copier la piste vidéo telle quelle.
   ita: Questo si limiterà a copiare la traccia video così com'è.
   spa: Esto sólo copiará la pista del video tal como está.
-  zho: 仅原样复制视频轨道。
+  chs: 仅原样复制视频轨道。
   jpn: これにより、ビデオトラックがそのままコピーされます。
   rus: Это просто скопирует видеодорожку как есть.
   por: Isto irá apenas copiar a faixa de vídeo tal como está.
@@ -5203,7 +5218,7 @@ Tier:
   fra: Tier
   ita: Livello
   spa: Tier
-  zho: 层
+  chs: 层
   jpn: ティア
   rus: Ярус
   por: Nível
@@ -5218,7 +5233,7 @@ Tile Columns:
   fra: Colonnes de tuiles
   ita: Colonne di piastrelle
   spa: Columnas de azulejos
-  zho: Tile列数量
+  chs: Tile列数量
   jpn: タイルの列数
   rus: Столбцы плитки
   por: Colunas de Ladrilho
@@ -5233,7 +5248,7 @@ Tile Rows:
   fra: Les rangées de carreaux
   ita: File di piastrelle
   spa: Filas de azulejos
-  zho: Tile行数量
+  chs: Tile行数量
   jpn: タイルの行数
   rus: Строки плитки
   por: Fileiras de Azulejos
@@ -5248,7 +5263,7 @@ Tiles:
   fra: Carreaux
   ita: Piastrelle
   spa: Baldosas
-  zho: Tiles
+  chs: Tiles
   jpn: タイル
   rus: Плитки
   por: Azulejos
@@ -5263,7 +5278,7 @@ Time Left:
   fra: Temps restant
   ita: Tempo rimanente
   spa: Tiempo restante
-  zho: 剩余时间
+  chs: 剩余时间
   jpn: 残り時間
   rus: Оставшееся время
   por: Tempo restante
@@ -5278,7 +5293,7 @@ Time Elapsed:
   fra: Temps écoulé
   ita: Tempo trascorso
   spa: Tiempo transcurrido
-  zho: 已用时间
+  chs: 已用时间
   jpn: 経過時間
   rus: Прошедшее время
   por: Tempo decorrido
@@ -5293,7 +5308,7 @@ Title:
   fra: Titre
   ita: Titolo
   spa: Título
-  zho: 标题
+  chs: 标题
   jpn: タイトル
   rus: Название
   por: Título
@@ -5308,7 +5323,7 @@ Top:
   fra: Top
   ita: Top
   spa: Top
-  zho: 上端
+  chs: 上端
   jpn: 上
   rus: Верх
   por: Início
@@ -5323,7 +5338,7 @@ Total video height must be greater than 0:
   fra: La hauteur totale de la vidéo doit être supérieure à 0
   ita: L'altezza totale del video deve essere superiore a 0
   spa: La altura total del video debe ser mayor que 0
-  zho: 视频总高度必须大于0
+  chs: 视频总高度必须大于0
   jpn: 動画の全高が0より大きいこと
   rus: Общая высота видео должна быть больше 0
   por: A altura total do vídeo deve ser superior a 0
@@ -5338,7 +5353,7 @@ Tune:
   fra: Tune
   ita: Tune
   spa: Sintoniza
-  zho: 调校
+  chs: 调校
   jpn: チューニング
   rus: Настроить
   por: Melodia
@@ -5353,7 +5368,7 @@ Tune the settings for a particular type of source or situation:
   fra: Régler les paramètres pour un type de source ou une situation particulière
   ita: Sintonizzare le impostazioni per un particolare tipo di sorgente o situazione
   spa: Sintonizar los ajustes para un tipo de fuente o situación particular
-  zho: 针对特定类型的源文件或情形调整设置。
+  chs: 针对特定类型的源文件或情形调整设置。
   jpn: 特定の種類のソースや状況に合わせて設定を調整する
   rus: Настройте параметры для определенного типа источника или ситуации
   por: Ajustar as definições para um determinado tipo de fonte ou situação
@@ -5368,7 +5383,7 @@ Unspecified:
   fra: Non spécifié
   ita: Non specificato
   spa: Sin especificar
-  zho: 未指定
+  chs: 未指定
   jpn: 指定なし
   rus: Неуказанный
   por: Não especificado
@@ -5383,7 +5398,7 @@ Usage:
   fra: Utilisation
   ita: Utilizzo
   spa: Uso
-  zho: 用法
+  chs: 用法
   jpn: 使用方法
   rus: Использование
   por: Utilização
@@ -5398,7 +5413,7 @@ Use --bframes 0 to force all P/I low-latency encodes.:
   fra: Utilisez --bframes 0 pour forcer tous les codes P/I à faible latence.
   ita: Utilizzare --bframes 0 per forzare tutte le codifiche P/I a bassa latenza.
   spa: Use --bframes 0 para forzar todos los códigos de baja latencia P/I.
-  zho: 使用--bframes 0强制进行全P/I帧的低延迟编码。
+  chs: 使用--bframes 0强制进行全P/I帧的低延迟编码。
   jpn: すべてのP/I低レイテンシーエンコードを強制するには、--bframes 0を使用してください。
   rus: Используйте --bframes 0, чтобы заставить все P/I кодировать с низкой задержкой.
   por: Use --bframes 0 para forçar todos os códigos P/I de baixa latência.
@@ -5414,7 +5429,7 @@ Use B frames as references:
   fra: Utiliser les cadres B comme références
   ita: Usa i fotogrammi B come riferimenti
   spa: Utilizar los fotogramas B como referencia
-  zho: 用B帧作为参考
+  chs: 用B帧作为参考
   jpn: Bフレームを参考にする
   rus: Используйте B-кадры в качестве эталонов
   por: Utilizar molduras B como referências
@@ -5429,7 +5444,7 @@ Use Sane Audio Selection (customizable in config file):
   fra: Utiliser la sélection audio Sane (actualisable dans le fichier de configuration)
   ita: Utilizzare Sane Audio Selection (aggiornabile nel file di configurazione)
   spa: Usar la Selección de Audio Sane (actualizable en el archivo de configuración)
-  zho: 使用合理音频编码选择（可在配置文件中更改）
+  chs: 使用合理音频编码选择（可在配置文件中更改）
   jpn: 合理的なオーディオを選択する（設定ファイルでカスタマイズ可能）
   rus: Использовать Разумный выбор аудио (настраивается в конфигурационном файле)
   por: Usar Selecção Áudio Sã (personalizável em ficheiro de configuração)
@@ -5444,7 +5459,7 @@ Useful when there is a desire to signal 0 values for max-cll and max-fall.:
   fra: Utile lorsqu'on souhaite signaler des valeurs 0 pour max-cll et max-fall.
   ita: Utile quando si desidera segnalare i valori 0 per max-cll e max-fall.
   spa: Es útil cuando se desea señalar los valores 0 para max-cll y max-fall.
-  zho: 当需要将max-cll及max-fall置0值时有用。
+  chs: 当需要将max-cll及max-fall置0值时有用。
   jpn: max-cellとmax-fallの値を0にしたい場合に便利です。
   rus: Полезно, когда есть желание сигнализировать 0 значений для max-cll и max-fall.
   por: Útil quando há um desejo de assinalar valores 0 para max-cll e max-fall.
@@ -5461,7 +5476,7 @@ Useful when you have the "Too many packets buffered for output stream" error:
     uscita".
   spa: Útil cuando se tiene el error "Demasiados paquetes almacenados en la memoria
     intermedia para el flujo de salida".
-  zho: 当出现“输出流缓冲的数据包太多”（Too many packets buffered for output stream）错误时有用。
+  chs: 当出现“输出流缓冲的数据包太多”（Too many packets buffered for output stream）错误时有用。
   jpn: '"Too many packets buffered for output stream"というエラーが発生した場合で役に立つ。'
   rus: Полезно, когда у вас возникает ошибка "Слишком много пакетов буферизировано
     для выходного потока".
@@ -5484,7 +5499,7 @@ Using 1 or 2 will increase encoding speed at the expense of having some impact o
     sulla qualità e sulla precisione del controllo del tasso.
   spa: El uso de 1 o 2 aumentará la velocidad de codificación a expensas de tener
     algún impacto en la calidad y la precisión del control de la tasa.
-  zho: 使用1或2会提高编码速度，但代价是对质量和码率控制精度有一定影响。
+  chs: 使用1或2会提高编码速度，但代价是对质量和码率控制精度有一定影响。
   jpn: 1または2を使用すると、画質やレートコントロールの精度に多少の影響を与えますが、エンコード速度が向上します。
   rus: Использование 1 или 2 увеличит скорость кодирования за счет некоторого влияния
     на качество и точность контроля скорости.
@@ -5507,7 +5522,7 @@ Using a single frame thread gives a slight improvement in compression,:
   ita: L'utilizzo di una filettatura a telaio singolo offre un leggero miglioramento
     della compressione,
   spa: Usar un solo hilo de cuadro da una ligera mejora en la compresión,
-  zho: 使用单帧线程会使压缩率略有提高，
+  chs: 使用单帧线程会使压缩率略有提高，
   jpn: シングルフレームスレッドを使用すると、圧縮率が少し向上します。
   rus: Использование одного кадрового потока дает небольшое улучшение сжатия,
   por: A utilização de um único fio de moldura dá uma ligeira melhoria na compressão,
@@ -5522,7 +5537,7 @@ VBR Target:
   fra: Cible VBR
   ita: Obiettivo VBR
   spa: Objetivo VBR
-  zho: 目标VBR
+  chs: 目标VBR
   jpn: VBR目標
   rus: VBR Цель
   por: Alvo VBR
@@ -5537,7 +5552,7 @@ VBR Target:
   fra: 'Les valeurs : 0:aucun ; 1:rapide ; 2:plein(treillis) par défaut'
   ita: 'Valori: 0:nessuno; 1:veloce; 2:pieno (traliccio) predefinito'
   spa: 'Valores: 0:ninguno; 1:rápido; 2:completo (enrejado) por defecto'
-  zho: '取值：0:none；1:fast；2:full(trellis)（默认）'
+  chs: '取值：0:none；1:fast；2:full(trellis)（默认）'
   jpn: '値を指定します。0：なし、1：速い、2：フル（tresllis）デフォルト'
   rus: 'Значения: 0:нет; 1:быстро; 2:полностью (решетка) по умолчанию'
   por: 'Valores: 0:nenhum; 1:rápido; 2:cheio(trellis) por defeito'
@@ -5552,7 +5567,7 @@ Variable:
   fra: Variable
   ita: Variabile
   spa: Variable
-  zho: 可变
+  chs: 可变
   jpn: 可変
   rus: Переменная
   por: Variável
@@ -5567,8 +5582,8 @@ Various:
   fra: Divers
   ita: Varie
   spa: Varios
-  zho: 多种许可
-  jpn: 複数の
+  chs: 多种许可
+  jpn: 複数のライセンス
   rus: Разное
   por: Vários
   swe: Olika
@@ -5582,7 +5597,7 @@ Vert + Hoz Flip:
   fra: Vert + Hoz Flip
   ita: Vert + Hoz Flip
   spa: Vert + Hoz Flip
-  zho: 垂直+水平翻转
+  chs: 垂直+水平翻转
   jpn: 上下反転と左右反転
   rus: Верт + Гор переворот
   por: Vert + Hoz Flip
@@ -5597,7 +5612,7 @@ Vertical Flip:
   fra: Volteo vertical
   ita: Capovolgimento verticale
   spa: Volteo vertical
-  zho: 垂直翻转
+  chs: 垂直翻转
   jpn: 垂直反転
   rus: Вертикальный переворот
   por: Vertical Flip
@@ -5612,7 +5627,7 @@ Video Speed:
   fra: Vitesse de la vidéo
   ita: Velocità video
   spa: Velocidad de video
-  zho: 视频速度
+  chs: 视频速度
   jpn: ビデオスピード
   rus: Скорость видео
   por: Velocidade do vídeo
@@ -5627,7 +5642,7 @@ Video Track:
   fra: Piste vidéo
   ita: Traccia video
   spa: Pista de video
-  zho: 视频轨
+  chs: 视频轨
   jpn: ビデオトラック
   rus: Видеодорожка
   por: Pista de vídeo
@@ -5642,7 +5657,7 @@ View:
   fra: Voir
   ita: Visualizza
   spa: Ver
-  zho: 查看
+  chs: 查看
   jpn: 閲覧
   rus: Просмотр
   por: Ver
@@ -5657,7 +5672,7 @@ View Changes:
   fra: Voir les changements
   ita: Visualizza le modifiche
   spa: Ver cambios
-  zho: 查看更新记录
+  chs: 查看更新记录
   jpn: 変更点を見る
   rus: Просмотр изменений
   por: Ver Alterações
@@ -5672,7 +5687,7 @@ View GUI Debug Logs:
   fra: Voir les journaux de débogage de l'interface graphique
   ita: Visualizza i registri di debug GUI
   spa: Ver los registros de depuración del GUI
-  zho: 查看GUI调试日志
+  chs: 查看GUI调试日志
   jpn: GUIのデバッグログを見る
   rus: Просмотр журналов отладки графического интерфейса
   por: Ver Registos de Depuração GUI
@@ -5688,8 +5703,8 @@ View GUI Debug Logs:
     plus volumineux'
   ita: 'ATTENZIONE: Ci vorrà molto più tempo e il risultato sarà un file più grande'
   spa: 'ADVERTENCIA: Esto tomará mucho más tiempo y resultará en un archivo más grande'
-  zho: 警告：这将导致转换用时大幅延长，输出文件体积增大。
-  jpn: 警告：この作業はかなりの時間がかかり、ファイルも大きくなります。
+  chs: 警告：这将导致转换用时大幅延长，输出文件体积增大。
+  jpn: 注意喚起：結果としてこの作業はかなりの時間がかかり、ファイルも大きくなります。
   rus: 'ВНИМАНИЕ: Это займет гораздо больше времени и приведет к увеличению размера
     файла'
   por: 'AVISO: Isto levará muito mais tempo e resultará num ficheiro maior'
@@ -5710,7 +5725,7 @@ Wait for the current command to finish, and stop the next command from processin
     comando successivo
   spa: Espere a que termine el comando actual y detenga el procesamiento del siguiente
     comando...
-  zho: 等待当前命令完成，之后暂不处理后面的命令
+  chs: 等待当前命令完成，之后暂不处理后面的命令
   jpn: 現在のコマンドが終了するのを待ち、次のコマンドの処理を停止する
   rus: Дождитесь завершения выполнения текущей команды и остановите обработку следующей
     команды
@@ -5728,7 +5743,7 @@ Wait for the current command to finish, and stop the next command from processin
   fra: "Avertissement : L'audio ne sera pas modifié"
   ita: "Attenzione: L'audio non verrà modificato"
   spa: 'Advertencia: El audio no será modificado'
-  zho: 警告： 音频不会被修改
+  chs: 警告： 音频不会被修改
   jpn: 注意喚起：音声は変えません
   rus: 'Предупреждение: Аудио не будет изменено'
   por: 'Advertência: O áudio não será modificado'
@@ -5743,7 +5758,7 @@ Watch:
   fra: Voir
   ita: Guarda
   spa: Mira
-  zho: 观看
+  chs: 观看
   jpn: 閲覧
   rus: Смотреть
   por: Ver
@@ -5758,7 +5773,7 @@ Width:
   fra: Ancho
   ita: Larghezza
   spa: Ancho
-  zho: 宽度
+  chs: 宽度
   jpn: 幅
   rus: Ширина
   por: Largura
@@ -5773,7 +5788,7 @@ Width must be divisible by 2:
   fra: La largeur doit être divisible par 2
   ita: La larghezza deve essere divisibile per 2
   spa: El ancho debe ser divisible por 2
-  zho: 宽度必须能被2整除
+  chs: 宽度必须能被2整除
   jpn: 幅が2で割り切れること
   rus: Ширина должна быть кратной 2
   por: A largura deve ser divisível por 2
@@ -5788,7 +5803,7 @@ Width must be divisible by 2 - Source width:
   fra: La largeur doit être divisible par 2 - Largeur de la source
   ita: La larghezza deve essere divisibile per 2 - Larghezza della sorgente
   spa: El ancho debe ser divisible por 2 - Ancho de la fuente
-  zho: 宽度必须能被2整除--源文件宽度
+  chs: 宽度必须能被2整除--源文件宽度
   jpn: 幅が2で割り切れること - ソースの幅
   rus: Ширина должна быть кратной 2 - Ширина источника
   por: A largura deve ser divisível por 2 - Largura da fonte
@@ -5803,7 +5818,7 @@ Will fix first subtitle track to not be default:
   fra: Fixera la première piste de sous-titres pour qu'elle ne soit pas par défaut
   ita: Correggerà la prima traccia dei sottotitoli per non essere predefinita
   spa: Arreglará que la primera pista de subtítulos no sea la predeterminada
-  zho: Will fix first subtitle track to not be default
+  chs: 将修正第1个字幕成不是默认
   jpn: 最初の字幕トラックがデフォルトにならないように修正する
   rus: Будет исправлено, чтобы первая дорожка субтитров не была дорожкой по умолчанию
   por: Irá corrigir a primeira faixa de legendas para não ser por defeito
@@ -5822,7 +5837,7 @@ With b-adapt 0, the GOP structure is fixed based on the values of --keyint and -
   ita: Con b-adapt 0, la struttura GOP è fissa in base ai valori di --keyint e --bframes.
   spa: Con b-adaptado 0, la estructura del GOP se fija en base a los valores de --keyint
     y --bframes.
-  zho: 当b-adapt为0时，图像组（Group Of Pictures, GOP）结构是根据--keyint和--bframes的值确定并固定的。
+  chs: 当b-adapt为0时，图像组（Group Of Pictures, GOP）结构是根据--keyint和--bframes的值确定并固定的。
   jpn: b-adapt 0では、--keyintおよび--bframesの値に基づいてGOP構造が固定されます。
   rus: При b-adapt 0 структура GOP фиксируется на основе значений параметров --keyint
     и --bframes.
@@ -5845,7 +5860,7 @@ With b-adapt 1 a light lookahead is used to choose B frame placement.:
     telaio B.
   spa: Con b-adapt 1 se utiliza un lookahead ligero para elegir la colocación del
     marco B.
-  zho: 当b-adapt为1时，通过轻量级的lookahead来选择B帧的位置。
+  chs: 当b-adapt为1时，通过轻量级的lookahead来选择B帧的位置。
   jpn: b-adapt 1では、Bフレームの配置を選択するために軽いルックアヘッドが使用されます。
   rus: При использовании b-adapt 1 для выбора размещения B-кадра используется легкая
     заставка.
@@ -5866,7 +5881,7 @@ With b-adapt 2 (trellis) a viterbi B path selection is performed:
   ita: Con b-adapt 2 (traliccio) viene eseguita una selezione del percorso viterbi
     B
   spa: Con b-adapt 2 (espaldera) se realiza una selección de trayectoria B viterbi
-  zho: 对于b-adapt 2 (trellis)，则执行viterbi B path selection。
+  chs: 对于b-adapt 2 (trellis)，则执行viterbi B path selection。
   jpn: b-adapt 2 (トレリス)では、ビタビB経路選択を行います。
   rus: С помощью b-адаптации 2 (решетка) выполняется выбор пути Витерби B
   por: Com b-adapt 2 (treliças) é efectuada uma selecção de caminhos viterbi B
@@ -5883,7 +5898,7 @@ Work Directory:
   fra: Répertoire des travaux
   ita: Elenco dei lavori
   spa: Directorio de trabajo
-  zho: 工作目录
+  chs: 工作目录
   jpn: 作業ディレクトリ
   rus: Рабочий каталог
   por: Directório de Trabalho
@@ -5898,8 +5913,8 @@ Yes:
   fra: Oui
   ita: Sì
   spa: Sì
-  zho: 是
-  jpn: はい。
+  chs: 是
+  jpn: はい
   rus: Да
   por: Sim
   swe: Ja
@@ -5913,7 +5928,7 @@ You are using the latest version of FastFlix:
   fra: Vous utilisez la dernière version de FastFlix
   ita: State utilizzando l'ultima versione di FastFlix
   spa: Está usando la última versión de FastFlix
-  zho: 当前FastFlix为最新版本
+  chs: 当前FastFlix为最新版本
   jpn: FastFlixは最新版です。
   rus: Вы используете последнюю версию FastFlix
   por: Está a utilizar a última versão de FastFlix
@@ -5928,7 +5943,7 @@ all conversions complete:
   fra: toutes les conversions sont terminées
   ita: tutte le conversioni completate
   spa: todas las conversiones se han completado
-  zho: 全部转换完成
+  chs: 全部转换完成
   jpn: すべての変換が完了
   rus: все преобразования завершены
   por: todas as conversões completas
@@ -5943,7 +5958,7 @@ already exists:
   fra: existe déjà
   ita: esiste già
   spa: ya existe
-  zho: 已有
+  chs: 已有
   jpn: 既に存在する
   rus: уже существует
   por: já existe
@@ -5961,7 +5976,7 @@ and the amount of work performed by the full trellis version of --b-adapt lookah
     di --b-adattate lookahead.
   spa: y la cantidad de trabajo realizado por la versión completa de la espaldera
     de --b-adaptado lookahead.
-  zho: lookahead在full(trellis)模式下执行的工作量有二次方的影响。
+  chs: lookahead在full(trellis)模式下执行的工作量有二次方的影响。
   jpn: と、フルtrellis版の--b-adapt lookaheadによる作業量を示しています。
   rus: и объем работы, выполняемой версией полной решетки --b-adapt lookahead.
   por: e a quantidade de trabalho realizado pela versão completa de --b-adapt lookahead.
@@ -5977,8 +5992,8 @@ and you want keyframes to be random access points.:
   fra: et vous voulez que les images clés soient des points d'accès aléatoires.
   ita: e si desidera che i fotogrammi chiave siano punti di accesso casuali.
   spa: y quieres que los fotogramas clave sean puntos de acceso aleatorios.
-  zho: and you want keyframes to be random access points.
-  jpn: で、キーフレームをランダムなアクセスポイントにしたい場合。
+  chs: 最好让关键帧做随机访问点。
+  jpn: で、キーフレームをランダムなアクセスポイントにしたほうがいい。
   rus: и вы хотите, чтобы ключевые кадры были случайными точками доступа.
   por: e pretende que os quadros-chave sejam pontos de acesso aleatórios.
   swe: och du vill att keyframes ska vara slumpmässiga åtkomstpunkter.
@@ -5992,7 +6007,7 @@ and you want keyframes to be random access points.:
   fra: 'aq-mode : Mode de fonctionnement de la quantification adaptative.'
   ita: 'aq-mode: Modalità operativa di quantizzazione adattiva.'
   spa: 'aq-mode: Modo de operación de Cuantificación Adaptativa.'
-  zho: aq-mode：自适应量化（Adaptive Quantization）工作模式。
+  chs: aq-mode：自适应量化（Adaptive Quantization）工作模式。
   jpn: aq-mode:Adaptive Quantization（適応型量子化）の動作モード。
   rus: 'aq-режим: Режим работы адаптивной квантизации.'
   por: 'aq-mode: Modo de operação de quantificação adaptativa.'
@@ -6007,7 +6022,7 @@ are mere suggestions!:
   fra: ne sont que des suggestions !
   ita: sono semplici suggerimenti!
   spa: son meras sugerencias!
-  zho: 的对应关系仅供参考
+  chs: 的对应关系仅供参考
   jpn: は単なる提案に過ぎません。
   rus: это всего лишь предположения!
   por: são meras sugestões!
@@ -6022,7 +6037,7 @@ attachment tracks found:
   fra: pistes d'attache trouvées
   ita: tracce di attacco trovate
   spa: pistas de adjuntos encontradas
-  zho: 发现附件轨
+  chs: 发现附件轨
   jpn: 添付トラックが見つかりました
   rus: найдены следы прикрепления
   por: rastos de anexos encontrados
@@ -6037,7 +6052,7 @@ audio tracks found:
   fra: pistes audio trouvées
   ita: tracce audio trovate
   spa: pistas de audio encontradas
-  zho: 发现音频轨
+  chs: 发现音频轨
   jpn: オーディオトラックが見つかりました
   rus: найдены звуковые дорожки
   por: faixas de áudio encontradas
@@ -6052,7 +6067,7 @@ b-adapt:
   fra: b-adapt
   ita: b-adatta
   spa: b-adapt
-  zho: b-adapt
+  chs: b-adapt
   jpn: b-adapt
   rus: b-adapt
   por: b-adapt
@@ -6070,7 +6085,7 @@ b-adapt:
     del telaio B.'
   spa: 'b-adaptado: Establece el nivel de esfuerzo para determinar la colocación del
     marco B.'
-  zho: b-adapt：对决定B帧位置时的工作量水平进行调整。
+  chs: b-adapt：对决定B帧位置时的工作量水平进行调整。
   jpn: B-ADAPTBフレームの配置を決定する際の努力の度合いを設定します。
   rus: 'b-adapt: Установите уровень усилий при определении размещения B кадра.'
   por: 'b-adapt: Definir o nível de esforço na determinação da colocação da moldura
@@ -6088,7 +6103,7 @@ bad micro value:
   fra: mauvaise micro valeur
   ita: micro valore negativo
   spa: mal valor micro
-  zho: bad micro value
+  chs: bad micro value
   jpn: バッドマイクロバリュー
   rus: плохое микрозначение
   por: mau microvalor
@@ -6108,8 +6123,8 @@ best is recommended if you have lots of time and want the best compression effic
     la migliore efficienza di compressione.
   spa: Se recomienda el mejor si tienes mucho tiempo y quieres la mejor eficiencia
     de compresión.
-  zho: 在时间充裕且希望获得最佳压缩效率的情况下，建议使用best。
-  jpn: 時間に余裕があり、最高の圧縮効率を求める場合には、最高の製品をお勧めします。
+  chs: 在时间充裕且希望获得最佳压缩效率的情况下，建议使用best。
+  jpn: 時間に余裕があり、最高の圧縮効率を求める場合には、bestを推奨します。
   rus: рекомендуется, если у вас много времени и вы хотите получить максимальную эффективность
     сжатия.
   por: o melhor é recomendado se tiver muito tempo e quiser a melhor eficiência de
@@ -6128,7 +6143,7 @@ bframes:
   fra: bframes
   ita: telai b
   spa: bframes
-  zho: b帧
+  chs: b帧
   jpn: Bフレーム
   rus: bframes
   por: quadros
@@ -6143,8 +6158,8 @@ bframes:
   fra: 'bframes : Nombre maximum de b-frames consécutives. '
   ita: 'bframes: Numero massimo di b-frame consecutivi. '
   spa: 'bframes: Número máximo de b-frames consecutivos. '
-  zho: bframes：连续B帧的最大数量。
-  jpn: bframes:連続するb-フレームの最大数。
+  chs: bframes：连续B帧的最大数量。
+  jpn: 'bframes:連続するb-フレームの最大数。'
   rus: 'bframes: Максимальное количество последовательных b-кадров.'
   por: 'quadros: Número máximo de b-frames consecutivos.'
   swe: 'bframes: Maximalt antal på varandra följande b-frames.'
@@ -6158,7 +6173,7 @@ but it has severe performance implications.:
   fra: mais elle a de graves implications en termes de performances.
   ita: ma ha gravi implicazioni in termini di prestazioni.
   spa: pero tiene severas implicaciones de rendimiento.
-  zho: 但对性能有严重影响。默认为根据CPU内核数和是否启用
+  chs: 但对性能有严重影响。默认为根据CPU内核数和是否启用
   jpn: しかし、これはパフォーマンスに大きく影響します。
   rus: но это имеет серьезные последствия для производительности.
   por: mas tem graves implicações em termos de desempenho.
@@ -6173,7 +6188,7 @@ but over a period of multiple frames instead of a single keyframe.:
   fra: mais sur une période de plusieurs images au lieu d'une seule image clé.
   ita: ma su un periodo di frame multipli invece di un singolo keyframe.
   spa: pero en un período de múltiples fotogramas en lugar de un solo fotograma clave.
-  zho: 从而刷新图像，而不使用单个关键帧。
+  chs: 从而刷新图像，而不使用单个关键帧。
   jpn: が、1つのキーフレームではなく、複数のフレームに渡って行われます。
   rus: но в течение нескольких кадров, а не одного ключевого кадра.
   por: mas durante um período de múltiplos quadros em vez de um único quadro-chave.
@@ -6188,7 +6203,7 @@ cannot modify generated settings:
   fra: ne peut pas modifier les paramètres générés
   ita: non può modificare le impostazioni generate
   spa: no puede modificar los ajustes generados
-  zho: 不能修改生成的设置
+  chs: 不能修改生成的设置
   jpn: 生成された設定を変更できない
   rus: не может изменять созданные настройки
   por: não pode modificar as configurações geradas
@@ -6203,7 +6218,7 @@ channels:
   fra: canaux
   ita: canali
   spa: canales
-  zho: 声道
+  chs: 声道
   jpn: チャンネル
   rus: каналы
   por: canais
@@ -6218,7 +6233,7 @@ codec:
   fra: codec
   ita: codec
   spa: códec
-  zho: codec
+  chs: codec
   jpn: コーデック
   rus: кодек
   por: codec
@@ -6233,7 +6248,7 @@ compression level:
   fra: niveau de compression
   ita: livello di compressione
   spa: nivel de compresión
-  zho: 压缩级别
+  chs: 压缩级别
   jpn: 圧縮レベル
   rus: степень сжатия
   por: nível de compressão
@@ -6248,7 +6263,7 @@ data tracks found:
   fra: pistes de données trouvées
   ita: tracce di dati trovati
   spa: pistas de datos encontradas
-  zho: 找到数据轨
+  chs: 找到数据轨
   jpn: データトラックが見つかりました
   rus: найдены дорожки данных
   por: pistas de dados encontradas
@@ -6263,7 +6278,7 @@ data tracks found:
   fra: 'dhdr10-opt : Réduire les frais généraux du SEI'
   ita: 'dhdr10-opt: Riduce le spese generali SEI'
   spa: 'dhdr10-opt: Reduce los gastos de SEI'
-  zho: 'dhdr10-opt：减少SEI开销'
+  chs: 'dhdr10-opt：减少SEI开销'
   jpn: 'dhdr10-opt:SEI のオーバーヘッドを削減'
   rus: 'dhdr10-opt: Уменьшает накладные расходы SEI'
   por: 'dhdr10-opt: Reduz as despesas gerais do SEI'
@@ -6278,7 +6293,7 @@ data tracks found:
   fra: 'exemples : level-idc=4.1:rc-lookahead=10'
   ita: 'esempi: level-idc=4.1:rc-lookahead=10'
   spa: 'ejemplos: level-idc=4.1:rc-lookahead=10'
-  zho: '示例：level-idc=4.1:rc-lookahead=10。'
+  chs: '示例：level-idc=4.1:rc-lookahead=10。'
   jpn: '例：level-idc=4.1:rc-lookahead=10'
   rus: 'примеры: level-idc=4.1:rc-lookahead=10'
   por: 'exemplos: level-idc=4.1:rc-lookahead=10'
@@ -6293,7 +6308,7 @@ data tracks found:
   fra: 'des fils de trame : Nombre de trames codées simultanément.'
   ita: 'telaio-filettature: Numero di frame codificati simultaneamente.'
   spa: 'Hilos de marcos: Número de cuadros codificados simultáneamente.'
-  zho: 'frame-threads：同时编码的帧数。'
+  chs: 'frame-threads：同时编码的帧数。'
   jpn: 'frame-threads。同時にエンコードされるフレームの数。'
   rus: 'frame-threads: Количество параллельно кодируемых кадров.'
   por: 'frame-threads: Número de quadros codificados em simultâneo.'
@@ -6309,7 +6324,7 @@ good is the default and recommended for most applications:
   fra: good est la valeur par défaut et est recommandé pour la plupart des applications
   ita: buono è il valore predefinito e raccomandato per la maggior parte delle applicazioni
   spa: bueno es el predeterminado y recomendado para la mayoría de las aplicaciones
-  zho: good是默认值，建议用于大多数应用。
+  chs: good是默认值，建议用于大多数应用。
   jpn: ほとんどの場合でgoodを推奨されています。
   rus: хороший - по умолчанию и рекомендуется для большинства приложений
   por: bom é o padrão e recomendado para a maioria das aplicações
@@ -6328,7 +6343,7 @@ good is the default and recommended for most applications:
     \ per i contenuti HDR10."
   spa: 'hdr10-opt: Habilitar la optimización de la luma a nivel de bloque y la QP
     cromática para el contenido de HDR10.'
-  zho: hdr10-opt：启用HDR10内容的块级亮度和色度量化参数（Quantization Parameter, QP）优化。
+  chs: hdr10-opt：启用HDR10内容的块级亮度和色度量化参数（Quantization Parameter, QP）优化。
   jpn: HDR10-OPT:HDR10コンテンツに対して、ブロックレベルでのルーマおよびクロマのQP最適化を有効にします。
   rus: 'hdr10-opt: Включение оптимизации QP на уровне яркости и цветности блока для
     контента HDR10.'
@@ -6347,7 +6362,7 @@ good is the default and recommended for most applications:
   fra: 'hdr10 : Forcer la signalisation des paramètres HDR10 dans les paquets SEI.'
   ita: 'hdr10: Forza la segnalazione dei parametri HDR10 nei pacchetti SEI.'
   spa: 'hdr10: Forzar la señalización de los parámetros HDR10 en los paquetes SEI.'
-  zho: hdr10：强制在SEI包中发送HDR10参数。
+  chs: hdr10：强制在SEI包中发送HDR10参数。
   jpn: 'hdr10: SEIパケットのHDR10パラメータのシグナリングを強制する。'
   rus: 'hdr10: принудительная передача параметров HDR10 в пакетах SEI.'
   por: 'hdr10: Forçar a sinalização dos parâmetros HDR10 em pacotes SEI.'
@@ -6362,7 +6377,7 @@ hq - High Quality, ll - Low Latency, ull - Ultra Low Latency:
   fra: hq - Haute qualité, ll - Latence faible, ull - Latence ultra faible
   ita: hq - Alta qualità, ll - Bassa latenza, ull - Ultra bassa latenza
   spa: hq - Alta calidad, ll - Baja latencia, ull - Ultra baja latencia
-  zho: hq - 高质量，ll - 低延迟，ull - 超低延迟。
+  chs: hq - 高质量，ll - 低延迟，ull - 超低延迟。
   jpn: hq - 高品質, ll - 低遅延, ull - 超低遅延
   rus: hq - высокое качество, ll - низкая задержка, ull - сверхнизкая задержка
   por: hq - Alta Qualidade, ll - Baixa Latência, ull - Latência Ultra Baixa
@@ -6377,7 +6392,7 @@ installer:
   fra: installateur
   ita: installatore
   spa: instalador
-  zho: 安装程序
+  chs: 安装程序
   jpn: インストーラ
   rus: установщик
   por: instalador
@@ -6395,7 +6410,7 @@ installer:
     \ del keyframe."
   spa: 'intra-refresco: Habilita el Refresco Intra Periódico (PIR) en lugar de la
     inserción de fotogramas clave.'
-  zho: intra-refresh：启用周期性帧内刷新（Periodic Intra Refresh, PIR）代替关键帧插入。
+  chs: intra-refresh：启用周期性帧内刷新（Periodic Intra Refresh, PIR）代替关键帧插入。
   jpn: イントラリフレシュキーフレーム挿入の代わりにPIR（Periodic Intra Refresh）を有効にします。
   rus: 'intra-refresh: Включает периодическое внутреннее обновление (PIR) вместо вставки
     ключевого кадра.'
@@ -6416,7 +6431,7 @@ is a default profile and will not be removed:
   fra: est un profil par défaut et ne sera pas supprimé
   ita: è un profilo predefinito e non verrà rimosso
   spa: es un perfil predeterminado y no se eliminará
-  zho: 是默认配置，不会被删除。
+  chs: 是默认配置，不会被删除。
   jpn: はデフォルトのプロファイルであり、削除されることはできません。
   rus: является профилем по умолчанию и не будет удален
   por: é um perfil padrão e não será removido
@@ -6431,7 +6446,7 @@ is extremely source dependant:
   fra: est extrêmement dépendante de la source
   ita: è estremamente dipendente dalla fonte
   spa: es extremadamente dependiente de la fuente
-  zho: 与源文件有很大关系
+  chs: 与源文件有很大关系
   jpn: はソースに大きく依存しています。
   rus: чрезвычайно зависит от источника
   por: é extremamente dependente da fonte
@@ -6446,8 +6461,8 @@ it will generally just increase memory use.:
   fra: elle ne fera généralement qu'augmenter l'utilisation de la mémoire.
   ita: in genere aumenta solo l'uso della memoria.
   spa: generalmente sólo aumentará el uso de la memoria.
-  zho: 一般只会增加内存占用。
-  jpn: は、一般的にメモリ使用量を増やすだけです。
+  chs: 一般只会增加内存占用。
+  jpn: それは、単にメモリ使用量が増えるだけです。
   rus: это, как правило, только увеличит использование памяти.
   por: geralmente só irá aumentar o uso de memória.
   swe: Det kommer i allmänhet bara att öka minnesanvändningen.
@@ -6466,7 +6481,7 @@ it will generally just increase memory use.:
     \ spec)"
   spa: 'keyint: Habilitar la intracodificación forzando los fotogramas clave cada
     1 segundo (Blu-ray spec)'
-  zho: 'keyint: Enable Intra-Encoding by forcing keyframes every 1 second (Blu-ray
+  chs: 'keyint: Enable Intra-Encoding by forcing keyframes every 1 second (Blu-ray
     spec)'
   jpn: 'keyint：1秒ごとにキーフレームを強制的に生成してイントラエンコードを有効にする（Blu-ray仕様）。'
   rus: 'keyint: Включить внутреннее кодирование путем принудительного воспроизведения
@@ -6488,7 +6503,7 @@ lossless:
   fra: sans perte
   ita: senza perdite
   spa: Lossless
-  zho: 无损
+  chs: 无损
   jpn: ロスレス
   rus: без потерь
   por: sem perdas
@@ -6508,9 +6523,9 @@ lossless:
     \ per il flusso di uscita"
   spa: 'tamaño_muxing_queue_size: Subir para corregir el error "Demasiados paquetes
     almacenados en la memoria intermedia para el flujo de salida".'
-  zho: max_muxing_queue_size：提高以解决 "输出流缓冲的数据包太多（Too many packets buffered for output
+  chs: max_muxing_queue_size：提高以解决 "输出流缓冲的数据包太多（Too many packets buffered for output
     stream）"的错误。
-  jpn: max_muxing_queue_sizeを変更しました。出力ストリームにバッファリングされるパケット数が多すぎる」というエラーを修正するために値を上げる。
+  jpn: max_muxing_queue_size 「出力ストリームにバッファリングされるパケット数が多すぎる」というエラーが発生した場合は値を上げてください。
   rus: 'max_muxing_queue_size: Повышение для исправления ошибки "Слишком много пакетов
     буферизировано для выходного потока"'
   por: 'max_muxing_queue_queue_size: Aumentar para corrigir o erro "Demasiados pacotes
@@ -6530,7 +6545,7 @@ none:
   fra: aucun
   ita: nessuno
   spa: ninguno
-  zho: 无
+  chs: 无
   jpn: なし
   rus: нет
   por: nenhuma
@@ -6545,7 +6560,7 @@ of:
   fra: de
   ita: di
   spa: de
-  zho: 条，总计
+  chs: 条，总计
   jpn: の
   rus: из
   por: de
@@ -6560,7 +6575,7 @@ out file is already in queue:
   fra: notre dossier est déjà dans la file d'attente
   ita: il file in uscita è già in coda
   spa: nuestro archivo ya está en la cola
-  zho: out file is already in queue
+  chs: 输出文件已在队列中
   jpn: アウトファイルがすでにキューに入っている
   rus: выходной файл уже находится в очереди
   por: O ficheiro já está em fila de espera
@@ -6575,7 +6590,7 @@ portable:
   fra: portable
   ita: portatile
   spa: portátil
-  zho: 可移动
+  chs: 可移动
   jpn: ポータブル
   rus: портативный
   por: portátil
@@ -6590,7 +6605,7 @@ preset:
   fra: préréglage
   ita: preimpostato
   spa: preestablecido
-  zho: 预设
+  chs: 预设
   jpn: プリセット
   rus: предустановка
   por: pré-definido
@@ -6608,7 +6623,7 @@ preset:
   ita: 'preimpostata: Più lento è il preset, migliore è la compressione e la qualità'
   spa: 'preestablecido: Cuanto más lento el preajuste, mejor será la compresión y
     la calidad'
-  zho: 'preset：较慢的预设能提供更好的压缩比和质量。'
+  chs: 'preset：较慢的预设能提供更好的压缩比和质量。'
   jpn: 'プリセットの速度が遅いほど、圧縮率と品質が向上します。'
   rus: 'предустановка: Чем медленнее предустановка, тем лучше сжатие и качество'
   por: 'pré-definido: Quanto mais lenta for a predefinição, melhor será a compressão
@@ -6626,7 +6641,7 @@ preventing large-scale patterns such as color banding in images.:
   fra: empêcher les motifs à grande échelle comme les bandes de couleur dans les images.
   ita: impedendo modelli su larga scala come le bande di colore nelle immagini.
   spa: evitando patrones a gran escala como las bandas de color en las imágenes.
-  zho: 用以防止图像中出现色带等大面积图案。
+  chs: 用以防止图像中出现色带等大面积图案。
   jpn: 画像のカラーバンディングのような大規模なパターンを防ぐことができます。
   rus: предотвращение крупномасштабных деталей, таких как цветовые полосы на изображениях.
   por: prevenindo padrões em grande escala, tais como bandas de cor em imagens.
@@ -6642,7 +6657,7 @@ profile:
   fra: profil
   ita: profilo
   spa: perfil
-  zho: 配置
+  chs: 配置
   jpn: プロフィール
   rus: профиль
   por: perfil
@@ -6657,7 +6672,7 @@ profile:
   fra: 'profil : Appliquer un profil de codage'
   ita: 'profilo: Applicare un profilo di codifica'
   spa: 'perfil: Hacer cumplir un perfil codificado'
-  zho: '配置：应用一个编码配置'
+  chs: '配置：应用一个编码配置'
   jpn: 'プロフィール：エンコードプロファイルを適用してください。'
   rus: 'профиль: Применить профиль кодирования'
   por: 'perfil: Forçar um perfil de codificação'
@@ -6674,7 +6689,7 @@ profile:
     punta'
   spa: 'perfil: Perfil de codificación del VP9 - debe coincidir con la profundidad
     del bit'
-  zho: '配置：VP9编码规格——必须与位深度相匹配。'
+  chs: '配置：VP9编码规格——必须与位深度相匹配。'
   jpn: 'プロファイルを使用しています。VP9コーディングプロファイル - ビット深度と一致する必要があります'
   rus: 'профиль: Профиль кодирования VP9 - должен соответствовать битовой глубине'
   por: 'perfil: perfil de codificação VP9 - deve corresponder à profundidade do bit'
@@ -6690,14 +6705,14 @@ python-box:
   fra: python-box
   ita: python-box
   spa: python-box
-  zho: python-box
+  chs: python-box
   jpn: python-box
   rus: python-box
   por: python-box
   swe: python-box
   pol: python-box
   ukr: python-box
-  kor: 파이썬 박스
+  kor: python-box
   ron: python-box
 rav1e github:
   deu: rav1e github
@@ -6705,14 +6720,14 @@ rav1e github:
   fra: rav1e github
   ita: github rav1e
   spa: rav1e github
-  zho: rav1e github
+  chs: rav1e github
   jpn: rav1e github
   rus: rav1e github
   por: rav1e github
   swe: rav1e github
   pol: rav1e github
   ukr: rav1e github
-  kor: rav1e 깃허브
+  kor: rav1e github
   ron: rav1e github
 'repeat-headers: If enabled, x265 will emit VPS, SPS, and PPS headers with every keyframe.':
   deu: 'Kopfzeilen wiederholen: Wenn aktiviert, gibt x265 mit jedem Keyframe VPS-,
@@ -6725,7 +6740,7 @@ rav1e github:
     ogni fotogramma chiave.'
   spa: 'repetición de los encabezamientos: Si se activa, x265 emitirá encabezados
     VPS, SPS y PPS con cada fotograma clave.'
-  zho: repeat-headers：如果启用，x265将随每个关键帧加入VPS，SPS和PPS标头。
+  chs: repeat-headers：如果启用，x265将随每个关键帧加入VPS，SPS和PPS标头。
   jpn: repeat-headersを有効にすると、x265はキーフレームごとにVPS、SPS、PPSの各ヘッダを出力します。
   rus: 'повторять заголовки: Если включено, x265 будет выдавать заголовки VPS, SPS
     и PPS с каждым ключевым кадром.'
@@ -6750,7 +6765,7 @@ since the entire reference frames are always available for motion compensation,:
     del movimento,
   spa: ya que todos los fotogramas de referencia están siempre disponibles para la
     compensación de movimiento,
-  zho: 因为总是可以获取完整的参考帧来进行运动补偿，
+  chs: 因为总是可以获取完整的参考帧来进行运动补偿，
   jpn: は、リファレンスフレーム全体が常に動きの補正に利用できるからです。
   rus: поскольку для компенсации движения всегда доступны все опорные кадры,
   por: uma vez que todos os quadros de referência estão sempre disponíveis para compensação
@@ -6767,7 +6782,7 @@ starting next command:
   fra: démarrage de la commande suivante
   ita: avvio del prossimo comando
   spa: comenzando el siguiente comando
-  zho: 正在开始下一条命令
+  chs: 正在开始下一条命令
   jpn: 次のコマンドの開始
   rus: запуск следующей команды
   por: início do próximo comando
@@ -6782,7 +6797,7 @@ subtitle tracks found:
   fra: Les pistes de sous-titres trouvées
   ita: tracce sottotitoli trovati
   spa: pistas de subtítulos encontradas
-  zho: 找到字幕轨
+  chs: 找到字幕轨
   jpn: 字幕トラックが見つかりました
   rus: найдены дорожки субтитров
   por: legendas encontradas
@@ -6800,7 +6815,7 @@ that move across the video from one side to the other and thereby refresh the im
   ita: che si muovono attraverso il video da un lato all'altro e quindi rinfrescano
     l'immagine
   spa: que se mueven a través del video de un lado a otro y así refrescan la imagen
-  zho: 这些intra blocks的位置在若干帧的时间内从视频一侧移动到另一侧，
+  chs: 这些intra blocks的位置在若干帧的时间内从视频一侧移动到另一侧，
   jpn: 画像の中を左右に移動することで画像を更新する
   rus: которые перемещаются по видео с одной стороны на другую и тем самым обновляют
     изображение
@@ -6819,7 +6834,7 @@ the resolution-to-:
   fra: la reso
   ita: il risuonare
   spa: la reso
-  zho: 分辨率与
+  chs: 分辨率与
   jpn: 解像度と
   rus: разрешение на
   por: a resolução de
@@ -6834,7 +6849,7 @@ to Blu-ray standards to burn to a physical disk:
   fra: a los estándares de Blu-ray para grabar en un disco físico
   ita: agli standard Blu-ray per masterizzare su un disco fisico
   spa: a los estándares de Blu-ray para grabar en un disco físico
-  zho: 否则不建议启用该选项。
+  chs: 否则不建议启用该选项。
   jpn: Blu-ray規格で物理ディスクに書き込むために
   rus: в стандарты Blu-ray для записи на физический диск
   por: para os padrões Blu-ray para queimar num disco físico
@@ -6851,8 +6866,8 @@ to Blu-ray standards to burn to a physical disk:
   ita: 'sintonizzarsi: Sintonizzare le impostazioni per un particolare tipo di sorgente
     o situazione'
   spa: 'afinar: Sintonizar los ajustes para un tipo de fuente o situación particular'
-  zho: tune：针对特定类型的来源或情况调整设置。
-  jpn: をチューニングします。特定の種類のソースや状況に合わせて設定をチューニングする
+  chs: 针对特定类型的来源或情况调整设置。
+  jpn: 特定の種類のソースや状況に合わせて設定をチューニングする
   rus: 'настраивать: Настроить параметры для определенного типа источника или ситуации'
   por: 'melodia: Sintonizar as definições para um determinado tipo de fonte ou situação'
   swe: 'melodi: Justera inställningarna för en viss typ av källa eller situation.'
@@ -6866,7 +6881,7 @@ video tracks found:
   fra: pistas de vídeo encontradas
   ita: tracce video trovate
   spa: pistas de vídeo encontradas
-  zho: 发现视频轨
+  chs: 发现视频轨
   jpn: ビデオトラック発見
   rus: найдены видеодорожки
   por: faixas de vídeo encontradas
@@ -6881,7 +6896,7 @@ vsync:
   fra: vsync
   ita: vsync
   spa: vsync
-  zho: vsync
+  chs: vsync
   jpn: vsync
   rus: vsync
   por: vsync
@@ -6896,7 +6911,7 @@ There are no videos to start converting:
   fra: Il n'y a pas de vidéos à convertir
   ita: Non ci sono video da convertire
   spa: No hay vídeos para empezar a convertir
-  zho: 没有视频可以开始转换
+  chs: 没有视频可以开始转换
   jpn: 変換する動画はありません
   rus: Нет видео, чтобы начать конвертацию
   por: Não há vídeos para começar a converter
@@ -6914,7 +6929,7 @@ No crop, scale, rotation,flip nor any other filters will be applied.:
   ita: Nessun ritaglio, scala, rotazione, flip o qualsiasi altro filtro sarà applicato.
   spa: No se aplicará ningún filtro de recorte, escala, rotación, volteo ni ningún
     otro.
-  zho: 不会应用裁切、缩放、旋转、翻转或任何其他滤镜。
+  chs: 不会应用裁切、缩放、旋转、翻转或任何其他滤镜。
   jpn: クロップ、スケール、ローテーション、フリップなどのフィルターは適用されません。
   rus: Обрезка, масштабирование, поворот, переворот и другие фильтры не применяются.
   por: Não se aplicará cultura, escala, rotação,flip nem qualquer outro filtro.
@@ -6931,7 +6946,7 @@ Are you sure you want to stop the current encode?:
   fra: Êtes-vous sûr de vouloir arrêter le codage actuel?
   ita: Sei sicuro di voler fermare la codifica in corso?
   spa: ¿Está seguro de que quiere detener la codificación actual?
-  zho: 你确定要停止当前的编码吗？
+  chs: 你确定要停止当前的编码吗？
   jpn: 本当に現在実行中のエンコードを中止してもいいですか？
   rus: Вы уверены, что хотите остановить текущее кодирование?
   por: Tem a certeza de que quer parar o código actual?
@@ -6946,7 +6961,7 @@ Confirm Stop Encode:
   fra: Confirmer le code d'arrêt
   ita: Confermare Stop Encode
   spa: Confirmar parada de codificación
-  zho: 确认停止编码
+  chs: 确认停止编码
   jpn: エンコード中止を確認
   rus: Подтверждение остановки кодирование
   por: Confirmar Codificação de paragem
@@ -6961,7 +6976,7 @@ Use Sane Audio Selection (updatable in config file):
   fra: Utiliser la sélection audio (mise à jour dans le fichier de configuration)
   ita: Usa la selezione audio (aggiornabile nel file di configurazione)
   spa: Utilizar la selección de audio (actualizable en el archivo de configuración)
-  zho: 使用音频合理选择（可在配置文件中更改）
+  chs: 使用音频合理选择（可在配置文件中更改）
   jpn: 合理的なオーディオを選択する（設定ファイルで変更可能）
   rus: Используйте Разумный выбор аудио (обновляется в конфигурационном файле)
   por: Use Sane Audio Selection (actualizável em ficheiro de configuração)
@@ -6976,7 +6991,7 @@ HDR10+ Parser:
   fra: HDR10+ Parser
   ita: HDR10+ Parser
   spa: Analizador HDR10+
-  zho: HDR10+解析器
+  chs: HDR10+解析器
   jpn: HDR10+分析器
   rus: Парсер HDR10+
   por: HDR10+ Parser
@@ -6991,7 +7006,7 @@ Not all items in the queue were completed:
   fra: Tous les articles dans la file d'attente n'ont pas été complétés
   ita: Non tutti gli elementi in coda sono stati completati
   spa: No se han completado todos los elementos de la cola
-  zho: 队列中有未完成的项目
+  chs: 队列中有未完成的项目
   jpn: キュー内のすべてのアイテムが完了していない
   rus: Не все пункты в очереди были завершены
   por: Nem todos os itens da fila foram completados
@@ -7006,7 +7021,7 @@ Would you like to keep them in the queue?:
   fra: Souhaitez-vous les garder dans la file d'attente?
   ita: Volete tenerli in coda?
   spa: ¿Quiere mantenerlos en la cola?
-  zho: 你想把他们留在队列中吗？
+  chs: 你想把他们留在队列中吗？
   jpn: このままキューに残しますか？
   rus: Хотите ли вы оставить их в очереди?
   por: Gostaria de os manter na fila de espera?
@@ -7021,7 +7036,7 @@ Recover Queue Items:
   fra: Récupérer les articles en file d'attente
   ita: Recuperare elementi della coda
   spa: Recuperar elementos de la cola
-  zho: 恢复队列中的项目
+  chs: 恢复队列中的项目
   jpn: キューアイテムの復元
   rus: Восстановление элементов очереди
   por: Recuperar artigos em fila de espera
@@ -7036,7 +7051,7 @@ There is already a video being processed:
   fra: Il y a déjà une vidéo en cours de traitement
   ita: C'è già un video in elaborazione
   spa: Ya hay un vídeo en proceso
-  zho: 已经有一个视频正在处理中
+  chs: 已经有一个视频正在处理中
   jpn: すでに処理中の動画があります
   rus: Видео уже обрабатывается
   por: Já há um vídeo a ser processado
@@ -7051,7 +7066,7 @@ Are you sure you want to discard it?:
   fra: Êtes-vous sûr de vouloir la supprimer?
   ita: Sei sicuro di volerlo scartare?
   spa: ¿Estás seguro de que quieres descartarlo?
-  zho: 您确定要丢弃它吗？
+  chs: 您确定要丢弃它吗？
   jpn: 本当に破棄してもいいですか？
   rus: Вы уверены, что хотите отказаться от него?
   por: Tem a certeza de que quer descartá-la?
@@ -7066,7 +7081,7 @@ Discard current video:
   fra: Jeter la vidéo actuelle
   ita: Scartare il video corrente
   spa: Descartar el vídeo actual
-  zho: 丢弃当前视频
+  chs: 丢弃当前视频
   jpn: 現在の動画を破棄する
   rus: Удалить текущее видео
   por: Descarte vídeo actual
@@ -7081,14 +7096,14 @@ FastFlix Wiki:
   fra: FastFlix Wiki
   ita: FastFlix Wiki
   spa: FastFlix Wiki
-  zho: FastFlix Wiki
+  chs: FastFlix Wiki
   jpn: FastFlix Wiki
   rus: FastFlix Wiki
   por: FastFlix Wiki
   swe: FastFlix Wiki
   pol: FastFlix Wiki
   ukr: FastFlix Вікі
-  kor: FastFlix 위키
+  kor: FastFlix Wiki
   ron: FastFlix Wiki
 Custom VCEEncC options:
   deu: angepasste VCEEncC-Optionen
@@ -7096,7 +7111,7 @@ Custom VCEEncC options:
   fra: Options VCEEncC personnalisées
   ita: Opzioni VCEEncC personalizzate
   spa: Opciones personalizadas de VCEEncC
-  zho: 自定义VCEEncC选项
+  chs: 自定义VCEEncC选项
   jpn: VCEEncCのカスタムオプション
   rus: Пользовательские опции VCEEncC
   por: Opções VCEEncC personalizadas
@@ -7111,7 +7126,7 @@ VBAQ:
   fra: VBAQ
   ita: VBAQ
   spa: VBAQ
-  zho: VBAQ
+  chs: VBAQ
   jpn: VBAQ
   rus: VBAQ
   por: VBAQ
@@ -7126,7 +7141,7 @@ Variance Based Adaptive Quantization:
   fra: Quantification adaptative basée sur la variance
   ita: Quantizzazione adattiva basata sulla varianza
   spa: Cuantización adaptativa basada en la varianza
-  zho: 基于方差的自适应量化
+  chs: 基于方差的自适应量化
   jpn: Variance Based Adaptive Quantization（分散ベースの適応型量子化）
   rus: Адаптивное квантование на основе дисперсии
   por: Quantização Adaptativa com Base na Variância
@@ -7141,7 +7156,7 @@ Pre Encode:
   fra: Précodage
   ita: Pre-codifica
   spa: Precodificación
-  zho: 预编码
+  chs: 预编码
   jpn: プリエンコード
   rus: Предварительное кодирование
   por: Pré-Codificação
@@ -7156,7 +7171,7 @@ Pre Analysis:
   fra: Préanalyse
   ita: Pre analisi
   spa: Análisis previo
-  zho: 预分析
+  chs: 预分析
   jpn: 事前分析
   rus: Предварительный анализ
   por: Pré-análise
@@ -7171,7 +7186,7 @@ VCEEncC Options:
   fra: Options VCEEncC
   ita: Opzioni VCEEncC
   spa: Opciones de VCEEncC
-  zho: VCEEncC选项
+  chs: VCEEncC选项
   jpn: VCEEncCオプション
   rus: Опции VCEEncC
   por: Opções VCEEncC
@@ -7186,7 +7201,7 @@ VCEEncC Encoder support is still experimental!:
   fra: Le support des encodeurs VCEEncC est encore expérimental !
   ita: Il supporto VCEEncC Encoder è ancora sperimentale!
   spa: La compatibilidad con el codificador VCEEncC es todavía experimental.
-  zho: VCEEncC编码器支持仍然是实验性的!
+  chs: VCEEncC编码器支持仍然是实验性的!
   jpn: VCEEncCエンコーダのサポートはまだ実験的なものです。
   rus: Поддержка кодировщика VCEEncC все еще является экспериментальной!
   por: O suporte do codificador VCEEncC ainda é experimental!
@@ -7201,7 +7216,7 @@ Profile:
   fra: profil
   ita: profilo
   spa: perfil
-  zho: 配置
+  chs: 配置
   jpn: プロフィール
   rus: Профиль
   por: Perfil
@@ -7216,7 +7231,7 @@ Decoder:
   fra: Décodeur
   ita: Decoder
   spa: Decodificador
-  zho: 解码器
+  chs: 解码器
   jpn: デコーダ
   rus: Декодер
   por: Descodificador
@@ -7231,7 +7246,7 @@ Decoder:
   fra: "Hardware : utiliser libavformat + décodeur matériel pour l'entrée"
   ita: "Hardware: usa libavformat + decoder hardware per l'ingresso"
   spa: 'Hardware: utilizar libavformat + decodificador de hardware para la entrada'
-  zho: 'Hardware：使用libavformat+硬件解码器'
+  chs: 'Hardware：使用libavformat+硬件解码器'
   jpn: 'ハードウェア：入力にlibavformat＋ハードウェアデコーダを使用'
   rus: 'Аппаратное обеспечение: использование libavformat + аппаратного декодера для
     ввода'
@@ -7248,7 +7263,7 @@ Decoder:
   fra: 'Software : utiliser avcodec + décodeur logiciel'
   ita: 'Software: usa avcodec + decoder software'
   spa: 'Software: utilizar avcodec + decodificador de software'
-  zho: 'Software：使用avcodec + 软件解码器'
+  chs: 'Software：使用avcodec + 软件解码器'
   jpn: 'ソフトウェア：avcodec + ソフトウェアデコーダを使用'
   rus: 'Программное обеспечение: используйте avcodec + программный декодер'
   por: 'Software: utilizar avcodec + descodificador de software'
@@ -7263,7 +7278,7 @@ Preview - Press Q to Exit:
   fra: Aperçu - Appuyez sur Q pour quitter
   ita: Anteprima - Premere Q per uscire
   spa: Vista previa - Pulse Q para salir
-  zho: 预览 - 按Q键退出
+  chs: 预览 - 按Q键退出
   jpn: プレビュー - Qを押して終了
   rus: Предпросмотр - Нажмите Q для выхода
   por: Pré-visualização - Imprensa Q para Sair
@@ -7278,7 +7293,7 @@ Tools:
   fra: Outils
   ita: Strumenti
   spa: Herramientas
-  zho: 工具
+  chs: 工具
   jpn: ツール
   rus: Инструменты
   por: Ferramentas
@@ -7293,7 +7308,7 @@ Concatenation Builder:
   fra: Créateur de concaténation
   ita: Costruttore di concatenazioni
   spa: Constructor de Concatenación
-  zho: 创建合并序列
+  chs: 创建合并序列
   jpn: 連結ビルダー
   rus: Конструктор конкатенации
   por: Construtor de Concatenação
@@ -7308,7 +7323,7 @@ Brightness:
   fra: Luminosité
   ita: Luminosità
   spa: Brillo
-  zho: 亮度
+  chs: 亮度
   jpn: 明るさ
   rus: Яркость
   por: Luminosidade
@@ -7323,7 +7338,7 @@ Contrast:
   fra: Contraste
   ita: Contrasto
   spa: Contraste
-  zho: 对比度
+  chs: 对比度
   jpn: コントラスト
   rus: Контраст
   por: Contraste
@@ -7338,7 +7353,7 @@ Saturation:
   fra: Saturation
   ita: Saturazione
   spa: Saturación
-  zho: 饱和度
+  chs: 饱和度
   jpn: 飽和
   rus: Насыщенность
   por: Saturação
@@ -7353,7 +7368,7 @@ Trim:
   fra: Découpage
   ita: Trim
   spa: Recorte
-  zho: 修剪
+  chs: 修剪
   jpn: トリム
   rus: Подрезка
   por: Trim
@@ -7368,7 +7383,7 @@ Resolution:
   fra: Résolution
   ita: Risoluzione
   spa: Resolución
-  zho: 分辨率
+  chs: 分辨率
   jpn: 解像度
   rus: Разрешение
   por: Resolução
@@ -7383,7 +7398,7 @@ Theme:
   fra: Thème
   ita: Tema
   spa: Tema
-  zho: 主题
+  chs: 主题
   jpn: テーマ
   rus: Тема
   por: Tema
@@ -7398,7 +7413,7 @@ Base Folder:
   fra: Dossier de base
   ita: Cartella base
   spa: Carpeta base
-  zho: 当前文件夹
+  chs: 当前文件夹
   jpn: ベースフォルダー
   rus: Базовая папка
   por: Pasta de base
@@ -7413,7 +7428,7 @@ Open Folder:
   fra: Ouvrir le dossier
   ita: Aprire la cartella
   spa: Abrir carpeta
-  zho: 打开文件夹
+  chs: 打开文件夹
   jpn: フォルダを開く
   rus: Открыть папку
   por: Pasta Aberta
@@ -7428,7 +7443,7 @@ Load:
   fra: Charger
   ita: Carica
   spa: Cargar
-  zho: 载入
+  chs: 载入
   jpn: ロード
   rus: Загрузка
   por: Carga
@@ -7446,8 +7461,8 @@ Drag and Drop to reorder - All items need to be same dimensions:
   ita: Drag and Drop per riordinare - Tutti gli elementi devono avere le stesse dimensioni
   spa: Arrastrar y soltar para reordenar - Todos los elementos deben tener las mismas
     dimensiones
-  zho: '拖放来重新排序 - 所有项目的尺寸都需要相同'
-  jpn: 'ドラッグ＆ドロップで並び替え - すべてのアイテムが同じ寸法である必要があります。'
+  chs: 拖放来重新排序 - 所有项目的尺寸都需要相同
+  jpn: ドラッグ＆ドロップで並び替え - すべてのアイテムが同じ寸法である必要があります。
   rus: Перетаскивание для изменения порядка - все элементы должны иметь одинаковые
     размеры
   por: Arrastar e largar para reordenar - Todos os artigos precisam de ter as mesmas
@@ -7470,7 +7485,7 @@ The following items were excluded as they could not be identified as image or vi
     come file immagine o video
   spa: Se han excluido los siguientes elementos por no poder ser identificados como
     archivos de imagen o vídeo
-  zho: 以下项目被排除在外，因为它们无法被识别为图像或视频文件
+  chs: 以下项目被排除在外，因为它们无法被识别为图像或视频文件
   jpn: 以下のものは、画像・動画ファイルとして識別できないため、除外しました。
   rus: Следующие элементы были исключены, поскольку их нельзя было идентифицировать
     как файлы изображений или видеофайлы
@@ -7491,7 +7506,7 @@ There are already items in this list:
   fra: Il y a déjà des éléments dans cette liste
   ita: Ci sono già elementi in questa lista
   spa: Ya hay elementos en esta lista
-  zho: 此列表中已经有项目
+  chs: 此列表中已经有项目
   jpn: このリストにはすでにアイテムがあります
   rus: В этом списке уже есть пункты
   por: Já existem itens nesta lista
@@ -7506,7 +7521,7 @@ if you open a new directory, they will all be removed.:
   fra: si vous ouvrez un nouveau répertoire, ils seront tous supprimés.
   ita: se si apre una nuova directory, saranno tutti rimossi.
   spa: si abre un nuevo directorio, se eliminarán todos.
-  zho: 如果你打开一个新的目录，它们将被全部删除。
+  chs: 如果你打开一个新的目录，它们将被全部删除。
   jpn: 新しいディレクトリを開いた場合、それらはすべて削除されます。
   rus: если вы откроете новый каталог, все они будут удалены.
   por: se se abrir um novo directório, todos eles serão removidos.
@@ -7521,7 +7536,7 @@ Continue:
   fra: Continuer
   ita: Continua
   spa: Continuar
-  zho: 继续
+  chs: 继续
   jpn: 続ける
   rus: Продолжить
   por: Continuar
@@ -7536,7 +7551,7 @@ Confirm Change Folder:
   fra: Confirmer le changement de dossier
   ita: Conferma il cambio di cartella
   spa: Confirmar cambio de carpeta
-  zho: 确认更改文件夹
+  chs: 确认更改文件夹
   jpn: 変更フォルダの確認
   rus: Подтверждение изменения папки
   por: Confirmar Pasta de Mudança
@@ -7551,7 +7566,7 @@ does not support concatenating files together:
   fra: ne supporte pas la concaténation de fichiers ensemble
   ita: non supporta la concatenazione di file
   spa: no admite la concatenación de archivos
-  zho: 不支持将文件合并起来
+  chs: 不支持将文件合并起来
   jpn: は、ファイルの連結をサポートしていません。
   rus: не поддерживает конкатенацию файлов вместе
   por: não suporta a concatenação de ficheiros em conjunto
@@ -7568,7 +7583,7 @@ does not support concatenating files together:
   ita: 'ATTENZIONE: Questa funzione non è fornita direttamente dal software di codifica'
   spa: 'ADVERTENCIA: Esta función no es proporcionada por el software del codificador
     directamente'
-  zho: 警告：编码器软件不直接提供这一功能。
+  chs: 警告：编码器软件不直接提供这一功能。
   jpn: 注意喚起：この機能は、エンコーダソフトウェアが直接提供するものではありません。
   rus: 'ВНИМАНИЕ: Эта функция не обеспечивается непосредственно программным обеспечением
     энкодера'
@@ -7586,7 +7601,7 @@ It is NOT supported by VCE or NVENC encoders, it will break the encoding:
   fra: Elle n'est PAS supportée par les encodeurs VCE ou NVENC, elle interrompra l'encodage.
   ita: NON è supportata dagli encoder VCE o NVENC, interromperà la codifica
   spa: NO es soportada por los codificadores VCE o NVENC, romperá la codificación
-  zho: VCE或NVENC编码器不支持该功能，它将破坏编码。
+  chs: VCE或NVENC编码器不支持该功能，它将破坏编码。
   jpn: VCEやNVENCのエンコーダではサポートされていません。
   rus: Он НЕ поддерживается кодировщиками VCE или NVENC, это нарушит кодирование
   por: NÃO é suportado por codificadores VCE ou NVENC, irá quebrar a codificação
@@ -7601,7 +7616,7 @@ Are you sure you want to continue?:
   fra: Etes-vous sûr de vouloir continuer?
   ita: Sei sicuro di voler continuare?
   spa: ¿Está seguro de que desea continuar?
-  zho: 你确定你要继续吗?
+  chs: 你确定你要继续吗?
   jpn: 本当に続けてもいいですか？
   rus: Вы уверены, что хотите продолжать?
   por: Tem a certeza de que quer continuar?
@@ -7616,7 +7631,7 @@ Pause Warning:
   fra: Pause Avertissement
   ita: Avviso di pausa
   spa: Advertencia de pausa
-  zho: 暂停警告
+  chs: 暂停警告
   jpn: 中止注意
   rus: Предупреждение о паузе
   por: Aviso de Pausa
@@ -7632,7 +7647,7 @@ First:
   fra: Premier
   ita: Prima
   spa: Primero
-  zho: 开始
+  chs: 开始
   jpn: 先頭
   rus: Первый
   por: Primeiro
@@ -7647,7 +7662,7 @@ Last:
   fra: Dernier site
   ita: Ultimo
   spa: Última
-  zho: 最后
+  chs: 最后
   jpn: 最後
   rus: Последний
   por: Último
@@ -7662,7 +7677,7 @@ Track Number:
   fra: Numéro de piste
   ita: Numero di traccia
   spa: Número de pista
-  zho: 轨道编号
+  chs: 轨道编号
   jpn: トラック番号
   rus: Номер дорожки
   por: Número da faixa
@@ -7677,7 +7692,7 @@ Channels:
   fra: Chaînes
   ita: Canali
   spa: Canales
-  zho: 声道
+  chs: 声道
   jpn: チャンネル
   rus: Каналы
   por: Canais
@@ -7692,7 +7707,7 @@ Audio Select:
   fra: Sélection audio
   ita: Selezione audio
   spa: Selección de audio
-  zho: 音频选择
+  chs: 音频选择
   jpn: オーディオ選択
   rus: Выбор аудио
   por: Selecione o áudio
@@ -7707,7 +7722,7 @@ Passthrough All:
   fra: Passthrough Tous
   ita: Passthrough Tutti
   spa: Transferencia Todos
-  zho: 所有不更改
+  chs: 所有不更改
   jpn: 全てパススルー
   rus: Пропускная способность Все
   por: Passagem de tudo
@@ -7722,7 +7737,7 @@ Add Pattern Match:
   fra: Ajouter une correspondance de motifs
   ita: Aggiungere la corrispondenza del modello
   spa: Añadir coincidencia de patrones
-  zho: 添加模式匹配
+  chs: 添加模式匹配
   jpn: パターンマッチの追加
   rus: Добавить сопоставление шаблонов
   por: Adicionar Padrão de Combinação
@@ -7737,7 +7752,7 @@ contains:
   fra: contient
   ita: contiene
   spa: contiene
-  zho: 包含
+  chs: 包含
   jpn: を含む
   rus: содержит
   por: contém
@@ -7752,7 +7767,7 @@ Match:
   fra: Match
   ita: Partita
   spa: Partido
-  zho: 匹配
+  chs: 匹配
   jpn: マッチ
   rus: Совпадение
   por: Combinar
@@ -7767,7 +7782,7 @@ Select By:
   fra: Sélectionner par
   ita: Seleziona per
   spa: Seleccionar por
-  zho: 选择方式
+  chs: 选择方式
   jpn: 選び方
   rus: Выбрать по
   por: Selecione por
@@ -7782,7 +7797,7 @@ Advanced Options:
   fra: Options avancées
   ita: Opzioni avanzate
   spa: Opciones avanzadas
-  zho: 高级选项
+  chs: 高级选项
   jpn: 高度な設定
   rus: Дополнительные параметры
   por: Opções avançadas
@@ -7796,7 +7811,7 @@ License:
   fra: Licence
   ita: Licenza
   spa: Licencia
-  zho: 许可
+  chs: 许可
   jpn: ライセンス
   rus: Лицензия
   por: Licença
@@ -7811,7 +7826,7 @@ Quantization Mode:
   fra: Mode de quantification
   ita: Modalità di quantizzazione
   spa: Modo de cuantificación
-  zho: 量化模式
+  chs: 量化模式
   jpn: 量子化モード
   rus: Режим квантования
   por: Modo de quantificação
@@ -7826,7 +7841,7 @@ Use CRF or QP:
   fra: Utiliser le CRF ou le QP
   ita: Utilizzare CRF o QP
   spa: Utilizar CRF o QP
-  zho: 使用CRF或QP
+  chs: 使用CRF或QP
   jpn: CRFまたはQPを使用する
   rus: Используйте CRF или QP
   por: Use CRF ou QP
@@ -7841,7 +7856,7 @@ Additional svt av1 params:
   fra: Paramètres supplémentaires de svt av1
   ita: Parametri svt av1 aggiuntivi
   spa: Parámetros adicionales de svt av1
-  zho: 额外的svt av1参数
+  chs: 额外的svt av1参数
   jpn: svt av1 の追加パラメータ
   rus: Дополнительные параметры svt av1
   por: Parâmetros adicionais svt av1
@@ -7856,7 +7871,7 @@ Extra svt av1 params in opt=1:opt2=0 format:
   fra: Paramètres supplémentaires de svt av1 au format opt=1:opt2=0
   ita: Parametri extra svt av1 nel formato opt=1:opt2=0
   spa: Parámetros extra svt av1 en formato opt=1:opt2=0
-  zho: 额外的svt av1参数，格式为opt=1:opt2=0
+  chs: 额外的svt av1参数，格式为opt=1:opt2=0
   jpn: opt=1:opt2=0のフォーマットでの他のsvt av1パラメータ
   rus: Дополнительные параметры svt av1 в формате opt=1:opt2=0
   por: Parâmetros av1 extra svt no formato opt=1:opt2=0
@@ -7871,7 +7886,7 @@ Max Colors:
   fra: Couleurs maximales
   ita: Colori massimi
   spa: Colores máximos
-  zho: 最大颜色
+  chs: 最大颜色
   jpn: 最大色数
   rus: Максимальные цвета
   por: Cores máximas
@@ -7886,7 +7901,7 @@ Frame Rate:
   fra: Fréquence d'images
   ita: Frame Rate
   spa: Velocidad de fotogramas
-  zho: 帧速率
+  chs: 帧速率
   jpn: フレームレート
   rus: Частота кадров
   por: Taxa de quadros
@@ -7901,7 +7916,7 @@ Equalizer:
   fra: Égaliseur
   ita: Equalizzatore
   spa: Ecualizador
-  zho: 均衡器
+  chs: 均衡器
   jpn: イコライザー
   rus: Эквалайзер
   por: Equalizador
@@ -7916,7 +7931,7 @@ Method:
   fra: Méthode
   ita: Metodo
   spa: Método
-  zho: 方式
+  chs: 方式
   jpn: 方法
   rus: Метод
   por: Método
@@ -7931,7 +7946,7 @@ Color Formats:
   fra: Formats de couleur
   ita: Formati di colore
   spa: Formatos de color
-  zho: 色彩格式
+  chs: 色彩格式
   jpn: カラーフォーマット
   rus: Форматы цветов
   por: Formatos de cores
@@ -7946,7 +7961,7 @@ Video Buffering:
   fra: Mise en mémoire tampon des vidéos
   ita: Buffering video
   spa: Buffering de vídeo
-  zho: 视频缓冲
+  chs: 视频缓冲
   jpn: ビデオバッファリング
   rus: Буферизация видео
   por: Buffer de vídeo
@@ -7961,7 +7976,7 @@ Verifier:
   fra: Vérificateur
   ita: Verificatore
   spa: Verificador
-  zho: 验证人
+  chs: 验证人
   jpn: 確認者
   rus: Верификатор
   por: Verificador
@@ -7976,7 +7991,7 @@ Statistics Mode:
   fra: Mode statistiques
   ita: Modalità statistiche
   spa: Modo de estadísticas
-  zho: 统计模式
+  chs: 统计模式
   jpn: 統計モード
   rus: Режим статистики
   por: Modo Estatísticas
@@ -7991,7 +8006,7 @@ Scene Detection:
   fra: Détection de la scène
   ita: Rilevamento della scena
   spa: Detección de escenas
-  zho: 场景检测
+  chs: 场景检测
   jpn: シーン検出
   rus: Обнаружение сцены
   por: Detecção de cenas
@@ -8006,7 +8021,7 @@ Determine OpenCL Support:
   fra: Déterminer la prise en charge d'OpenCL
   ita: Determinare il supporto OpenCL
   spa: Determinar la compatibilidad con OpenCL
-  zho: 确定OpenCL支持
+  chs: 确定OpenCL支持
   jpn: OpenCLのサポートを検出
   rus: Определить поддержку OpenCL
   por: Determinar o suporte do OpenCL
@@ -8021,7 +8036,7 @@ Please load in a video to configure a new profile:
   fra: Veuillez charger une vidéo pour configurer un nouveau profil.
   ita: Si prega di caricare un video per configurare un nuovo profilo
   spa: Por favor, cargue un vídeo para configurar un nuevo perfil
-  zho: 请加载一个视频来配置一个新的配置文件
+  chs: 请加载一个视频来配置一个新的配置文件
   jpn: 新しいプロファイルを設定するための動画をロードしてください。
   rus: Пожалуйста, загрузите видео для настройке нового профиля
   por: Por favor, carregue em um vídeo para configurar um novo perfil
@@ -8036,7 +8051,7 @@ Please load in a video to configure a new profile:
   fra: 10-bit
   ita: 10-bit
   spa: 10-bit
-  zho: 10位
+  chs: 10位
   jpn: 10ビット
   rus: 10-бит
   por: 10 bit
@@ -8056,7 +8071,7 @@ This encoder does not support duplicating audio tracks, please remove copied tra
     le tracce copiate!
   spa: Este codificador no admite la duplicación de pistas de audio, por favor, elimine
     las pistas copiadas.
-  zho: 此编码器不支持复制音轨，请删除已复制的音轨!
+  chs: 此编码器不支持复制音轨，请删除已复制的音轨!
   jpn: このエンコーダーはオーディオトラックの複製をサポートしていません。コピーしたトラックを削除してください。
   rus: Этот кодер не поддерживает дублирование звуковых дорожек, пожалуйста, удалите
     скопированные дорожки!
@@ -8075,7 +8090,7 @@ Not supported by rigaya's hardware encoders:
   fra: Non supporté par les encodeurs matériels de rigaya
   ita: Non supportato dagli encoder hardware di rigaya
   spa: No es compatible con los codificadores de hardware de Rigaya
-  zho: 不被Rigaya的硬件编码器所支持
+  chs: 不被Rigaya的硬件编码器所支持
   jpn: Rigayaのハードウェアエンコーダには対応していません。
   rus: Не поддерживается аппаратными кодерами rigaya
   por: Não suportado pelos codificadores de hardware da rigaya
@@ -8090,7 +8105,7 @@ AVC coding profile:
   fra: Profil de codage AVC
   ita: Profilo di codifica AVC
   spa: Perfil de codificación AVC
-  zho: AVC编码配置
+  chs: AVC编码配置
   jpn: AVCエンコードプロファイル
   rus: Профиль кодирования AVC
   por: Perfil de codificação AVC
@@ -8105,7 +8120,7 @@ Allow Software Encoding:
   fra: Autoriser le codage logiciel
   ita: Permettere la codifica del software
   spa: Permitir la codificación del software
-  zho: 允许软件编码
+  chs: 允许软件编码
   jpn: ソフトウェアエンコードを許可する
   rus: Разрешить программное кодирование
   por: Permitir a codificação de software
@@ -8120,7 +8135,7 @@ Require Software Encoding:
   fra: Exiger le codage du logiciel
   ita: Richiedere la codifica del software
   spa: Requiere codificación de software
-  zho: 要求软件编码
+  chs: 要求软件编码
   jpn: ソフトウェアエンコードは必要
   rus: Требуется программное кодирование
   por: Exigir codificação de software
@@ -8135,7 +8150,7 @@ Realtime Encoding:
   fra: Encodage en temps réel
   ita: Codifica in tempo reale
   spa: Codificación en tiempo real
-  zho: 实时编码
+  chs: 实时编码
   jpn: リアルタイムエンコード
   rus: Кодирование в реальном времени
   por: Codificação em tempo real
@@ -8151,7 +8166,7 @@ Hint that encoding should happen in real-time if not faster:
   ita: 'Suggerimento: la codifica dovrebbe avvenire in tempo reale, se non più velocemente'
   spa: Indicación de que la codificación debe realizarse en tiempo real, si no más
     rápido
-  zho: 提示编码应该实时发生，如果不是更快的话
+  chs: 提示编码应该实时发生，如果不是更快的话
   jpn: ヒント：エンコードはリアルタイムで実行すべきです。（それよりも速くなければ）
   rus: Подсказка, что кодирование должно происходить в режиме реального времени, если
     не быстрее
@@ -8169,7 +8184,7 @@ Frames Before:
   fra: Cadres avant
   ita: Cornici Prima
   spa: Marcos Antes
-  zho: 之前的帧数
+  chs: 之前的帧数
   jpn: フレーム数 前
   rus: Кадры до
   por: Quadros antes
@@ -8189,7 +8204,7 @@ Other frames will come before the frames in this session. This helps smooth conc
     aiuta a smussare i problemi di concatenazione.
   spa: Los demás fotogramas vendrán antes que los fotogramas de esta sesión. Esto
     ayuda a suavizar los problemas de concatenación.
-  zho: 其他的帧会在这个会话中的帧之前出现。这有助于缓解合并中的问题。
+  chs: 其他的帧会在这个会话中的帧之前出现。这有助于缓解合并中的问题。
   jpn: 他のフレームは、このセッションのフレームより前に来ます。これは、連結の問題をスムーズにするのに役立ちます。
   rus: Другие кадры будут идти перед кадрами в этой сессии. Это помогает сгладить
     проблемы конкатенации.
@@ -8210,7 +8225,7 @@ Frames After:
   fra: Cadres après
   ita: Fotogrammi dopo
   spa: Fotogramas después
-  zho: 之后的帧数
+  chs: 之后的帧数
   jpn: 後のフレーム数
   rus: Кадры после
   por: Quadros após
@@ -8230,7 +8245,7 @@ Other frames will come after the frames in this session. This helps smooth conca
     aiuta a smussare i problemi di concatenazione.
   spa: Otros marcos vendrán después de los marcos de esta sesión. Esto ayuda a suavizar
     los problemas de concatenación.
-  zho: 其他的帧将在这个会话中的帧之后出现。这有助于缓解合并中的问题。
+  chs: 其他的帧将在这个会话中的帧之后出现。这有助于缓解合并中的问题。
   jpn: 他のフレームは、このセッションのフレームの後に来ます。これは、連結の問題をスムーズにするのに役立ちます。
   rus: Другие кадры будут идти после кадров этой сессии. Это помогает сгладить проблемы
     с конкатенацией.
@@ -8251,7 +8266,7 @@ HEVC coding profile - must match bit depth:
   fra: Profil de codage HEVC - doit correspondre à la profondeur de bit
   ita: Profilo di codifica HEVC - deve corrispondere alla profondità di bit
   spa: 'Perfil de codificación HEVC: debe coincidir con la profundidad de bits'
-  zho: HEVC编码配置文件 - 必须与位深度相匹配
+  chs: HEVC编码配置文件 - 必须与位深度相匹配
   jpn: HEVCコーディングプロファイル - ビット深度との一致が必要
   rus: Профиль кодирования HEVC - должен соответствовать битовой глубине
   por: Perfil de codificação HEVC - deve corresponder à profundidade do bit
@@ -8266,7 +8281,7 @@ Ignore Errors:
   fra: Ignorer les erreurs
   ita: Ignorare gli errori
   spa: Ignorar errores
-  zho: 忽略错误
+  chs: 忽略错误
   jpn: エラーを無視する
   rus: Игнорировать ошибки
   por: Ignorar erros
@@ -8281,7 +8296,7 @@ Custom QSVEncC options:
   fra: Options personnalisées de QSVEncC
   ita: Opzioni QSVEncC personalizzate
   spa: Opciones personalizadas de QSVEncC
-  zho: 自定义QSVEncC选项
+  chs: 自定义QSVEncC选项
   jpn: QSVEncCのカスタムオプション
   rus: Пользовательские опции QSVEncC
   por: Opções personalizadas de QSVEncC
@@ -8296,7 +8311,7 @@ QSVEncC Options:
   fra: Options QSVEncC
   ita: Opzioni QSVEncC
   spa: Opciones de QSVEncC
-  zho: QSVEncC选项
+  chs: QSVEncC选项
   jpn: QSVEncCオプション
   rus: Опции QSVEncC
   por: Opções QSVEncC
@@ -8311,7 +8326,7 @@ QSVEncC Encoder support is still experimental!:
   fra: Le support de l'encodeur QSVEncC est encore expérimental !
   ita: Il supporto di QSVEncC Encoder è ancora sperimentale!
   spa: La compatibilidad con el codificador QSVEncC es todavía experimental.
-  zho: QSVEncC编码器的支持仍然是试验性的!
+  chs: QSVEncC编码器的支持仍然是试验性的!
   jpn: QSVEncC エンコーダのサポートはまだ実験的です。
   rus: Поддержка кодировщика QSVEncC все еще является экспериментальной!
   por: O suporte ao codificador QSVEncC ainda é experimental!
@@ -8326,7 +8341,7 @@ Save Queue to File:
   fra: Enregistrer la file d'attente dans un fichier
   ita: Salvare la coda su file
   spa: Guardar la cola en un archivo
-  zho: 保存队列到文件
+  chs: 保存队列到文件
   jpn: キューをファイルに保存する
   rus: Сохранить очередь в файл
   por: Salvar fila no arquivo
@@ -8341,7 +8356,7 @@ Load Queue from File:
   fra: Chargement de la file d'attente à partir d'un fichier
   ita: Caricare la coda da file
   spa: Cargar la cola desde un archivo
-  zho: 从文件中加载队列
+  chs: 从文件中加载队列
   jpn: ファイルからキューを読み込む
   rus: Загрузка очереди из файла
   por: Fila de carga do arquivo
@@ -8356,7 +8371,7 @@ This will remove all items in the queue currently:
   fra: Cela supprimera tous les éléments de la file d'attente actuellement
   ita: Questo rimuoverà tutti gli elementi nella coda attualmente
   spa: Esto eliminará todos los elementos en la cola actualmente
-  zho: 这将删除当前队列中的所有项目。
+  chs: 这将删除当前队列中的所有项目。
   jpn: これにより、現在キューにあるすべてのアイテムが削除されます。
   rus: Это приведет к удалению всех элементов в очереди в настоящее время
   por: Isto removerá todos os itens da fila atualmente
@@ -8371,7 +8386,7 @@ It will update it with the contents of:
   fra: Il le mettra à jour avec le contenu de
   ita: Lo aggiornerà con il contenuto di
   spa: Lo actualizará con el contenido de
-  zho: 将用以下内容更新
+  chs: 将用以下内容更新
   jpn: 以下の内容で更新されます。
   rus: Он обновит его содержимым
   por: Ele o atualizará com o conteúdo de
@@ -8386,7 +8401,7 @@ Are you sure you want to proceed?:
   fra: Vous êtes sûr de vouloir continuer ?
   ita: Sei sicuro di voler procedere?
   spa: ¿Estás seguro de que quieres continuar?
-  zho: 确定要继续吗？
+  chs: 确定要继续吗？
   jpn: 本当に進めてもいいですか？
   rus: Вы уверены, что хотите продолжить?
   por: Você tem certeza de que quer prosseguir?
@@ -8401,7 +8416,7 @@ Overwrite existing queue?:
   fra: Écraser la file d'attente existante ?
   ita: Sovrascrivere la coda esistente?
   spa: ¿Sobreescribir la cola existente?
-  zho: 覆盖现有队列？
+  chs: 覆盖现有队列？
   jpn: 既存のキューを上書きしますか？
   rus: Перезаписать существующую очередь?
   por: Sobregravar a fila existente?
@@ -8416,7 +8431,7 @@ Save Queue:
   fra: Sauvegarder la file d'attente
   ita: Salvare la coda
   spa: Guardar cola
-  zho: 保存队列
+  chs: 保存队列
   jpn: キューを保存する
   rus: Сохранить очередь
   por: Salvar fila
@@ -8431,7 +8446,7 @@ Load Queue:
   fra: File d'attente de chargement
   ita: Coda di carico
   spa: Cola de carga
-  zho: 加载队列
+  chs: 加载队列
   jpn: キューをロードする
   rus: Загрузить очередь
   por: Fila de carga
@@ -8446,7 +8461,7 @@ Queue saved to:
   fra: File d'attente enregistrée dans
   ita: Coda salvata in
   spa: Cola guardada en
-  zho: 队列保存到
+  chs: 队列保存到
   jpn: に保存されました
   rus: Очередь сохранена в
   por: Fila salva para
@@ -8461,7 +8476,7 @@ That file doesn't exist:
   fra: Ce fichier n'existe pas
   ita: Quel file non esiste
   spa: Ese archivo no existe
-  zho: 该文件不存在
+  chs: 该文件不存在
   jpn: 該当ファイルは存在しません
   rus: Этот файл не существует
   por: Esse arquivo não existe
@@ -8476,7 +8491,7 @@ There are more than 100 files, skipping pre-processing.:
   fra: Il y a plus de 100 fichiers, en sautant le prétraitement.
   ita: Ci sono più di 100 file, saltando la pre-elaborazione.
   spa: Hay más de 100 archivos, omitiendo el preprocesamiento.
-  zho: 文件多于100个，跳过预处理。
+  chs: 文件多于100个，跳过预处理。
   jpn: 100ファイル以上ありますので、プリプロセスをスキップします。
   rus: Имеется более 100 файлов, пропуская предварительную обработку.
   por: Existem mais de 100 ficheiros, saltando o pré-processamento.
@@ -8493,7 +8508,7 @@ No audio tracks matched for this profile, enable first track?:
     traccia?
   spa: No hay pistas de audio que coincidan con este perfil, habilitar la primera
     pista?
-  zho: 此配置文件没有匹配的音轨，启用第一个音轨？
+  chs: 此配置文件没有匹配的音轨，启用第一个音轨？
   jpn: このプロファイルに一致するオーディオトラックがありません。最初のトラックを有効にしますか？
   rus: Для этого профиля не подобраны звуковые дорожки, включить первую дорожку?
   por: Não há faixas de áudio correspondentes a este perfil, permitir a primeira faixa?
@@ -8508,7 +8523,7 @@ No Audio Match:
   fra: Pas de correspondance audio
   ita: Nessuna corrispondenza audio
   spa: No hay coincidencia de audio
-  zho: 没有音频匹配
+  chs: 没有音频匹配
   jpn: マッチしたオーディオはありません
   rus: Нет звукового соответствия
   por: Sem Audio Match
@@ -8523,7 +8538,7 @@ Unselect All:
   fra: Désélectionner tout
   ita: Deselezionare tutti
   spa: Deseleccionar todo
-  zho: 取消选择所有
+  chs: 取消选择所有
   jpn: すべて選択解除
   rus: Снять выбор всего
   por: Desseleccionar todos
@@ -8538,7 +8553,7 @@ Preserve All:
   fra: Préserver tout
   ita: Conservare tutto
   spa: Conservar todo
-  zho: 保存所有
+  chs: 保存所有
   jpn: 全て保留
   rus: Сохранить все
   por: Preservar tudo
@@ -8553,7 +8568,7 @@ Rigaya's encoders will only match one encoding per track:
   fra: Les encodeurs de Rigaya ne correspondent qu'à un seul encodage par piste.
   ita: I codificatori di Rigaya corrispondono solo a una codifica per traccia.
   spa: Los codificadores de Rigaya sólo coincidirán con una codificación por pista
-  zho: Rigaya的编码器在每条轨道上只能匹配一个编码
+  chs: Rigaya的编码器在每条轨道上只能匹配一个编码
   jpn: Rigayaのエンコーダーは1トラックにつき1つのエンコーディングにしかマッチしません
   rus: Кодировщики Rigaya будут соответствовать только одной кодировке на дорожку
   por: Os codificadores de Rigaya corresponderão apenas a uma codificação por pista
@@ -8569,7 +8584,7 @@ Default Output Folder:
   fra: Dossier de sortie par défaut
   ita: Cartella di output predefinita
   spa: Carpeta de salida por defecto
-  zho: 默认输出文件夹
+  chs: 默认输出文件夹
   jpn: デフォルトの出力先フォルダ
   rus: Папка вывода по умолчанию
   por: Pasta de saída por defeito
@@ -8584,7 +8599,7 @@ Use same output directory as source file:
   fra: Utiliser le même répertoire de sortie que le fichier source
   ita: Usa la stessa directory di output del file sorgente
   spa: Utilizar el mismo directorio de salida que el archivo de origen
-  zho: 使用与源文件相同的输出目录
+  chs: 使用与源文件相同的输出目录
   jpn: ソースファイルと同じ出力ディレクトリを使用する
   rus: Использовать тот же выходной каталог, что и исходный файл
   por: Usar o mesmo directório de saída que o ficheiro fonte
@@ -8599,7 +8614,7 @@ Please consider supporting FastFlix with a one time contribution!:
   fra: Merci d'envisager de soutenir FastFlix par une contribution unique!
   ita: Considerate di sostenere FastFlix con un contributo una tantum!
   spa: Por favor, considere apoyar a FastFlix con una contribución única.
-  zho: 请考虑用一次性捐款支持FastFlix!
+  chs: 请考虑用一次性捐款支持FastFlix!
   jpn: FastFlixへの1回限りの寄付をご検討ください。
   rus: Пожалуйста, рассмотрите возможность поддержать FastFlix единовременным взносом!
   por: Por favor, considere apoiar FastFlix com uma contribuição única!
@@ -8614,7 +8629,7 @@ Default Source Folder:
   fra: Dossier source par défaut
   ita: Cartella sorgente predefinita
   spa: Carpeta de origen por defecto
-  zho: 默认的源文件夹
+  chs: 默认的源文件夹
   jpn: デフォルトのソースフォルダ
   rus: Исходная папка по умолчанию
   por: Pasta da fonte por defeito
@@ -8629,7 +8644,7 @@ No Default Source Folder:
   fra: Pas de dossier source par défaut
   ita: Nessuna cartella di origine predefinita
   spa: No hay carpeta de origen por defecto
-  zho: 没有默认的源文件夹
+  chs: 没有默认的源文件夹
   jpn: デフォルトのソースフォルダはありません
   rus: Нет Исходной папки по умолчанию
   por: Sem pasta de origem por defeito
@@ -8644,7 +8659,7 @@ Stay on Top:
   fra: Rester au top
   ita: Rimanere al top
   spa: Manténgase en la cima
-  zho: 窗口保持再最上方
+  chs: 窗口保持在最上方
   jpn: ウィンドウを最上位にする
   rus: Оставаться поверх
   por: Fique no topo
@@ -8659,7 +8674,7 @@ Priority:
   fra: Priorité
   ita: Priorità
   spa: Prioridad
-  zho: 优先权
+  chs: 优先权
   jpn: 優先順位
   rus: Приоритет
   por: Prioridade
@@ -8674,7 +8689,7 @@ Bitrate Mode:
   fra: Mode de débit binaire
   ita: Modalità Bitrate
   spa: Modo Bitrate
-  zho: 比特率模式
+  chs: 比特率模式
   jpn: ビットレートモード
   rus: Режим битрейта
   por: Modo Bitrate
@@ -8689,7 +8704,7 @@ VCEEncC AV1 Encoder is untested!:
   fra: VCEEncC AV1 Encoder n'est pas testé !
   ita: VCEEncC AV1 Encoder non è stato testato!
   spa: El codificador VCEEncC AV1 no ha sido probado.
-  zho: VCEEncC AV1编码器未经测试!
+  chs: VCEEncC AV1编码器未经测试!
   jpn: VCEEncC AV1エンコーダは未検証です!
   rus: VCEEncC AV1 Encoder не тестировался!
   por: O codificador VCEEncC AV1 não foi testado!
@@ -8704,7 +8719,7 @@ QSVEncC AV1 Encoder is untested!:
   fra: QSVEncC AV1 Encoder n'est pas testé !
   ita: Il codificatore QSVEncC AV1 non è stato testato!
   spa: El codificador QSVEncC AV1 no ha sido probado.
-  zho: QSVEncC AV1编码器未经测试!
+  chs: QSVEncC AV1编码器未经测试!
   jpn: QSVEncC AV1 Encoderは未検証です。
   rus: Кодировщик QSVEncC AV1 не тестировался!
   por: O codificador QSVEncC AV1 não foi testado!
@@ -8719,7 +8734,7 @@ NVEncC AV1 Encoder is untested!:
   fra: L'encodeur NVEncC AV1 n'est pas testé !
   ita: Il codificatore NVEncC AV1 non è stato testato!
   spa: El codificador NVEncC AV1 no ha sido probado.
-  zho: NVEncC AV1编码器未经测试!
+  chs: NVEncC AV1编码器未经测试!
   jpn: NVEncC AV1 Encoderは未検証です。
   rus: NVEncC AV1 Encoder не тестировался!
   por: O codificador NVEncC AV1 não foi testado!
@@ -8734,8 +8749,8 @@ Load Directory:
   fra: Chargement du répertoire
   ita: Elenco dei carichi
   spa: Cargar directorio
-  zho: 加载目录
-  jpn: ロードディレクトリ
+  chs: 加载目录
+  jpn: ディレクトリをロードする
   rus: Загрузить каталог
   por: Directório de Carga
   swe: Lasta in katalogen
@@ -8749,7 +8764,7 @@ Multiple Files:
   fra: Fichiers multiples
   ita: File multipli
   spa: Varios archivos
-  zho: 多个文件
+  chs: 多个文件
   jpn: 複数のファイル
   rus: Множество файлов
   por: Ficheiros múltiplos
@@ -8764,7 +8779,7 @@ Drag and Drop to reorder:
   fra: Glisser et déposer pour réorganiser
   ita: Trascinare e rilasciare per riordinare
   spa: Arrastrar y soltar para reordenar
-  zho: 拖放重新排序
+  chs: 拖放重新排序
   jpn: ドラッグ＆ドロップで並び替え
   rus: Перетаскивание для изменения порядка
   por: Arrastar e largar para reordenar
@@ -8779,7 +8794,7 @@ Long Edge:
   fra: Bord long
   ita: Bordo lungo
   spa: Borde largo
-  zho: 长边
+  chs: 长边
   jpn: 長い端
   rus: Длинная кромка
   por: Bordo Longo
@@ -8794,7 +8809,7 @@ Filename:
   fra: Nom de fichier
   ita: Nome del file
   spa: Archivo
-  zho: 文件名
+  chs: 文件名
   jpn: ファイル名
   rus: Имя файла
   por: Nome do ficheiro
@@ -8809,7 +8824,7 @@ Folder:
   fra: Dossier
   ita: Cartella
   spa: Carpeta
-  zho: 文件夹
+  chs: 文件夹
   jpn: フォルダ
   rus: Папка
   por: Pasta
@@ -8825,7 +8840,7 @@ Custom (w:h):
   fra: Sur mesure (l:h)
   ita: Personalizzato (l:h)
   spa: Personalizado (ancho:alto)
-  zho: 自定义(w:h)
+  chs: 自定义(w:h)
   jpn: カスタム（w：h）
   rus: Пользовательский (w:h)
   por: Personalizado (w:h)
@@ -8840,7 +8855,7 @@ Video Title:
   fra: Titre de la vidéo
   ita: Titolo del video
   spa: Título del vídeo
-  zho: 视频标题
+  chs: 视频标题
   jpn: 動画タイトル
   rus: Название видео
   por: Título do vídeo
@@ -8855,7 +8870,7 @@ Video Track Title:
   fra: Titre de la piste vidéo
   ita: Titolo della traccia video
   spa: Título de la pista de vídeo
-  zho: 视频曲目名称
+  chs: 视频曲目名称
   jpn: ビデオトラックタイトル
   rus: Название видеодорожки
   por: Título da faixa de vídeo
@@ -8875,7 +8890,7 @@ Remove GUI logs and compress conversion logs older than 30 days at exit:
     più vecchi di 30 giorni all'uscita.
   spa: Elimina los registros GUI y comprime los registros de conversión de más de
     30 días al salir.
-  zho: 在退出时删除GUI日志并压缩超过30天的转换日志
+  chs: 在退出时删除GUI日志并压缩超过30天的转换日志
   jpn: 終了時にGUIログを削除し、30日以上前の変換ログを圧縮します
   rus: Удаление журналов GUI и сжатие журналов конвертации старше 30 дней при выходе
   por: Remover registos GUI e comprimir registos de conversão com mais de 30 dias
@@ -8894,7 +8909,7 @@ UI Scale:
   fra: Échelle de l'interface utilisateur
   ita: Scala UI
   spa: Escala de IU
-  zho: UI规模
+  chs: UI规模
   jpn: UIスケール
   rus: Масштаб интерфейса
   por: Escala UI
@@ -8908,7 +8923,7 @@ IDC Level:
   fra: Niveau IDC
   ita: Livello IDC
   spa: Nivel IDC
-  zho: IDC级别
+  chs: IDC级别
   jpn: IDCレベル
   rus: Уровень IDC
   por: Nível IDC
@@ -8923,7 +8938,7 @@ Set the IDC level:
   fra: Régler le niveau de l'IDC
   ita: Impostare il livello IDC
   spa: Ajustar el nivel IDC
-  zho: 设置IDC水平
+  chs: 设置IDC水平
   jpn: IDCレベルを設定する
   rus: Установите уровень IDC
   por: Definir o nível IDC
@@ -8938,7 +8953,7 @@ Additional vvc params:
   fra: Paramètres supplémentaires de la vvc
   ita: Parametri aggiuntivi di vvc
   spa: Parámetros vvc adicionales
-  zho: 附加vvc参数
+  chs: 附加vvc参数
   jpn: vvcの追加パラメータ
   rus: Дополнительные параметры vvc
   por: Parâmetros vvc adicionais
@@ -8953,7 +8968,7 @@ Extra vvc params in opt=1:opt2=0 format:
   fra: Paramètres vvc supplémentaires au format opt=1:opt2=0
   ita: Parametri vvc extra nel formato opt=1:opt2=0
   spa: Parámetros vvc adicionales en formato opt=1:opt2=0
-  zho: opt=1:opt2=0格式的额外vvc参数
+  chs: opt=1:opt2=0格式的额外vvc参数
   jpn: opt=1:opt2=0の形式でvvcパラメータを追加する。
   rus: Дополнительные параметры vvc в формате opt=1:opt2=0
   por: Parâmetros vvc adicionais no formato opt=1:opt2=0
@@ -8973,7 +8988,7 @@ That video was added with an encoder that is no longer available, unable to load
     caricarlo dalla coda.
   spa: Ese vídeo se añadió con un codificador que ya no está disponible, no se puede
     cargar desde la cola
-  zho: 该视频是用一个不再可用的编码器添加的，无法从队列中加载。
+  chs: 该视频是用一个不再可用的编码器添加的，无法从队列中加载。
   jpn: その動画は、利用できなくなったエンコーダーで追加されたため、キューから読み込むことができません。
   rus: Это видео было добавлено с помощью кодировщика, который больше не доступен,
     не удается загрузить из очереди
@@ -8994,7 +9009,7 @@ That video was added with an encoder that is no longer available, unable to load
   fra: 'Ce profil sera appliqué à tous les éléments sélectionnés :'
   ita: 'Questo profilo verrà applicato a tutti gli elementi selezionati:'
   spa: 'Este perfil se aplicará a todos los elementos seleccionados:'
-  zho: 这个配置文件将被应用于所有选定的项目。
+  chs: 这个配置文件将被应用于所有选定的项目。
   jpn: このプロファイルは、選択されたすべてのアイテムに適用されます。
   rus: 'Этот профиль будет применен ко всем выбранным элементам:'
   por: 'Este perfil será aplicado a todos os artigos seleccionados:'
@@ -9009,7 +9024,7 @@ QP Mode:
   fra: Mode QP
   ita: Modalità QP
   spa: Modo QP
-  zho: QP模式
+  chs: QP模式
   jpn: QPモード
   rus: Режим QP
   por: Modo QP
@@ -9029,7 +9044,7 @@ Constant Quality, Intelligent Constant Quality, Intelligent + Lookahead Constant
     costante
   spa: Calidad constante, Inteligente Calidad constante, Inteligente + Lookahead Calidad
     constante
-  zho: 恒定质量，智能恒定质量，智能+前瞻恒定质量
+  chs: 恒定质量，智能恒定质量，智能+前瞻恒定质量
   jpn: 品質固定、インテリジェント品質固定、インテリジェント＋ルックアヘッド品質固定
   rus: Постоянное качество, интеллектуальное постоянное качество, интеллектуальное
     качество + опережающее постоянное качество
@@ -9054,7 +9069,7 @@ The following items were excluded as they could not be identified as a video fil
     come file video
   spa: Se excluyeron los siguientes elementos por no poder identificarse como archivos
     de vídeo
-  zho: 以下项目被排除在外，因为它们不能被确定为视频文件
+  chs: 以下项目被排除在外，因为它们不能被确定为视频文件
   jpn: 以下のものは、動画ファイルとして識別できないため、除外した。
   rus: Следующие предметы были исключены, так как их нельзя было идентифицировать
     как видеофайлы
@@ -9074,7 +9089,7 @@ more:
   fra: plus
   ita: di più
   spa: más
-  zho: 更多
+  chs: 更多
   jpn: もっと
   rus: больше
   por: mais
@@ -9089,7 +9104,7 @@ Loading Videos:
   fra: Chargement des vidéos
   ita: Caricamento dei video
   spa: Cargando vídeos
-  zho: 加载视频
+  chs: 加载视频
   jpn: 動画読み込み
   rus: Загружаемые видеоролики
   por: Carregamento de vídeos
@@ -9104,7 +9119,7 @@ Open FastFlix:
   fra: Ouvrir FastFlix
   ita: Aprire FastFlix
   spa: Abrir FastFlix
-  zho: 打开FastFlix
+  chs: 打开FastFlix
   jpn: FastFlixを開く
   rus: Открыть FastFlix
   por: Abrir FastFlix
@@ -9119,7 +9134,7 @@ Minimize to Tray:
   fra: Réduire au plateau
   ita: Riduci a icona nel vassoio
   spa: Minimizar a bandeja
-  zho: 最小化到托盘
+  chs: 最小化到托盘
   jpn: トレイに最小化する
   rus: Свернуть в лоток
   por: Minimizar para bandeja
@@ -9134,7 +9149,7 @@ Device:
   fra: Dispositif
   ita: Dispositivo
   spa: Dispositivo
-  zho: 设备
+  chs: 设备
   jpn: デバイス
   rus: Устройство
   por: Dispositivo
@@ -9149,7 +9164,7 @@ Don't Select Any Audio:
   fra: Ne pas sélectionner d'audio
   ita: Non selezionare alcun audio
   spa: No seleccione ningún audio
-  zho: 不选择任何音频
+  chs: 不选择任何音频
   jpn: オーディオを選択しない
   rus: Не выбирайте аудио
   por: Não seleccione nenhum áudio
@@ -9164,7 +9179,7 @@ Adaptive Reference Frames:
   fra: Cadres de référence adaptatifs
   ita: Cornici di riferimento adattive
   spa: Marcos de referencia adaptativos
-  zho: 自适应参考Z帧
+  chs: 自适应参考Z帧
   jpn: アダプティブリファレンスフレーム
   rus: Адаптивные опорные кадры
   por: Quadros de referência adaptativos
@@ -9182,7 +9197,7 @@ Adaptively select list of reference frames to improve encoding quality.:
     la qualità della codifica.
   spa: Selección adaptativa de la lista de fotogramas de referencia para mejorar la
     calidad de la codificación.
-  zho: 自适应地选择参考帧的列表以提高编码质量。
+  chs: 自适应地选择参考帧的列表以提高编码质量。
   jpn: エンコード品質を向上させるために、参照フレームのリストを適応的に選択する。
   rus: Адаптивный выбор списка опорных кадров для улучшения качества кодирования.
   por: Seleccionar de forma adaptativa a lista de quadros de referência para melhorar
@@ -9199,7 +9214,7 @@ Adaptive Long-Term Reference Frames:
   fra: Cadres de référence adaptatifs à long terme
   ita: Quadri di riferimento adattativi a lungo termine
   spa: Marcos de referencia a largo plazo adaptables
-  zho: 自适应的长期参考帧
+  chs: 自适应的长期参考帧
   jpn: 適応型長期基準フレーム
   rus: Адаптивные долгосрочные опорные кадры
   por: Quadros de referência adaptativos de longo prazo
@@ -9219,7 +9234,7 @@ Mark, modify, or remove LTR frames based on encoding parameters and content prop
     di codifica e alle proprietà del contenuto.
   spa: Marque, modifique o elimine tramas LTR en función de los parámetros de codificación
     y las propiedades del contenido.
-  zho: 根据编码参数和内容属性，标记、修改或删除LTR框架。
+  chs: 根据编码参数和内容属性，标记、修改或删除LTR框架。
   jpn: エンコーディングパラメータとコンテンツプロパティに基づいて、LTRフレームをマーク、修正、または削除する。
   rus: Пометить, изменить или удалить кадры LTR на основе параметров кодирования и
     свойств содержимого.
@@ -9239,7 +9254,7 @@ Adaptive CQM:
   fra: CQM adaptatif
   ita: CQM adattivo
   spa: CQM adaptable
-  zho: 自适应的CQM
+  chs: 自适应的CQM
   jpn: アダプティブCQM
   rus: Адаптивный CQM
   por: CQM Adaptativo
@@ -9264,7 +9279,7 @@ Adaptive CQM:
   spa: Selecciona de forma adaptativa una de las matrices de cuantización definidas
     por la aplicación para cada fotograma, con el fin de mejorar la calidad visual
     subjetiva en determinadas condiciones.
-  zho: 为每一帧自适应地选择执行定义的量化矩阵之一，以改善某些条件下的主观视觉质量。
+  chs: 为每一帧自适应地选择执行定义的量化矩阵之一，以改善某些条件下的主观视觉质量。
   jpn: 特定の条件下で主観的な視覚品質を向上させるために、各フレームに対して実装定義された量子化マトリックスの1つを適応的に選択する。
   rus: Адаптивный выбор одной из определяемых реализацией матриц квантования для каждого
     кадра для улучшения субъективного визуального качества при определенных условиях.
@@ -9288,7 +9303,7 @@ Hardware Decoding:
   fra: Décodage matériel
   ita: Decodifica hardware
   spa: Descodificación de hardware
-  zho: 硬件解码
+  chs: 硬件解码
   jpn: ハードウェアデコード
   rus: Аппаратное декодирование
   por: Descodificação de Hardware
@@ -9303,7 +9318,7 @@ Use hardware decoding:
   fra: Utiliser le décodage matériel
   ita: Utilizzare la decodifica hardware
   spa: Utilizar descodificación por hardware
-  zho: 使用硬件解码
+  chs: 使用硬件解码
   jpn: ハードウェアデコードを使用する
   rus: Используйте аппаратное декодирование
   por: Utilizar a descodificação de hardware
@@ -9318,7 +9333,7 @@ Scene Change:
   fra: Changement de scène
   ita: Cambio di scena
   spa: Cambio de escena
-  zho: 场景变化
+  chs: 场景变化
   jpn: シーンチェンジ
   rus: Изменение сцены
   por: Mudança de Cena
@@ -9333,7 +9348,7 @@ Scene change detection method:
   fra: Méthode de détection des changements de scène
   ita: Metodo di rilevamento dei cambiamenti di scena
   spa: Método de detección de cambios en la escena
-  zho: 场景变化检测方法
+  chs: 场景变化检测方法
   jpn: シーンチェンジ検出方法
   rus: Метод обнаружения изменения сцены
   por: Método de detecção de mudança de cenas
@@ -9348,7 +9363,7 @@ Static Scene:
   fra: Scène statique
   ita: Scena statica
   spa: Escena estática
-  zho: 静态场面
+  chs: 静态场面
   jpn: 静止画シーン
   rus: Статическая сцена
   por: Cena estática
@@ -9363,7 +9378,7 @@ Sensitivity of static scene detection:
   fra: Sensibilité de la détection des scènes statiques
   ita: Sensibilità del rilevamento di scene statiche
   spa: Sensibilidad de la detección de escenas estáticas
-  zho: 静态场景检测的敏感度
+  chs: 静态场景检测的敏感度
   jpn: 静止画シーン検出の感度
   rus: Чувствительность обнаружения статических сцен
   por: Sensibilidade da detecção de cena estática
@@ -9378,7 +9393,7 @@ Activity Type:
   fra: Type d'activité
   ita: Tipo di attività
   spa: Tipo de actividad
-  zho: 活动类型
+  chs: 活动类型
   jpn: アクティビティタイプ
   rus: Тип активности
   por: Tipo de actividade
@@ -9393,7 +9408,7 @@ Activity type detection method:
   fra: Méthode de détection du type d'activité
   ita: Metodo di rilevamento del tipo di attività
   spa: Método de detección de la clase de actividad
-  zho: 活动类型检测方法
+  chs: 活动类型检测方法
   jpn: アクティビティタイプ検出方式
   rus: Метод определения типа активности
   por: Método de detecção do tipo de actividade
@@ -9408,7 +9423,7 @@ CAQ Strength:
   fra: La force du CAQ
   ita: Forza del CAQ
   spa: Fuerza del CAQ
-  zho: CAQ的实力
+  chs: CAQ的实力
   jpn: CAQの強さ
   rus: Сила CAQ
   por: Força CAQ
@@ -9423,7 +9438,7 @@ Strength of CAQ:
   fra: Force de la CAQ
   ita: Forza del CAQ
   spa: Fuerza de CAQ
-  zho: CAQ的实力
+  chs: CAQ的实力
   jpn: CAQの強さ
   rus: Сила CAQ
   por: Força do CAQ
@@ -9438,7 +9453,7 @@ SC QP:
   fra: SC QP
   ita: SC QP
   spa: SC QP
-  zho: SC QP
+  chs: SC QP
   jpn: SC QP
   rus: SC QP
   por: SC QP
@@ -9453,7 +9468,7 @@ Initial qp after scene change:
   fra: QP initial après le changement de scène
   ita: Qp iniziale dopo il cambio di scena
   spa: qp inicial tras el cambio de escena
-  zho: 场景变化后的初始qp
+  chs: 场景变化后的初始qp
   jpn: シーンチェンジ後の初期qp
   rus: Начальное qp после смены сцены
   por: Qp inicial após mudança de cena
@@ -9468,7 +9483,7 @@ Lookahead distance:
   fra: Distance d'anticipation
   ita: Distanza di sicurezza
   spa: Distancia de seguridad
-  zho: 向前看的距离
+  chs: 向前看的距离
   jpn: 前向きの距離
   rus: Дистанция опережения
   por: Distância Lookahead
@@ -9483,7 +9498,7 @@ FSkip Max QP:
   fra: FSkip Max QP
   ita: FSkip Max QP
   spa: FSkip Max QP
-  zho: 基金会最大QP
+  chs: 基金会最大QP
   jpn: FSkip Max QP
   rus: FSkip Max QP
   por: FSkip Max QP
@@ -9498,7 +9513,7 @@ Threshold to insert skip frame on static:
   fra: Seuil d'insertion d'une trame de saut sur les données statiques
   ita: Soglia per l'inserimento di un frame di salto in caso di statica
   spa: Umbral para insertar trama de salto en estático
-  zho: 在静态时插入跳帧的阈值
+  chs: 在静态时插入跳帧的阈值
   jpn: 静止画でスキップフレームを挿入するための閾値
   rus: Порог для вставки пропуска кадра при статическом
   por: Limiar para inserir moldura de saltar sobre estática
@@ -9513,7 +9528,7 @@ LTR:
   fra: LTR
   ita: LTR
   spa: LTR
-  zho: LTR
+  chs: LTR
   jpn: LTR
   rus: LTR
   por: LTR
@@ -9528,7 +9543,7 @@ Enable long-term reference frame:
   fra: Activer le cadre de référence à long terme
   ita: Abilitazione del quadro di riferimento a lungo termine
   spa: Habilitar el marco de referencia a largo plazo
-  zho: 启用长期参考框架
+  chs: 启用长期参考框架
   jpn: 長期的な参照フレームを有効にする
   rus: Включить долгосрочную систему отсчета
   por: Habilitar quadro de referência a longo prazo
@@ -9543,7 +9558,7 @@ PAQ:
   fra: PAQ
   ita: PAQ
   spa: PAQ
-  zho: PAQ
+  chs: PAQ
   jpn: PAQ
   rus: PAQ
   por: PAQ
@@ -9558,7 +9573,7 @@ Perceptual AQ mode:
   fra: Mode QA perceptuel
   ita: Modalità percettiva AQ
   spa: Modo AQ perceptivo
-  zho: 感知型AQ模式
+  chs: 感知型AQ模式
   jpn: パーセプチュアルAQモード
   rus: Перцептивный режим AQ
   por: Modo AQ Perceptual
@@ -9573,7 +9588,7 @@ TAQ:
   fra: TAQ
   ita: TAQ
   spa: TAQ
-  zho: TAQ
+  chs: TAQ
   jpn: TAQ
   rus: TAQ
   por: TAQ
@@ -9588,7 +9603,7 @@ Temporal AQ mode:
   fra: Mode QA temporel
   ita: Modalità AQ temporale
   spa: Modo AQ temporal
-  zho: 时间性AQ模式
+  chs: 时间性AQ模式
   jpn: Temporal AQモード
   rus: Временной режим AQ
   por: Modo AQ temporal
@@ -9603,7 +9618,7 @@ Motion Quality:
   fra: Qualité du mouvement
   ita: Qualità del movimento
   spa: Calidad del movimiento
-  zho: 运动质量
+  chs: 运动质量
   jpn: モーションクオリティ
   rus: Качество движения
   por: Qualidade do movimento
@@ -9618,7 +9633,7 @@ High motion quality boost mode:
   fra: Mode d'amélioration de la qualité du mouvement
   ita: Modalità di incremento della qualità del movimento
   spa: Modo de aumento de la calidad de movimiento
-  zho: 高运动质量提升模式
+  chs: 高运动质量提升模式
   jpn: 高画質ブーストモード
   rus: Режим повышения качества движения
   por: Modo de impulso de alta qualidade de movimento
@@ -9633,7 +9648,7 @@ Disable Automatic Tab Switching:
   fra: Désactiver la commutation automatique des onglets
   ita: Disattivare la commutazione automatica delle schede
   spa: Desactivar el cambio automático de pestañas
-  zho: 禁用自动标签切换
+  chs: 禁用自动标签切换
   jpn: タブの自動切替を無効にする
   rus: Отключить автоматическое переключение вкладок
   por: Desactivar a troca automática de separadores
@@ -9648,7 +9663,7 @@ Rate Control Mode:
   fra: Mode de contrôle des taux
   ita: Modalità di controllo della velocità
   spa: Modo de control de velocidad
-  zho: 速率控制模式
+  chs: 速率控制模式
   jpn: レートコントロールモード
   rus: Режим управления скоростью
   por: Modo de Controlo de Taxa
@@ -9663,7 +9678,7 @@ Set rate control mode:
   fra: Régler le mode de contrôle du taux
   ita: Impostare la modalità di controllo della velocità
   spa: Ajustar el modo de control de velocidad
-  zho: 设置速率控制模式
+  chs: 设置速率控制模式
   jpn: レートコントロールモードを設定する
   rus: Установите режим управления скоростью
   por: Definir o modo de controlo da taxa
@@ -9678,7 +9693,7 @@ VA-API Device:
   fra: Dispositif VA-API
   ita: Dispositivo VA-API
   spa: Dispositivo VA-API
-  zho: VA-API设备
+  chs: VA-API设备
   jpn: VA-APIデバイス
   rus: Устройство VA-API
   por: Dispositivo VA-API
@@ -9693,7 +9708,7 @@ VA-API device to use (default /dev/dri/renderD128):
   fra: Périphérique VA-API à utiliser (par défaut /dev/dri/renderD128)
   ita: Dispositivo VA-API da utilizzare (predefinito /dev/dri/renderD128)
   spa: Dispositivo VA-API a utilizar (por defecto /dev/dri/renderD128)
-  zho: 要使用的VA-API设备（默认为/dev/dri/renderD128）。
+  chs: 要使用的VA-API设备（默认为/dev/dri/renderD128）。
   jpn: 使用するVA-APIデバイス（デフォルト：/dev/dri/renderD128）
   rus: Устройство VA-API для использования (по умолчанию /dev/dri/renderD128)
   por: Dispositivo VA-API a utilizar (por defeito /dev/dri/renderD128)
@@ -9708,7 +9723,7 @@ B Depth:
   fra: B Profondeur
   ita: B Profondità
   spa: B Profundidad
-  zho: B深度
+  chs: B深度
   jpn: B深度
   rus: B Глубина
   por: B Profundidade
@@ -9726,7 +9741,7 @@ Maximum B-frame reference depth (from 1 to INT_MAX) (default 1):
     predefinito 1)
   spa: Profundidad máxima de referencia de fotogramas B (de 1 a INT_MAX) (por defecto
     1)
-  zho: 最大的B-帧参考深度（从1到INT_MAX）（默认为1）。
+  chs: 最大的B-帧参考深度（从1到INT_MAX）（默认为1）。
   jpn: 最大Bフレーム参照深度（1～INT_MAX）（デフォルト1）
   rus: Максимальная опорная глубина B-кадра (от 1 до INT_MAX) (по умолчанию 1)
   por: Profundidade máxima de referência do quadro B (de 1 a INT_MAX) (por defeito
@@ -9742,7 +9757,7 @@ IDR Interval:
   fra: Intervalle IDR
   ita: Intervallo IDR
   spa: Intervalo IDR
-  zho: IDR 间隔
+  chs: IDR 间隔
   jpn: IDRインターバル
   rus: Интервал IDR
   por: Intervalo IDR
@@ -9757,7 +9772,7 @@ Distance between IDR frames (from 0 to INT_MAX) (default 0):
   fra: Distance entre les trames IDR (de 0 à INT_MAX) (par défaut 0)
   ita: Distanza tra i frame IDR (da 0 a INT_MAX) (valore predefinito 0)
   spa: Distancia entre tramas IDR (de 0 a INT_MAX) (por defecto 0)
-  zho: IDR帧之间的距离（从0到INT_MAX）（默认为0）。
+  chs: IDR帧之间的距离（从0到INT_MAX）（默认为0）。
   jpn: IDRフレーム間の距離（0～INT_MAX）（デフォルト0）
   rus: Расстояние между кадрами IDR (от 0 до INT_MAX) (по умолчанию 0)
   por: Distância entre quadros IDR (de 0 a INT_MAX) (padrão 0)
@@ -9772,7 +9787,7 @@ Low Power Mode:
   fra: Mode basse consommation
   ita: Modalità basso consumo
   spa: Modo de bajo consumo
-  zho: 低功率模式
+  chs: 低功率模式
   jpn: ローパワーモード
   rus: Режим пониженного энергопотребления
   por: Modo de baixo consumo
@@ -9787,7 +9802,7 @@ Enable low power mode:
   fra: Activer le mode basse consommation
   ita: Abilitazione della modalità a basso consumo
   spa: Activar el modo de bajo consumo
-  zho: 启用低功率模式
+  chs: 启用低功率模式
   jpn: ローパワーモードを有効にする
   rus: Включить режим низкого энергопотребления
   por: Activar o modo de baixo consumo
@@ -9802,7 +9817,7 @@ VAAPI FFmpeg encoding:
   fra: Encodage VAAPI FFmpeg
   ita: Codifica VAAPI FFmpeg
   spa: Codificación VAAPI FFmpeg
-  zho: VAAPI FFmpeg 编码
+  chs: VAAPI FFmpeg 编码
   jpn: VAAPI FFmpegエンコーディング
   rus: Кодирование VAAPI FFmpeg
   por: Codificação VAAPI FFmpeg
@@ -9817,7 +9832,7 @@ Set level (general_level_idc):
   fra: Définir le niveau (general_level_idc)
   ita: Impostare il livello (general_level_idc)
   spa: Fijar nivel (general_level_idc)
-  zho: 设置级别（General_level_idc）。
+  chs: 设置级别（General_level_idc）。
   jpn: 設定レベル（general_level_idc）
   rus: Установить уровень (general_level_idc)
   por: Definir nível (geral_level_idc)
@@ -9832,7 +9847,7 @@ Async Depth:
   fra: Profondeur asynchrone
   ita: Profondità asincrona
   spa: Profundidad asíncrona
-  zho: 异步深度
+  chs: 异步深度
   jpn: 非同期深度
   rus: Асинхронная глубина
   por: Profundidade Async
@@ -9857,7 +9872,7 @@ Async Depth:
   spa: Máximo paralelismo de procesamiento. Auméntelo para mejorar el rendimiento
     de un solo canal. Esta opción no funciona si el controlador no implementa la función
     vaSyncBuffer.
-  zho: 最大的处理并行性。增加这个选项可以提高单通道的性能。如果驱动程序没有实现vaSyncBuffer函数，这个选项就不起作用。
+  chs: 最大的处理并行性。增加这个选项可以提高单通道的性能。如果驱动程序没有实现vaSyncBuffer函数，这个选项就不起作用。
   jpn: 最大処理並列度。シングルチャンネルの性能を向上させるために、これを増やします。ドライバがvaSyncBuffer関数を実装していない場合、このオプションは機能しません。
   rus: Максимальная параллельность обработки. Увеличьте это значение для повышения
     производительности одного канала. Эта опция не работает, если драйвер не реализует
@@ -9883,7 +9898,7 @@ AUD:
   fra: AUD
   ita: AUD
   spa: AUD
-  zho: AUD
+  chs: AUD
   jpn: AUD
   rus: AUD
   por: AUD
@@ -9898,7 +9913,7 @@ Include AUD:
   fra: Inclure l'AUD
   ita: Includere AUD
   spa: Incluir AUD
-  zho: 包括AUD
+  chs: 包括AUD
   jpn: AUDを含む
   rus: Включая AUD
   por: Incluir AUD
@@ -9913,7 +9928,7 @@ Forced:
   fra: Forcé
   ita: Costretto
   spa: Forzado
-  zho: 强制的
+  chs: 强制的
   jpn: 強制的
   rus: Принудительный
   por: Forçado
@@ -9928,7 +9943,7 @@ Default:
   fra: Défaut
   ita: Predefinito
   spa: Por defecto
-  zho: 默认
+  chs: 默认
   jpn: デフォルト
   rus: По умолчанию
   por: Predefinição
@@ -9943,7 +9958,7 @@ Hearing Impaired:
   fra: Malentendants
   ita: Non udenti
   spa: Discapacidad auditiva
-  zho: 听障
+  chs: 听障
   jpn: 耳の不自由
   rus: Нарушение слуха
   por: Deficiente Auditivo
@@ -9958,7 +9973,7 @@ Original:
   fra: Original
   ita: Originale
   spa: Original
-  zho: 原始
+  chs: 原始
   jpn: オリジナル
   rus: Оригинал
   por: Original
@@ -9973,7 +9988,7 @@ Comment:
   fra: Commentaire
   ita: Commento
   spa: Comentario
-  zho: 评论
+  chs: 评论
   jpn: コメント
   rus: Комментарий
   por: Comentário
@@ -9988,7 +10003,7 @@ Lyrics:
   fra: Paroles
   ita: Testi
   spa: Letra
-  zho: 歌词
+  chs: 歌词
   jpn: 歌詞
   rus: Тексты песен
   por: Letra de música
@@ -10003,7 +10018,7 @@ Karaoke:
   fra: Karaoké
   ita: Karaoke
   spa: Karaoke
-  zho: 卡拉OK
+  chs: 卡拉OK
   jpn: カラオケ
   rus: Караоке
   por: Karaoke
@@ -10018,7 +10033,7 @@ Dub:
   fra: Dub
   ita: Dub
   spa: Dub
-  zho: 配音
+  chs: 配音
   jpn: ダブ
   rus: Dub
   por: Dub
@@ -10033,7 +10048,7 @@ Set:
   fra: Set (jeu de mots)
   ita: Set
   spa: Establecer
-  zho: 设置
+  chs: 设置
   jpn: セット
   rus: Установите
   por: Conjunto
@@ -10048,7 +10063,7 @@ default:
   fra: par défaut
   ita: predefinito
   spa: por defecto
-  zho: 默认
+  chs: 默认
   jpn: デフォルト
   rus: по умолчанию
   por: padrão
@@ -10063,7 +10078,7 @@ original:
   fra: original
   ita: originale
   spa: original
-  zho: 原始
+  chs: 原始
   jpn: オリジナル
   rus: оригинал
   por: original
@@ -10078,7 +10093,7 @@ forced:
   fra: forcée
   ita: forzato
   spa: forzado
-  zho: 强制
+  chs: 强制
   jpn: 強制的
   rus: принудительно
   por: forçado
@@ -10093,7 +10108,7 @@ dub:
   fra: dub
   ita: doppiare
   spa: dub
-  zho: 配音
+  chs: 配音
   jpn: ダブ
   rus: dub
   por: dub
@@ -10108,7 +10123,7 @@ Dispositions:
   fra: Dispositions
   ita: Disposizioni
   spa: Disposiciones
-  zho: 处置
+  chs: 处置
   jpn: タグ
   rus: Диспозиции
   por: Disposições
@@ -10123,7 +10138,7 @@ karaoke:
   fra: karaoké
   ita: karaoke
   spa: karaoke
-  zho: 卡拉OK
+  chs: 卡拉OK
   jpn: カラオケ
   rus: караоке
   por: karaoke
@@ -10138,7 +10153,7 @@ lyrics:
   fra: paroles
   ita: testi
   spa: letra
-  zho: 歌词
+  chs: 歌词
   jpn: 歌詞
   rus: Тексты песен
   por: lyrics
@@ -10153,7 +10168,7 @@ comment:
   fra: commentaire
   ita: commento
   spa: comentario
-  zho: 评论
+  chs: 评论
   jpn: コメント
   rus: комментарий
   por: comentário
@@ -10168,7 +10183,7 @@ No Extra:
   fra: Pas de supplément
   ita: Nessun extra
   spa: No Extra
-  zho: 没有额外的
+  chs: 没有额外的
   jpn: 追加なし
   rus: Без доп. затрат
   por: Sem Extra
@@ -10183,7 +10198,7 @@ Threshold to insert skip frame on static scene:
   fra: Seuil pour l'insertion d'un saut d'image sur une scène statique
   ita: Soglia per l'inserimento di un frame di salto su una scena statica
   spa: Umbral para insertar fotograma de salto en escena estática
-  zho: 在静态场景中插入跳帧的阈值
+  chs: 在静态场景中插入跳帧的阈值
   jpn: 静的なシーンでスキップフレームを挿入するための閾値
   rus: Порог для вставки пропуска кадра на статичной сцене
   por: Limiar para inserir moldura de saltar em cena estática
@@ -10198,7 +10213,7 @@ hearing_impaired:
   fra: Malentendants
   ita: Non udenti
   spa: Discapacidad auditiva
-  zho: 听障
+  chs: 听障
   jpn: 耳の不自由
   rus: Нарушение слуха
   por: Deficiente Auditivo
@@ -10213,7 +10228,7 @@ visual_impaired:
   fra: Malvoyants
   ita: Improvvisazione visiva
   spa: Discapacidad visual
-  zho: 视障
+  chs: 视障
   jpn: 目の不自由
   rus: Слабовидящие
   por: Deficiente Visual
@@ -10228,7 +10243,7 @@ Disable completion and error messages:
   fra: Désactiver les messages de complétion et d'erreur
   ita: Disabilita messaggi di completamento e errori
   spa: Deshabilitar mensajes de finalización y error
-  zho: 禁用完成和错误消息
+  chs: 禁用完成和错误消息
   jpn: 完了とエラーメッセージを無効にする
   rus: Отключить сообщения об окончании и ошибках
   por: Desativar mensagens de conclusão e erro
@@ -10243,7 +10258,7 @@ Output Depth:
   fra: Profondeur de sortie
   ita: Profondità di uscita
   spa: Profundidad de salida
-  zho: 输出深度
+  chs: 输出深度
   jpn: アウトプット深度
   rus: Глубина вывода
   por: Profundidade de saída
@@ -10258,7 +10273,7 @@ Output Depth:
   fra: 8 bits seulement
   ita: Solo 8 bit
   spa: Solo 8 bits
-  zho: 仅限8位
+  chs: 仅限8位
   jpn: 8ビットのみ
   rus: Только 8 бит
   por: Apenas 8 bits
@@ -10273,7 +10288,7 @@ Copy HDR10+:
   fra: Copier HDR10+
   ita: Copia HDR10+
   spa: Copiar HDR10+
-  zho: 复制HDR10+
+  chs: 复制HDR10+
   jpn: HDR10+をコピー
   rus: Копировать HDR10+
   por: Copiar HDR10+
@@ -10288,7 +10303,7 @@ Copy HDR10+ dynamic metadata from input file:
   fra: Copier les métadonnées dynamiques HDR10+ du fichier d'entrée
   ita: Copia i metadati dinamici HDR10+ dal file di input
   spa: Copiar metadatos dinámicos HDR10+ del archivo de entrada
-  zho: 从输入文件复制HDR10+动态元数据
+  chs: 从输入文件复制HDR10+动态元数据
   jpn: 入力ファイルからHDR10+ダイナミックメタデータをコピー
   rus: Скопировать динамические метаданные HDR10+ из входного файла
   por: Copiar metadados dinâmicos HDR10+ do arquivo de entrada
@@ -10303,7 +10318,7 @@ Single Pass:
   fra: Passe unique
   ita: Passaggio singolo
   spa: Pase único
-  zho: 1次
+  chs: 1次
   jpn: 1回のみ
   rus: Одиночный проход
   por: Passe único
@@ -10318,7 +10333,7 @@ Single Pass Encoding:
   fra: Encodage à passage unique
   ita: Codifica a passaggio singolo
   spa: Codificación de una sola pasada
-  zho: 1次编码
+  chs: 1次编码
   jpn: 1回のみのエンコード
   rus: Однопроходное кодирование
   por: Codificação de passagem única

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -9943,8 +9943,8 @@ Hearing Impaired:
   fra: Malentendants
   ita: Non udenti
   spa: Discapacidad auditiva
-  zho: 听障者
-  jpn: 聴覚障がい者
+  zho: 听障
+  jpn: 耳の不自由
   rus: Нарушение слуха
   por: Deficiente Auditivo
   swe: Hörselskadade
@@ -10109,7 +10109,7 @@ Dispositions:
   ita: Disposizioni
   spa: Disposiciones
   zho: 处置
-  jpn: ディセンションズ
+  jpn: タグ
   rus: Диспозиции
   por: Disposições
   swe: Dispositioner
@@ -10139,7 +10139,7 @@ lyrics:
   ita: testi
   spa: letra
   zho: 歌词
-  jpn: 詞
+  jpn: 歌詞
   rus: Тексты песен
   por: lyrics
   swe: texter
@@ -10198,8 +10198,8 @@ hearing_impaired:
   fra: Malentendants
   ita: Non udenti
   spa: Discapacidad auditiva
-  zho: 听障者
-  jpn: 聴覚障がい者
+  zho: 听障
+  jpn: 耳の不自由
   rus: Нарушение слуха
   por: Deficiente Auditivo
   swe: Hörselskadade
@@ -10213,8 +10213,8 @@ visual_impaired:
   fra: Malvoyants
   ita: Improvvisazione visiva
   spa: Discapacidad visual
-  zho: 视障者
-  jpn: 視覚障がい者
+  zho: 视障
+  jpn: 目の不自由
   rus: Слабовидящие
   por: Deficiente Visual
   swe: Synskadade
@@ -10244,7 +10244,7 @@ Output Depth:
   ita: Profondità di uscita
   spa: Profundidad de salida
   zho: 输出深度
-  jpn: 出力深度
+  jpn: アウトプット深度
   rus: Глубина вывода
   por: Profundidade de saída
   swe: Utdata djup

--- a/fastflix/encoders/avc_x264/settings_panel.py
+++ b/fastflix/encoders/avc_x264/settings_panel.py
@@ -108,7 +108,7 @@ class AVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "Slow is highest personal recommenced, as past that is much smaller gains"
+                "\"Slow\" is the slowest personally recommended, presets slower this result in much smaller gains"
             ),
             connect="default",
             opt="preset",

--- a/fastflix/encoders/avc_x264/settings_panel.py
+++ b/fastflix/encoders/avc_x264/settings_panel.py
@@ -108,7 +108,8 @@ class AVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "\"Slow\" is the slowest personally recommended, presets slower than this result in much smaller gains"
+                "Slow is the slowest preset personally recommended,\n"
+                "presets slower than this result in much smaller gains"
             ),
             connect="default",
             opt="preset",

--- a/fastflix/encoders/avc_x264/settings_panel.py
+++ b/fastflix/encoders/avc_x264/settings_panel.py
@@ -108,7 +108,7 @@ class AVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "\"Slow\" is the slowest personally recommended, presets slower this result in much smaller gains"
+                "\"Slow\" is the slowest personally recommended, presets slower than this result in much smaller gains"
             ),
             connect="default",
             opt="preset",

--- a/fastflix/encoders/hevc_x265/settings_panel.py
+++ b/fastflix/encoders/hevc_x265/settings_panel.py
@@ -346,7 +346,7 @@ class HEVC(SettingPanel):
             widget_name="intra_encoding",
             tooltip=(
                 "keyint: Enable Intra-Encoding by forcing keyframes every 1 second (Blu-ray spec)\n"
-                "This option is not recommenced unless you need to conform \n"
+                "This option is not recommended unless you need to conform \n"
                 "to Blu-ray standards to burn to a physical disk"
             ),
             opt="intra_encoding",
@@ -400,7 +400,7 @@ class HEVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "Slow is highest personal recommenced, as past that is much smaller gains"
+                "\"Slow\" is the slowest personally recommended, presets slower this result in much smaller gains"
             ),
             connect=self.preset_update,
             opt="preset",

--- a/fastflix/encoders/hevc_x265/settings_panel.py
+++ b/fastflix/encoders/hevc_x265/settings_panel.py
@@ -400,7 +400,7 @@ class HEVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "\"Slow\" is the slowest personally recommended, presets slower this result in much smaller gains"
+                "\"Slow\" is the slowest personally recommended, presets slower than this result in much smaller gains"
             ),
             connect=self.preset_update,
             opt="preset",

--- a/fastflix/encoders/hevc_x265/settings_panel.py
+++ b/fastflix/encoders/hevc_x265/settings_panel.py
@@ -400,7 +400,8 @@ class HEVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "\"Slow\" is the slowest personally recommended, presets slower than this result in much smaller gains"
+                "Slow is the slowest preset personally recommended,\n"
+                "presets slower than this result in much smaller gains"
             ),
             connect=self.preset_update,
             opt="preset",

--- a/fastflix/encoders/vvc/settings_panel.py
+++ b/fastflix/encoders/vvc/settings_panel.py
@@ -146,7 +146,8 @@ class VVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "\"Slow\" is the slowest personally recommended, presets slower than this result in much smaller gains"
+                "Slow is the slowest preset personally recommended,\n"
+                "presets slower than this result in much smaller gains"
             ),
             connect="default",
             opt="preset",

--- a/fastflix/encoders/vvc/settings_panel.py
+++ b/fastflix/encoders/vvc/settings_panel.py
@@ -146,7 +146,7 @@ class VVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "\"Slow\" is the slowest personally recommended, presets slower this result in much smaller gains"
+                "\"Slow\" is the slowest personally recommended, presets slower than this result in much smaller gains"
             ),
             connect="default",
             opt="preset",

--- a/fastflix/encoders/vvc/settings_panel.py
+++ b/fastflix/encoders/vvc/settings_panel.py
@@ -146,7 +146,7 @@ class VVC(SettingPanel):
             options=presets,
             tooltip=(
                 "preset: The slower the preset, the better the compression and quality\n"
-                "Slow is highest personal recommenced, as past that is much smaller gains"
+                "\"Slow\" is the slowest personally recommended, presets slower this result in much smaller gains"
             ),
             connect="default",
             opt="preset",

--- a/fastflix/language.py
+++ b/fastflix/language.py
@@ -40,7 +40,7 @@ if not language:
 
 language_data = Box.from_yaml(filename=language_file, encoding="utf-8")
 
-if language not in ("deu", "eng", "fra", "ita", "spa", "zho", "rus", "jpn", "pol", "swe", "por", "ukr", "kor", "ron"):
+if language not in ("deu", "eng", "fra", "ita", "spa", "chs", "rus", "jpn", "pol", "swe", "por", "ukr", "kor", "ron"):
     print(f"WARNING: {language} is not a supported language, defaulting to eng")
     language = "eng"
 

--- a/fastflix/widgets/settings.py
+++ b/fastflix/widgets/settings.py
@@ -18,7 +18,7 @@ language_list = sorted((k for k, v in Lang._data["name"].items() if v["pt2B"] an
 
 known_language_list = [
     "English",
-    "Chinese",
+    "Chinese (Simplified)",
     "Italian",
     "French",
     "Spanish",
@@ -31,6 +31,7 @@ known_language_list = [
     "Romanian",
     "Ukrainian",
     "Korean",
+    #"Chinese (Traditional)"    #reserved for future use
 ]
 possible_detect_points = ["1", "2", "4", "6", "8", "10", "15", "20", "25", "50", "100"]
 
@@ -82,7 +83,15 @@ class Settings(QtWidgets.QWidget):
         self.language_combo = QtWidgets.QComboBox(self)
         self.language_combo.addItems(known_language_list)
         try:
-            index = known_language_list.index(Lang(self.app.fastflix.config.language).name)
+            if self.app.fastflix.config.language == "chs":
+                index = known_language_list.index("Chinese (Simplified)")
+
+            #reserved for future use
+            #elif self.app.fastflix.config.language == "cht":
+                #index = known_language_list.index("Chinese (Traditional)")
+
+            else:
+                index = known_language_list.index(Lang(self.app.fastflix.config.language).name)
         except (IndexError, InvalidLanguageValue):
             logger.exception(f"{t('Could not find language for')} {self.app.fastflix.config.language}")
             index = known_language_list.index("English")
@@ -297,8 +306,17 @@ class Settings(QtWidgets.QWidget):
         self.app.fastflix.config.theme = self.theme.currentText()
 
         old_lang = self.app.fastflix.config.language
+        current_text = self.language_combo.currentText()
         try:
-            self.app.fastflix.config.language = Lang(self.language_combo.currentText()).pt3
+            if current_text == "Chinese (Simplified)":
+                self.app.fastflix.config.language = "chs"
+
+            #reserved for future use
+            #elif current_text != "Chinese (Traditional)":
+                #self.app.fastflix.config.language = "cht"
+
+            else:
+                self.app.fastflix.config.language = Lang(self.language_combo.currentText()).pt3
         except InvalidLanguageValue:
             error_message(
                 f"{t('Could not set language to')} {self.language_combo.currentText()}\n {t('Please report this issue')}"


### PR DESCRIPTION
Absolutely love this program.
I've been using it for two years and it introduced me into the world of HDR, x265, and later av1.
Never found any translation issues before because I've been using the English version.

- Fixed some (not all) Chinese and Japanese translations
- Fixed a few typos "recommenced" --> "recommended"
- Changed the wording: "Slow is highest personal recommenced, as past that is much smaller gains" <-- the meaning of this sentence is not very clear, and some people may also find it "not gramatically correct".
- Changed the keys in the `language.yaml` to reflect the above change of strings.
- Added some single or double quotes to the `language.yaml`, as I found some strings to be at risk of misinterpretation

Disclaimer: I'm not a native speaker of English or Japanese, but I'm confident to say I'm "somewhat" fluent in both (duh). Also errrr, in yaml, I'm not sure if single or double quotes or `-` in the values should be escaped, but after some intensive googling and stackoverflowing, I think it may be safer to put some strings with special characters in quotes.

May the 4th be with you.