### PR TITLE
Themes stylesheet aren't installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ where = ["."]
 include = ["fastflix*"]
 
 [tool.setuptools.package-data]
-"*" = ['*.yaml', '*.ico', '*.svg', '*.png']
+"*" = ['*.yaml', '*.ico', '*.svg', '*.png', '*.qss']
 
 [build-system]
 requires = ["setuptools", "setuptools_scm[toml]>=6.2", "wheel"]


### PR DESCRIPTION
I noticed when I did the Debian packages that themes style sheet aren't installed.