### PR TITLE
Version 5.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ icons.py
 test.html
 iso-639-3.*
 build-dir/
+benchmarking/

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 * Adding QP mode for FFmpeg Nvenc encoding
 * Adding more preview positions
 * Adding ultra high quality mode for ffmpeg nvenc encoder
+* Adding #633 download for stable version of ffmpeg by default on Windows (thanks to Maddie Davis)
 * Fixing #611 Extension type not being selected properly from profiles if encoders isn't switched (thanks to Hankuu)
 * Fixing #628 Custom QP/CRF saved in profile may not be restored correctly (thanks to Gregorio O. DeMojeca)
 * Fixing #631 VVC Level can't be set to 0 anymore (thanks to GT500org)

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 5.9.0
+
+* Adding QP mode for FFmpeg Nvenc encoding
+* Adding more preview positions
+* Adding ultra high quality mode for ffmpeg nvenc encoder
+* Fixing #631 VVC Level can't be set to 0 anymore (thanks to GT500org)
+
 ## Version 5.8.2
 
 * Fixing #610 Do not try to divide by zero if HDR metadata has bad values (thanks to Noelle Leigh)

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 * Adding QP mode for FFmpeg Nvenc encoding
 * Adding more preview positions
 * Adding ultra high quality mode for ffmpeg nvenc encoder
+* Fixing #611 Extension type not being selected properly from profiles if encoders isn't switched (thanks to Hankuu)
 * Fixing #628 Custom QP/CRF saved in profile may not be restored correctly (thanks to Gregorio O. DeMojeca)
 * Fixing #631 VVC Level can't be set to 0 anymore (thanks to GT500org)
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 * Adding QP mode for FFmpeg Nvenc encoding
 * Adding more preview positions
 * Adding ultra high quality mode for ffmpeg nvenc encoder
+* Fixing #628 Custom QP/CRF saved in profile may not be restored correctly (thanks to Gregorio O. DeMojeca)
 * Fixing #631 VVC Level can't be set to 0 anymore (thanks to GT500org)
 
 ## Version 5.8.2

--- a/FastFlix.nsi
+++ b/FastFlix.nsi
@@ -10,7 +10,7 @@
 
 !define PRODUCT_NAME      "FastFlix"
 !define PRODUCT_AUTHOR    "Chris Griffith"
-!define PRODUCT_COPYRIGHT "(c) Chris Griffith 2021-2024"
+!define PRODUCT_COPYRIGHT "(c) Chris Griffith 2019-2025"
 
 VIProductVersion "${PRODUCT_VERSION}"
 VIFileVersion    "${PRODUCT_VERSION}"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2019-2024 Chris Griffith
