### PR TITLE
Version 5.5.6

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,8 +2,10 @@
 
 ## Version 5.5.6
 
-* Fixing #487 Filename corrupted on path change  (thanks to Maddie Davis)
+* Fixing #485 Cannot Restore Queue Containing HDR10+ Entries (thanks to Maddie Davis)
+* Fixing #487 Filename corrupted on path change (thanks to Maddie Davis)
 * Fixing #491 Can't open Setting in Chinese upgraded from old version (thanks to 谈天才)
+* Fixing #493 Profiles did not load config for remove hdr, remove metadata or copy chapter toggles (thanks to micron888)
 * Fixing #494 frame rate change in 2 pass mode ("Bitrate" mode) results in error for AVC x264 encoder (thanks to Ivan Gorin)
 
 ## Version 5.5.5

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,14 @@
 # Changelog
 
+## Version 5.5.6
+
+* Fixing #487 Filename corrupted on path change  (thanks to Maddie Davis)
+* Fixing #491 Can't open Setting in Chinese upgraded from old version (thanks to 谈天才)
+* Fixing #494 frame rate change in 2 pass mode ("Bitrate" mode) results in error for AVC x264 encoder (thanks to Ivan Gorin)
+
 ## Version 5.5.5
 
-* Fixed #479 some zho and jpn translations, fixed some typos (thanks to Jing Luo)
+* Fixing #479 some zho and jpn translations, fixed some typos (thanks to Jing Luo)
 * Fixing incorrect PNG profiles for mac toolbox icons
 
 ## Version 5.5.4

--- a/fastflix/encoders/av1_aom/command_builder.py
+++ b/fastflix/encoders/av1_aom/command_builder.py
@@ -9,7 +9,7 @@ from fastflix.models.fastflix import FastFlix
 
 def build(fastflix: FastFlix):
     settings: AOMAV1Settings = fastflix.current_video.video_settings.video_encoder_settings
-    beginning, ending = generate_all(fastflix, "libaom-av1")
+    beginning, ending, output_fps = generate_all(fastflix, "libaom-av1")
 
     beginning += (
         "-strict experimental "
@@ -25,7 +25,7 @@ def build(fastflix: FastFlix):
 
     if settings.bitrate:
         pass_log_file = fastflix.current_video.work_path / f"pass_log_file_{secrets.token_hex(10)}"
-        command_1 = f'{beginning} -passlogfile "{pass_log_file}" -b:v {settings.bitrate} -pass 1 {settings.extra if settings.extra_both_passes else ""} -an -f matroska {null}'
+        command_1 = f'{beginning} -passlogfile "{pass_log_file}" -b:v {settings.bitrate} -pass 1 {settings.extra if settings.extra_both_passes else ""} -an {output_fps} -f matroska {null}'
         command_2 = (
             f'{beginning} -passlogfile "{pass_log_file}" -b:v {settings.bitrate} -pass 2 {settings.extra} {ending}'
         )

--- a/fastflix/encoders/avc_x264/command_builder.py
+++ b/fastflix/encoders/avc_x264/command_builder.py
@@ -10,7 +10,7 @@ from fastflix.models.fastflix import FastFlix
 def build(fastflix: FastFlix):
     settings: x264Settings = fastflix.current_video.video_settings.video_encoder_settings
 
-    beginning, ending = generate_all(fastflix, "libx264")
+    beginning, ending, output_fps = generate_all(fastflix, "libx264")
 
     beginning += f'{f"-tune:v {settings.tune}" if settings.tune else ""} {generate_color_details(fastflix)} '
 
@@ -22,7 +22,7 @@ def build(fastflix: FastFlix):
     if settings.bitrate:
         command_1 = (
             f"{beginning} -pass 1 "
-            f'-passlogfile "{pass_log_file}" -b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} -an -sn -dn -f mp4 {null}'
+            f'-passlogfile "{pass_log_file}" -b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} -an -sn -dn {output_fps} -f mp4 {null}'
         )
         command_2 = (
             f'{beginning} -pass 2 -passlogfile "{pass_log_file}" '

--- a/fastflix/encoders/common/helpers.py
+++ b/fastflix/encoders/common/helpers.py
@@ -114,6 +114,7 @@ def generate_ending(
     ending = (
         f" {'-map_metadata -1' if remove_metadata else '-map_metadata 0'} "
         f"{'-map_chapters 0' if copy_chapters else '-map_chapters -1'} "
+        f"{f'-r {output_fps}' if output_fps else ''} "
         f"{audio} {subtitles} {cover} "
     )
 

--- a/fastflix/encoders/common/helpers.py
+++ b/fastflix/encoders/common/helpers.py
@@ -110,11 +110,10 @@ def generate_ending(
     output_fps: Union[str, None] = None,
     disable_rotate_metadata=False,
     **_,
-) -> str:
+):
     ending = (
         f" {'-map_metadata -1' if remove_metadata else '-map_metadata 0'} "
         f"{'-map_chapters 0' if copy_chapters else '-map_chapters -1'} "
-        f"{f'-r {output_fps}' if output_fps else ''} "
         f"{audio} {subtitles} {cover} "
     )
 
@@ -126,7 +125,7 @@ def generate_ending(
         ending += f'"{clean_file_string(sanitize(output_video))}"'
     else:
         ending += null
-    return ending
+    return ending, f"{f'-r {output_fps}' if output_fps else ''} "
 
 
 def generate_filters(
@@ -247,7 +246,7 @@ def generate_all(
     vaapi: bool = False,
     start_extra: str = "",
     **filters_extra,
-) -> Tuple[str, str]:
+) -> Tuple[str, str, str]:
     settings = fastflix.current_video.video_settings.video_encoder_settings
 
     audio = build_audio(fastflix.current_video.video_settings.audio_tracks) if audio else ""
@@ -281,7 +280,7 @@ def generate_all(
             **filter_details,
         )
 
-    ending = generate_ending(
+    ending, output_fps = generate_ending(
         audio=audio,
         subtitles=subtitles,
         cover=attachments,
@@ -303,7 +302,7 @@ def generate_all(
         **settings.dict(),
     )
 
-    return beginning, ending
+    return beginning, ending, output_fps
 
 
 def generate_color_details(fastflix: FastFlix) -> str:

--- a/fastflix/encoders/copy/command_builder.py
+++ b/fastflix/encoders/copy/command_builder.py
@@ -6,7 +6,7 @@ from fastflix.models.fastflix import FastFlix
 
 
 def build(fastflix: FastFlix):
-    beginning, ending = generate_all(fastflix, "copy", disable_filters=True)
+    beginning, ending, output_fps = generate_all(fastflix, "copy", disable_filters=True)
     rotation = 0
     if not fastflix.current_video.current_video_stream:
         return []

--- a/fastflix/encoders/ffmpeg_hevc_nvenc/command_builder.py
+++ b/fastflix/encoders/ffmpeg_hevc_nvenc/command_builder.py
@@ -10,7 +10,9 @@ from fastflix.models.fastflix import FastFlix
 def build(fastflix: FastFlix):
     settings: FFmpegNVENCSettings = fastflix.current_video.video_settings.video_encoder_settings
 
-    beginning, ending = generate_all(fastflix, "hevc_nvenc", start_extra="-hwaccel auto" if settings.hw_accel else "")
+    beginning, ending, output_fps = generate_all(
+        fastflix, "hevc_nvenc", start_extra="-hwaccel auto" if settings.hw_accel else ""
+    )
 
     beginning += f'{f"-tune:v {settings.tune}" if settings.tune else ""} {generate_color_details(fastflix)} -spatial_aq:v {settings.spatial_aq} -tier:v {settings.tier} -rc-lookahead:v {settings.rc_lookahead} -gpu {settings.gpu} -b_ref_mode {settings.b_ref_mode} '
 
@@ -28,7 +30,7 @@ def build(fastflix: FastFlix):
     command_1 = (
         f"{beginning} -pass 1 "
         f'-passlogfile "{pass_log_file}" -b:v {settings.bitrate} -preset:v {settings.preset} -2pass 1 '
-        f'{settings.extra if settings.extra_both_passes else ""} -an -sn -dn -f mp4 {null}'
+        f'{settings.extra if settings.extra_both_passes else ""} -an -sn -dn {output_fps} -f mp4 {null}'
     )
     command_2 = (
         f'{beginning} -pass 2 -passlogfile "{pass_log_file}" -2pass 1 '

--- a/fastflix/encoders/h264_videotoolbox/command_builder.py
+++ b/fastflix/encoders/h264_videotoolbox/command_builder.py
@@ -8,7 +8,7 @@ from fastflix.models.fastflix import FastFlix
 
 def build(fastflix: FastFlix):
     settings: HEVCVideoToolboxSettings = fastflix.current_video.video_settings.video_encoder_settings
-    beginning, ending = generate_all(fastflix, "h264_videotoolbox")
+    beginning, ending, output_fps = generate_all(fastflix, "h264_videotoolbox")
 
     beginning += generate_color_details(fastflix)
 
@@ -28,7 +28,7 @@ def build(fastflix: FastFlix):
         pass_log_file = fastflix.current_video.work_path / f"pass_log_file_{secrets.token_hex(10)}"
         beginning += f" "
 
-        command_1 = f"{beginning} -b:v {settings.bitrate} {details} -pass 1 -passlogfile \"{pass_log_file}\" {settings.extra if settings.extra_both_passes else ''} -an -f mp4 {null}"
+        command_1 = f"{beginning} -b:v {settings.bitrate} {details} -pass 1 -passlogfile \"{pass_log_file}\" {settings.extra if settings.extra_both_passes else ''} -an {output_fps} -f mp4 {null}"
         command_2 = f'{beginning} -b:v {settings.bitrate} {details} -pass 2 -passlogfile "{pass_log_file}" {settings.extra} {ending}'
         return [
             Command(command=command_1, name=f"First pass bitrate", exe="ffmpeg"),

--- a/fastflix/encoders/hevc_videotoolbox/command_builder.py
+++ b/fastflix/encoders/hevc_videotoolbox/command_builder.py
@@ -8,7 +8,7 @@ from fastflix.models.fastflix import FastFlix
 
 def build(fastflix: FastFlix):
     settings: HEVCVideoToolboxSettings = fastflix.current_video.video_settings.video_encoder_settings
-    beginning, ending = generate_all(fastflix, "hevc_videotoolbox")
+    beginning, ending, output_fps = generate_all(fastflix, "hevc_videotoolbox")
 
     beginning += generate_color_details(fastflix)
 
@@ -28,7 +28,7 @@ def build(fastflix: FastFlix):
         pass_log_file = fastflix.current_video.work_path / f"pass_log_file_{secrets.token_hex(10)}"
         beginning += f" "
 
-        command_1 = f"{beginning} -b:v {settings.bitrate} {details} -pass 1 -passlogfile \"{pass_log_file}\" {settings.extra if settings.extra_both_passes else ''} -an -f mp4 {null}"
+        command_1 = f"{beginning} -b:v {settings.bitrate} {details} -pass 1 -passlogfile \"{pass_log_file}\" {settings.extra if settings.extra_both_passes else ''} -an {output_fps} -f mp4 {null}"
         command_2 = f'{beginning} -b:v {settings.bitrate} {details} -pass 2 -passlogfile "{pass_log_file}" {settings.extra} {ending}'
         return [
             Command(command=command_1, name=f"First pass bitrate", exe="ffmpeg"),

--- a/fastflix/encoders/hevc_x265/command_builder.py
+++ b/fastflix/encoders/hevc_x265/command_builder.py
@@ -80,7 +80,7 @@ chromaloc_mapping = {"left": 0, "center": 1, "topleft": 2, "top": 3, "bottomleft
 def build(fastflix: FastFlix):
     settings: x265Settings = fastflix.current_video.video_settings.video_encoder_settings
 
-    beginning, ending = generate_all(fastflix, "libx265")
+    beginning, ending, output_fps = generate_all(fastflix, "libx265")
 
     if settings.tune and settings.tune != "default":
         beginning += f"-tune:v {settings.tune} "
@@ -182,7 +182,7 @@ def build(fastflix: FastFlix):
         command_1 = (
             f'{beginning} {get_x265_params(["pass=1", "no-slow-firstpass=1"])} '
             f'-passlogfile "{pass_log_file}" -b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} '
-            f" -an -sn -dn -f mp4 {null}"
+            f" -an -sn -dn {output_fps} -f mp4 {null}"
         )
         command_2 = (
             f'{beginning} {get_x265_params(["pass=2"])} -passlogfile "{pass_log_file}" '

--- a/fastflix/encoders/rav1e/command_builder.py
+++ b/fastflix/encoders/rav1e/command_builder.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("fastflix")
 
 def build(fastflix: FastFlix):
     settings: rav1eSettings = fastflix.current_video.video_settings.video_encoder_settings
-    beginning, ending = generate_all(fastflix, "librav1e")
+    beginning, ending, output_fps = generate_all(fastflix, "librav1e")
 
     beginning += (
         "-strict experimental "
@@ -59,7 +59,7 @@ def build(fastflix: FastFlix):
         command_1 = f"{beginning} -b:v {settings.bitrate} {settings.extra} {ending}"
         return [Command(command=command_1, name=f"{pass_type}", exe="ffmpeg")]
     else:
-        command_1 = f"{beginning} -b:v {settings.bitrate} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an -f matroska {null}"
+        command_1 = f"{beginning} -b:v {settings.bitrate} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an {output_fps} -f matroska {null}"
         command_2 = f"{beginning} -b:v {settings.bitrate} -pass 2 {settings.extra} {ending}"
         return [
             Command(command=command_1, name=f"First pass {pass_type}", exe="ffmpeg"),

--- a/fastflix/encoders/svt_av1/command_builder.py
+++ b/fastflix/encoders/svt_av1/command_builder.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("fastflix")
 @reusables.log_exception("fastflix", show_traceback=True)
 def build(fastflix: FastFlix):
     settings: SVTAV1Settings = fastflix.current_video.video_settings.video_encoder_settings
-    beginning, ending = generate_all(fastflix, "libsvtav1")
+    beginning, ending, output_fps = generate_all(fastflix, "libsvtav1")
 
     beginning += f"-strict experimental " f"-preset {settings.speed} " f"{generate_color_details(fastflix)} "
 
@@ -93,11 +93,11 @@ def build(fastflix: FastFlix):
         return [Command(command=command_1, name=f"{pass_type}", exe="ffmpeg")]
     else:
         if settings.bitrate:
-            command_1 = f"{beginning} -b:v {settings.bitrate} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an -f matroska {null}"
+            command_1 = f"{beginning} -b:v {settings.bitrate} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an {output_fps} -f matroska {null}"
             command_2 = f"{beginning} -b:v {settings.bitrate} -pass 2 {settings.extra} {ending}"
 
         elif settings.qp is not None:
-            command_1 = f"{beginning} -qp {settings.qp} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an -f matroska {null}"
+            command_1 = f"{beginning} -qp {settings.qp} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an {output_fps} -f matroska {null}"
             command_2 = f"{beginning} -qp {settings.qp} -pass 2 {settings.extra} {ending}"
         else:
             return []

--- a/fastflix/encoders/svt_av1_avif/command_builder.py
+++ b/fastflix/encoders/svt_av1_avif/command_builder.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("fastflix")
 @reusables.log_exception("fastflix", show_traceback=True)
 def build(fastflix: FastFlix):
     settings: SVTAVIFSettings = fastflix.current_video.video_settings.video_encoder_settings
-    beginning, ending = generate_all(fastflix, "libsvtav1", audio=False)
+    beginning, ending, output_fps = generate_all(fastflix, "libsvtav1", audio=False)
 
     beginning += f"-strict experimental " f"-preset {settings.speed} " f"{generate_color_details(fastflix)} "
 

--- a/fastflix/encoders/vaapi_h264/command_builder.py
+++ b/fastflix/encoders/vaapi_h264/command_builder.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("fastflix")
 def build(fastflix: FastFlix):
     settings: VAAPIH264Settings = fastflix.current_video.video_settings.video_encoder_settings
     start_extra = f"-init_hw_device vaapi=hwdev:{settings.vaapi_device} -hwaccel vaapi -hwaccel_device hwdev -hwaccel_output_format vaapi "
-    beginning, ending = generate_all(
+    beginning, ending, output_fps = generate_all(
         fastflix,
         "h264_vaapi",
         start_extra=start_extra,

--- a/fastflix/encoders/vaapi_hevc/command_builder.py
+++ b/fastflix/encoders/vaapi_hevc/command_builder.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("fastflix")
 def build(fastflix: FastFlix):
     settings: VAAPIHEVCSettings = fastflix.current_video.video_settings.video_encoder_settings
     start_extra = f"-init_hw_device vaapi=hwdev:{settings.vaapi_device} -hwaccel vaapi -hwaccel_device hwdev -hwaccel_output_format vaapi "
-    beginning, ending = generate_all(
+    beginning, ending, output_fps = generate_all(
         fastflix,
         "hevc_vaapi",
         start_extra=start_extra,

--- a/fastflix/encoders/vaapi_mpeg2/command_builder.py
+++ b/fastflix/encoders/vaapi_mpeg2/command_builder.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("fastflix")
 def build(fastflix: FastFlix):
     settings: VAAPIMPEG2Settings = fastflix.current_video.video_settings.video_encoder_settings
     start_extra = f"-init_hw_device vaapi=hwdev:{settings.vaapi_device} -hwaccel vaapi -hwaccel_device hwdev -hwaccel_output_format vaapi "
-    beginning, ending = generate_all(
+    beginning, ending, output_fps = generate_all(
         fastflix,
         "mpeg2_vaapi",
         start_extra=start_extra,

--- a/fastflix/encoders/vaapi_vp9/command_builder.py
+++ b/fastflix/encoders/vaapi_vp9/command_builder.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("fastflix")
 def build(fastflix: FastFlix):
     settings: VAAPIVP9Settings = fastflix.current_video.video_settings.video_encoder_settings
     start_extra = f"-init_hw_device vaapi=hwdev:{settings.vaapi_device} -hwaccel vaapi -hwaccel_device hwdev -hwaccel_output_format vaapi "
-    beginning, ending = generate_all(
+    beginning, ending, output_fps = generate_all(
         fastflix,
         "vp9_vaapi",
         start_extra=start_extra,

--- a/fastflix/encoders/vp9/command_builder.py
+++ b/fastflix/encoders/vp9/command_builder.py
@@ -9,7 +9,7 @@ from fastflix.models.fastflix import FastFlix
 
 def build(fastflix: FastFlix):
     settings: VP9Settings = fastflix.current_video.video_settings.video_encoder_settings
-    beginning, ending = generate_all(fastflix, "libvpx-vp9")
+    beginning, ending, output_fps = generate_all(fastflix, "libvpx-vp9")
 
     beginning += f'{"-row-mt 1" if settings.row_mt else ""} ' f"{generate_color_details(fastflix)} "
 
@@ -33,13 +33,13 @@ def build(fastflix: FastFlix):
                     exe="ffmpeg",
                 )
             ]
-        command_1 = f"{beginning} -speed:v {'4' if settings.fast_first_pass else settings.speed} -b:v {settings.bitrate} {details} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an -f webm {null}"
+        command_1 = f"{beginning} -speed:v {'4' if settings.fast_first_pass else settings.speed} -b:v {settings.bitrate} {details} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an {output_fps} -f webm {null}"
         command_2 = (
             f"{beginning} -speed:v {settings.speed} -b:v {settings.bitrate} {details} -pass 2 {settings.extra} {ending}"
         )
 
     elif settings.crf:
-        command_1 = f"{beginning} -b:v 0 -crf:v {settings.crf} {details} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an -f webm {null}"
+        command_1 = f"{beginning} -b:v 0 -crf:v {settings.crf} {details} -pass 1 {settings.extra if settings.extra_both_passes else ''} -an {output_fps} -f webm {null}"
         command_2 = (
             f"{beginning} -b:v 0 -crf:v {settings.crf} {details} "
             f'{"-pass 2" if not settings.single_pass else ""} {settings.extra} {ending}'

--- a/fastflix/encoders/vvc/command_builder.py
+++ b/fastflix/encoders/vvc/command_builder.py
@@ -80,7 +80,7 @@ chromaloc_mapping = {"left": 0, "center": 1, "topleft": 2, "top": 3, "bottomleft
 def build(fastflix: FastFlix):
     settings: VVCSettings = fastflix.current_video.video_settings.video_encoder_settings
 
-    beginning, ending = generate_all(fastflix, "libvvenc")
+    beginning, ending, output_fps = generate_all(fastflix, "libvvenc")
 
     if settings.tier:
         beginning += f"-tier:v {settings.tier} "
@@ -109,7 +109,7 @@ def build(fastflix: FastFlix):
         command_1 = (
             f'{beginning} {get_vvc_params(["pass=1", "no-slow-firstpass=1"])} '
             f'-passlogfile "{pass_log_file}" -b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} '
-            f" -an -sn -dn -f mp4 {null}"
+            f" -an -sn -dn {output_fps} -f mp4 {null}"
         )
         command_2 = (
             f'{beginning} {get_vvc_params(["pass=2"])} -passlogfile "{pass_log_file}" '

--- a/fastflix/encoders/webp/command_builder.py
+++ b/fastflix/encoders/webp/command_builder.py
@@ -7,7 +7,7 @@ from fastflix.models.fastflix import FastFlix
 def build(fastflix: FastFlix):
     settings: WebPSettings = fastflix.current_video.video_settings.video_encoder_settings
 
-    beginning, ending = generate_all(fastflix, "libwebp", audio=False, subs=False)
+    beginning, ending, output_fps = generate_all(fastflix, "libwebp", audio=False, subs=False)
 
     return [
         Command(

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "5.5.5"
+__version__ = "5.5.6"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -644,6 +644,12 @@ class Main(QtWidgets.QWidget):
                 logger.error(
                     f"Profile not set properly as we don't have encoder: {self.app.fastflix.config.opt('encoder')}"
                 )
+
+            self.widgets.remove_hdr.setChecked(self.app.fastflix.config.opt("remove_hdr"))
+            # self.widgets.deinterlace.setChecked(self.app.fastflix.config.opt("deinterlace"))
+            self.widgets.chapters.setChecked(self.app.fastflix.config.opt("copy_chapters"))
+            self.widgets.remove_metadata.setChecked(self.app.fastflix.config.opt("remove_metadata"))
+
             if self.app.fastflix.current_video:
                 self.video_options.new_source()
         finally:
@@ -1142,6 +1148,7 @@ class Main(QtWidgets.QWidget):
                 except Exception:
                     logger.exception(f"Could not load video {self.input_video}")
                 else:
+                    self.page_update(build_thumbnail=False)
                     self.add_to_queue()
                 signal.emit(int((i / total_items) * 100))
 
@@ -1345,10 +1352,10 @@ class Main(QtWidgets.QWidget):
             self.widgets.video_track.removeItem(0)
         self.widgets.preview.setText(t("No Video File"))
 
-        self.widgets.deinterlace.setChecked(False)
-        self.widgets.remove_hdr.setChecked(False)
-        self.widgets.remove_metadata.setChecked(True)
-        self.widgets.chapters.setChecked(True)
+        # self.widgets.deinterlace.setChecked(False)
+        # self.widgets.remove_hdr.setChecked(False)
+        # self.widgets.remove_metadata.setChecked(True)
+        # self.widgets.chapters.setChecked(True)
 
         self.widgets.flip.setCurrentIndex(0)
         self.widgets.rotate.setCurrentIndex(0)

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -1181,7 +1181,7 @@ class Main(QtWidgets.QWidget):
         filename = QtWidgets.QFileDialog.getSaveFileName(
             self,
             caption="Save Video As",
-            dir=str(Path(*self.generate_output_filename)) + f".{self.widgets.output_type_combo.currentText()}",
+            dir=str(Path(*self.generate_output_filename)) + f"{self.widgets.output_type_combo.currentText()}",
             filter=f"Save File (*.{extension})",
         )
         if filename and filename[0]:

--- a/fastflix/widgets/panels/queue_panel.py
+++ b/fastflix/widgets/panels/queue_panel.py
@@ -312,14 +312,14 @@ class EncodingQueue(FlixList):
             ):
                 self.app.fastflix.conversion_list = new_queue
 
-        registered_metadata = set()
-        for video in self.app.fastflix.conversion_list:
-            if getattr(video.video_settings.video_encoder_settings, "hdr10plus_metadata", None):
-                registered_metadata.add(Path(video.video_settings.video_encoder_settings.hdr10plus_metadata).name)
-
-        for metadata_file in (self.app.fastflix.config.work_path / "queue_extras").glob("*.json"):
-            if metadata_file.name not in registered_metadata:
-                metadata_file.unlink(missing_ok=True)
+        # registered_metadata = set()
+        # for video in self.app.fastflix.conversion_list:
+        #     if getattr(video.video_settings.video_encoder_settings, "hdr10plus_metadata", None):
+        #         registered_metadata.add(Path(video.video_settings.video_encoder_settings.hdr10plus_metadata).name)
+        #
+        # for metadata_file in (self.app.fastflix.config.work_path / "queue_extras").glob("*.json"):
+        #     if metadata_file.name not in registered_metadata:
+        #         metadata_file.unlink(missing_ok=True)
 
         self.new_source()
         save_queue(self.app.fastflix.conversion_list, self.app.fastflix.queue_path, self.app.fastflix.config)

--- a/fastflix/widgets/settings.py
+++ b/fastflix/widgets/settings.py
@@ -83,7 +83,7 @@ class Settings(QtWidgets.QWidget):
         self.language_combo = QtWidgets.QComboBox(self)
         self.language_combo.addItems(known_language_list)
         try:
-            if self.app.fastflix.config.language == "chs":
+            if self.app.fastflix.config.language in ("chs", "zho"):
                 index = known_language_list.index("Chinese (Simplified)")
 
             # reserved for future use


### PR DESCRIPTION
* Fixing #485 Cannot Restore Queue Containing HDR10+ Entries (thanks to Maddie Davis)
* Fixing #487 Filename corrupted on path change (thanks to Maddie Davis)
* Fixing #491 Can't open Setting in Chinese upgraded from old version (thanks to 谈天才)
* Fixing #493 Profiles did not load config for remove hdr, remove metadata or copy chapter toggles (thanks to micron888)
* Fixing #494 frame rate change in 2 pass mode ("Bitrate" mode) results in error for AVC x264 encoder (thanks to Ivan Gorin)