+Copyright (c) 2019-2025 Chris Griffith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Special thanks to [leonardyan](https://github.com/leonardyan) for numerous Chine
 
 # License
 
-Copyright (C) 2019-2024 Chris Griffith
+Copyright (C) 2019-2025 Chris Griffith
 
 The code itself is licensed under the MIT which you can read in the `LICENSE` file. <br>
 Read more about the release licensing in the [docs](docs/README.md) folder. <br>

--- a/fastflix/application.py
+++ b/fastflix/application.py
@@ -11,7 +11,7 @@ from fastflix.language import t
 from fastflix.models.config import Config, MissingFF
 from fastflix.models.fastflix import FastFlix
 from fastflix.models.fastflix_app import FastFlixApp
-from fastflix.program_downloads import ask_for_ffmpeg, latest_ffmpeg
+from fastflix.program_downloads import ask_for_ffmpeg, grab_stable_ffmpeg
 from fastflix.resources import main_icon, breeze_styles_path
 from fastflix.shared import file_date, message, latest_fastflix, DEVMODE
 from fastflix.widgets.container import Container
@@ -182,7 +182,7 @@ def app_setup(
     except MissingFF as err:
         if reusables.win_based and ask_for_ffmpeg():
             try:
-                ProgressBar(app, [Task(t("Downloading FFmpeg"), latest_ffmpeg)], signal_task=True)
+                ProgressBar(app, [Task(t("Downloading FFmpeg"), grab_stable_ffmpeg)], signal_task=True)
                 app.fastflix.config.load()
             except Exception as err:
                 logger.exception(str(err))

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -1677,21 +1677,6 @@ Download Cancelled:
   ukr: Завантажити Скасовано
   kor: 다운로드 취소
   ron: Descărcați Anulat
-Download Newest FFmpeg:
-  deu: Neuestes FFmpeg herunterladen
-  eng: Download Newest FFmpeg
-  fra: Télécharger le dernier FFmpeg
-  ita: Scarica il nuovo FFmpeg
-  spa: Descargar el nuevo FFmpeg
-  chs: 下载最新版FFmpeg
-  jpn: 最新のFFmpegをダウンロードする
-  rus: Скачать новейший FFmpeg
-  por: Fazer o download do FFmpeg mais recente
-  swe: Hämta Nyaste FFmpeg
-  pol: Pobierz Najnowszy FFmpeg
-  ukr: Завантажити останню версію FFmpeg
-  kor: 최신 FFmpeg 다운로드
-  ron: Descărcați cel mai nou FFmpeg
 Downloading FFmpeg:
   deu: Herunterladen von FFmpeg
   eng: Downloading FFmpeg
@@ -7442,7 +7427,8 @@ Drag and Drop to reorder - All items need to be same dimensions:
   eng: Drag and Drop to reorder - All items need to be same dimensions
   fra: Glissez et déposez pour réorganiser - Tous les éléments doivent avoir les mêmes
     dimensions.
-  ita: Per riordinare trascina e rilascia  - tutti gli elementi devono avere le stesse dimensioni
+  ita: Per riordinare trascina e rilascia  - tutti gli elementi devono avere le stesse
+    dimensioni
   spa: Arrastrar y soltar para reordenar - Todos los elementos deben tener las mismas
     dimensiones
   chs: 拖放来重新排序 - 所有项目的尺寸都需要相同
@@ -8824,8 +8810,8 @@ Remove GUI logs and compress conversion logs older than 30 days at exit:
     die älter als 30 Tage sind, beim Beenden
   fra: Suppression des journaux de l'interface graphique et compression des journaux
     de conversion de plus de 30 jours à la sortie.
-  ita: Rimuovi registri eventi GUI e comprimeri registri eventi conversione
-    più vecchi di 30 giorni all'uscita.
+  ita: Rimuovi registri eventi GUI e comprimeri registri eventi conversione più vecchi
+    di 30 giorni all'uscita.
   spa: Elimina los registros GUI y comprime los registros de conversión de más de
     30 días al salir.
   chs: 在退出时删除GUI日志并压缩超过30天的转换日志
@@ -10685,3 +10671,59 @@ Pattern Match:
   ukr: Збіг за зразком
   kor: 패턴 일치
   ron: Potrivire model
+Download Stable FFmpeg:
+  eng: Download Stable FFmpeg
+  deu: Stable FFmpeg herunterladen
+  fra: Télécharger Stable FFmpeg
+  ita: Scarica FFmpeg stabile
+  spa: Descargar FFmpeg estable
+  jpn: 安定したFFmpegをダウンロード
+  rus: Скачать стабильный FFmpeg
+  por: Descarregar o Stable FFmpeg
+  swe: Ladda ner stabil FFmpeg
+  pol: Pobierz Stable FFmpeg
+  chs: 下载稳定版 FFmpeg
+  ukr: Завантажити стабільний FFmpeg
+  kor: 안정적인 FFmpeg 다운로드
+  ron: Descarcă Stable FFmpeg
+Download Nightly FFmpeg:
+  eng: Download Nightly FFmpeg
+  deu: Neuestes FFmpeg herunterladen
+  fra: Télécharger le dernier FFmpeg
+  ita: Scarica il nuovo FFmpeg
+  spa: Descargar el nuevo FFmpeg
+  chs: 下载最新版FFmpeg
+  jpn: 最新のFFmpegをダウンロードする
+  rus: Скачать новейший FFmpeg
+  por: Fazer o download do FFmpeg mais recente
+  swe: Hämta Nyaste FFmpeg
+  pol: Pobierz Najnowszy FFmpeg
+  ukr: Завантажити останню версію FFmpeg
+  kor: 최신 FFmpeg 다운로드
+  ron: Descărcați cel mai nou FFmpeg
+hq - High Quality, uhq - Ultra High Quality, ll - Low Latency, ull - Ultra Low Latency:
+  eng: hq - High Quality, uhq - Ultra High Quality, ll - Low Latency, ull - Ultra
+    Low Latency
+  deu: hq - Hohe Qualität, uhq - Ultrahohe Qualität, ll - Niedrige Latenzzeit, ull
+    - Ultra-niedrige Latenzzeit
+  fra: hq - Haute qualité, uhq - Ultra haute qualité, ll - Faible latence, ull - Ultra
+    faible latence
+  ita: hq - Alta qualità, uhq - Ultra alta qualità, ll - Bassa latenza, ull - Ultra
+    bassa latenza
+  spa: hq - Alta calidad, uhq - Calidad ultra alta, ll - Baja latencia, ull - Latencia
+    ultra baja
+  jpn: hq - 高画質、uhq - 超高画質、ll - 低遅延、ull - 超低遅延
+  rus: hq - высокое качество, uhq - сверхвысокое качество, ll - низкая задержка, ull
+    - сверхнизкая задержка
+  por: hq - Alta Qualidade, uhq - Ultra Alta Qualidade, ll - Baixa Latência, ull -
+    Ultra Baixa Latência
+  swe: hq - Hög kvalitet, uhq - Ultrahög kvalitet, ll - Låg latens, ull - Ultra låg
+    latens
+  pol: hq - wysoka jakość, uhq - bardzo wysoka jakość, ll - niskie opóźnienie, ull
+    - bardzo niskie opóźnienie
+  chs: hq - 高质量，uhq - 超高质量，ll - 低延迟，ull - 超低延迟
+  ukr: hq - висока якість, uhq - надвисока якість, ll - низька затримка, ull - наднизька
+    затримка
+  kor: hq - 고품질, uhq - 초고화질, ll - 저지연, ull - 초저지연
+  ron: hq - calitate înaltă, uhq - calitate ultra înaltă, ll - latență redusă, ull
+    - latență ultra redusă

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -10727,3 +10727,33 @@ hq - High Quality, uhq - Ultra High Quality, ll - Low Latency, ull - Ultra Low L
   kor: hq - 고품질, uhq - 초고화질, ll - 저지연, ull - 초저지연
   ron: hq - calitate înaltă, uhq - calitate ultra înaltă, ll - latență redusă, ull
     - latență ultra redusă
+FFmpeg not found!:
+  eng: FFmpeg not found!
+  deu: FFmpeg nicht gefunden!
+  fra: FFmpeg introuvable !
+  ita: FFmpeg non trovato!
+  spa: ¡FFmpeg no encontrado!
+  jpn: FFmpegが見つかりません！
+  rus: FFmpeg не найден!
+  por: FFmpeg não encontrado!
+  swe: FFmpeg hittades inte!
+  pol: Nie znaleziono FFmpeg!
+  chs: 未找到 FFmpeg！
+  ukr: FFmpeg не знайдено!
+  kor: FFmpeg를 찾을 수 없습니다!
+  ron: FFmpeg nu a fost găsit!
+Automatically download FFmpeg?:
+  eng: Automatically download FFmpeg?
+  deu: Automatisches Herunterladen von FFmpeg?
+  fra: Télécharger automatiquement FFmpeg ?
+  ita: Scaricare automaticamente FFmpeg?
+  spa: ¿Descargar automáticamente FFmpeg?
+  jpn: FFmpegを自動的にダウンロードしますか？
+  rus: Автоматически загружать FFmpeg?
+  por: Descarregar automaticamente o FFmpeg?
+  swe: Ladda ner FFmpeg automatiskt?
+  pol: Automatycznie pobierać FFmpeg?
+  chs: 自动下载 FFmpeg？
+  ukr: Автоматично завантажити FFmpeg?
+  kor: FFmpeg를 자동으로 다운로드하시겠습니까?
+  ron: Descărcați automat FFmpeg?

--- a/fastflix/encoders/common/helpers.py
+++ b/fastflix/encoders/common/helpers.py
@@ -99,6 +99,18 @@ def generate_ffmpeg_start(
     )
 
 
+def rigaya_data(streams, copy_data=False, **_):
+    if not copy_data:
+        return ""
+    datas = []
+    for stream in streams:
+        if stream["codec_type"] == "data":
+            datas.append(str(stream["index"]))
+    if not datas:
+        return ""
+    return f"--data-copy {','.join(datas)}"
+
+
 def generate_ending(
     audio,
     subtitles,
@@ -109,6 +121,7 @@ def generate_ending(
     null_ending=False,
     output_fps: Union[str, None] = None,
     disable_rotate_metadata=False,
+    copy_data=False,
     **_,
 ):
     ending = (
@@ -116,6 +129,7 @@ def generate_ending(
         f"{'-map_chapters 0' if copy_chapters else '-map_chapters -1'} "
         f"{f'-r {output_fps}' if output_fps else ''} "
         f"{audio} {subtitles} {cover} "
+        f"{'-map 0:d -c:d copy ' if copy_data else ''}"
     )
 
     # In case they use a mp4 container, nix the rotation

--- a/fastflix/encoders/common/setting_panel.py
+++ b/fastflix/encoders/common/setting_panel.py
@@ -519,7 +519,7 @@ class SettingPanel(QtWidgets.QWidget):
                 self.bitrate_radio.setChecked(False)
                 qp = str(self.app.fastflix.config.encoder_opt(self.profile_name, self.qp_name))
                 for i, rec in enumerate(self.recommended_qps):
-                    if rec.startswith(qp):
+                    if rec.split(" ")[0] == qp:
                         self.widgets[self.qp_name].setCurrentIndex(i)
                         break
                 else:

--- a/fastflix/encoders/ffmpeg_hevc_nvenc/command_builder.py
+++ b/fastflix/encoders/ffmpeg_hevc_nvenc/command_builder.py
@@ -25,6 +25,10 @@ def build(fastflix: FastFlix):
     if settings.level:
         beginning += f"-level:v {settings.level} "
 
+    if not settings.bitrate:
+        command = (f"{beginning} -qp:v {settings.qp} -preset:v {settings.preset} " f"{settings.extra}") + ending
+        return [Command(command=command, name="Single QP encode", exe="ffmpeg")]
+
     pass_log_file = fastflix.current_video.work_path / f"pass_log_file_{secrets.token_hex(10)}"
 
     command_1 = (

--- a/fastflix/encoders/ffmpeg_hevc_nvenc/settings_panel.py
+++ b/fastflix/encoders/ffmpeg_hevc_nvenc/settings_panel.py
@@ -134,8 +134,8 @@ class NVENC(SettingPanel):
         return self._add_combo_box(
             label="Tune",
             widget_name="tune",
-            tooltip="Tune the settings for a particular type of source or situation\nhq - High Quality, ll - Low Latency, ull - Ultra Low Latency",
-            options=["hq", "ll", "ull", "lossless"],
+            tooltip="Tune the settings for a particular type of source or situation\nhq - High Quality, uqh - Ultra High Quality, ll - Low Latency, ull - Ultra Low Latency",
+            options=["hq", "uhq", "ll", "ull", "lossless"],
             opt="tune",
         )
 
@@ -248,10 +248,9 @@ class NVENC(SettingPanel):
         return layout
 
     def init_modes(self):
-        layout = self._add_modes(recommended_bitrates, recommended_crfs, qp_name="qp", add_qp=False)
+        layout = self._add_modes(recommended_bitrates, recommended_crfs, qp_name="qp")
         self.qp_radio.setChecked(False)
         self.bitrate_radio.setChecked(True)
-        self.qp_radio.setDisabled(True)
         return layout
 
     def mode_update(self):

--- a/fastflix/encoders/ffmpeg_hevc_nvenc/settings_panel.py
+++ b/fastflix/encoders/ffmpeg_hevc_nvenc/settings_panel.py
@@ -134,7 +134,7 @@ class NVENC(SettingPanel):
         return self._add_combo_box(
             label="Tune",
             widget_name="tune",
-            tooltip="Tune the settings for a particular type of source or situation\nhq - High Quality, uqh - Ultra High Quality, ll - Low Latency, ull - Ultra Low Latency",
+            tooltip="Tune the settings for a particular type of source or situation\nhq - High Quality, uhq - Ultra High Quality, ll - Low Latency, ull - Ultra Low Latency",
             options=["hq", "uhq", "ll", "ull", "lossless"],
             opt="tune",
         )

--- a/fastflix/encoders/vvc/settings_panel.py
+++ b/fastflix/encoders/vvc/settings_panel.py
@@ -115,12 +115,13 @@ class VVC(SettingPanel):
         )
 
     def init_levels(self):
+        # https://github.com/fraunhoferhhi/vvenc/blob/cf8ba5ed74f8e8c7c9e7b6f81f7fb08bce6241b0/source/Lib/vvenc/vvencCfg.cpp#L159
         return self._add_combo_box(
             label="IDC Level",
             tooltip="Set the IDC level",
             widget_name="levelidc",
             options=[
-                "0",
+                t("auto"),
                 "1",
                 "2",
                 "2.1",
@@ -135,6 +136,7 @@ class VVC(SettingPanel):
                 "6.1",
                 "6.2",
                 "6.3",
+                "15.5",
             ],
             opt="levelidc",
         )
@@ -226,12 +228,14 @@ class VVC(SettingPanel):
 
         vvc_params_text = self.widgets.vvc_params.text().strip()
 
+        level = self.widgets.levelidc.currentText() if self.widgets.levelidc.currentIndex() > 0 else None
+
         settings = VVCSettings(
             preset=self.widgets.preset.currentText(),
             max_muxing_queue_size=self.widgets.max_mux.currentText(),
             pix_fmt=self.widgets.pix_fmt.currentText().split(":")[1].strip(),
             tier=self.widgets.tier.currentText(),
-            levelidc=self.widgets.levelidc.currentText(),
+            levelidc=level,
             vvc_params=vvc_params_text.split(":") if vvc_params_text else [],
             extra=self.ffmpeg_extras,
             extra_both_passes=self.widgets.extra_both_passes.isChecked(),

--- a/fastflix/encoders/vvc/settings_panel.py
+++ b/fastflix/encoders/vvc/settings_panel.py
@@ -121,7 +121,7 @@ class VVC(SettingPanel):
             tooltip="Set the IDC level",
             widget_name="levelidc",
             options=[
-                t("auto"),
+                t("Auto"),
                 "1",
                 "2",
                 "2.1",

--- a/fastflix/flix.py
+++ b/fastflix/flix.py
@@ -190,7 +190,10 @@ def ffprobe_configuration(app, config: Config, **_):
 
 
 def probe(app: FastFlixApp, file: Path) -> Box:
-    """Run FFprobe on a file"""
+    """
+    Run FFprobe on a file
+    ffprobe -v quiet -loglevel panic -print_format json -show_format -show_streams
+    """
     command = [
         f"{app.fastflix.config.ffprobe}",
         "-v",

--- a/fastflix/models/video.py
+++ b/fastflix/models/video.py
@@ -109,6 +109,7 @@ class VideoSettings(BaseModel):
     brightness: Optional[str] = None
     contrast: Optional[str] = None
     saturation: Optional[str] = None
+    copy_data: bool = False
     video_encoder_settings: Optional[
         Union[
             x265Settings,

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "5.8.2"
+__version__ = "5.9.0"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -664,6 +664,7 @@ class Main(QtWidgets.QWidget):
 
             if self.app.fastflix.current_video:
                 self.video_options.new_source()
+            self.update_output_type()
         finally:
             # Hack to prevent a lot of thumbnail generation
             self.loading_video = False
@@ -771,18 +772,12 @@ class Main(QtWidgets.QWidget):
         if not self.initialized or not self.convert_to:
             return
         self.video_options.change_conversion(self.convert_to)
+        self.update_output_type()
+
+    def update_output_type(self):
         self.widgets.output_type_combo.clear()
         self.widgets.output_type_combo.addItems(self.current_encoder.video_extensions)
         self.widgets.output_type_combo.setCurrentText(self.app.fastflix.config.opt("output_type"))
-        if not self.app.fastflix.current_video:
-            return
-
-        last = self.widgets.output_type_combo.currentText()
-
-        self.widgets.output_type_combo.clear()
-        self.widgets.output_type_combo.addItems(self.current_encoder.video_extensions)
-        if last in {self.widgets.output_type_combo.itemText(i) for i in range(self.widgets.output_type_combo.count())}:
-            self.widgets.output_type_combo.setCurrentText(last)
 
     @property
     def current_encoder(self):

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -134,6 +134,7 @@ class MainWidgets(BaseModel):
     output_type_combo: QtWidgets.QComboBox = Field(default_factory=QtWidgets.QComboBox)
     output_directory_select: QtWidgets.QPushButton = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    copy_data: QtWidgets.QCheckBox = None
 
     def items(self):
         for key in dir(self):
@@ -394,8 +395,8 @@ class Main(QtWidgets.QWidget):
 
         self.widgets.thumb_time = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self.widgets.thumb_time.setMinimum(1)
-        self.widgets.thumb_time.setMaximum(10)
-        self.widgets.thumb_time.setValue(2)
+        self.widgets.thumb_time.setMaximum(100)
+        self.widgets.thumb_time.setValue(25)
         self.widgets.thumb_time.setTickPosition(QtWidgets.QSlider.TicksBelow)
         self.widgets.thumb_time.setTickInterval(1)
         self.widgets.thumb_time.setAutoFillBackground(False)
@@ -572,8 +573,21 @@ class Main(QtWidgets.QWidget):
         extra_details_layout = QtWidgets.QVBoxLayout()
         extra_details_layout.addWidget(self.widgets.deinterlace)
         extra_details_layout.addWidget(self.widgets.remove_hdr)
-
         transform_layout.addLayout(extra_details_layout)
+
+        # another_layout = QtWidgets.QVBoxLayout()
+        #
+        # self.widgets.copy_data = QtWidgets.QCheckBox(t("Copy Data"))
+        # self.widgets.copy_data.setChecked(False)
+        # self.widgets.copy_data.toggled.connect(self.page_update)
+        # self.widgets.copy_data.setToolTip(
+        #     f'{t("Copy all data streams from the source file.")}'
+        # )
+        #
+        # another_layout.addWidget(self.widgets.copy_data)
+        # another_layout.addWidget(QtWidgets.QWidget())
+        # transform_layout.addLayout(another_layout)
+
         return transform_layout
 
     def init_video_track_select(self):
@@ -1624,7 +1638,7 @@ class Main(QtWidgets.QWidget):
 
     @property
     def preview_place(self) -> Union[float, int]:
-        ticks = self.app.fastflix.current_video.duration / 10
+        ticks = self.app.fastflix.current_video.duration / 100
         return (self.widgets.thumb_time.value() - 1) * ticks
 
     @reusables.log_exception("fastflix", show_traceback=False)
@@ -1739,6 +1753,7 @@ class Main(QtWidgets.QWidget):
             video_title=self.video_options.advanced.video_title.text(),
             video_track_title=self.video_options.advanced.video_track_title.text(),
             remove_hdr=self.remove_hdr,
+            copy_data=self.widgets.copy_data.isChecked(),
         )
 
         self.video_options.get_settings()

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -1753,7 +1753,7 @@ class Main(QtWidgets.QWidget):
             video_title=self.video_options.advanced.video_title.text(),
             video_track_title=self.video_options.advanced.video_track_title.text(),
             remove_hdr=self.remove_hdr,
-            copy_data=self.widgets.copy_data.isChecked(),
+            # copy_data=self.widgets.copy_data.isChecked(),
         )
 
         self.video_options.get_settings()

--- a/fastflix/widgets/video_options.py
+++ b/fastflix/widgets/video_options.py
@@ -163,7 +163,7 @@ class VideoOptions(QtWidgets.QTabWidget):
 
         try:
             del self.app.fastflix.current_video.video_settings.video_encoder_settings
-        except KeyError:
+        except (KeyError, AttributeError):
             pass
         self.current_settings.update_video_encoder_settings()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "python-box[all]>=6.0,<7.0",
     "requests>=2.28,<3.0",
     "reusables>=0.9.6,<0.10.0",
+    "setuptools>=75.8",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
* Adding QP mode for FFmpeg Nvenc encoding
* Adding more preview positions
* Adding ultra high quality mode for ffmpeg nvenc encoder
* Adding #633 download for stable version of ffmpeg by default on Windows (thanks to Maddie Davis)
* Fixing #611 Extension type not being selected properly from profiles if encoders isn't switched (thanks to Hankuu)
* Fixing #628 Custom QP/CRF saved in profile may not be restored correctly (thanks to Gregorio O. DeMojeca)
* Fixing #631 VVC Level can't be set to 0 anymore (thanks to GT500org)