### PR TITLE
Version 5.10.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,9 @@
 
 * Adding global disable interlace check (thanks to Wontell)
 * Changing profile bitrate selector to be text field (thanks to Wontell)
-
+* Fixing #637 saving temp files for seven days to allow for better debug and recovery (thanks to marillat)
+* Fixing #638 switching archived library appdirs to maintained platformdirs (thanks to marillat)
+* Fixing x265 passlog file name was not being applied properly
 
 ## Version 5.9.0
 
@@ -17,7 +19,6 @@
 * Fixing #628 Custom QP/CRF saved in profile may not be restored correctly (thanks to Gregorio O. DeMojeca)
 * Fixing #631 VVC Level can't be set to 0 anymore (thanks to GT500org)
 * Removing Ubuntu 20.04, 22.04 and Mac 12 builds
-
 
 ## Version 5.8.2
 

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 ## Version 5.10.0
 
 * Adding global disable interlace check (thanks to Wontell)
+* Changing profile bitrate selector to be text field (thanks to Wontell)
 
 
 ## Version 5.9.0

--- a/CHANGES
+++ b/CHANGES
@@ -2,11 +2,12 @@
 
 ## Version 5.10.0
 
-* Adding global disable interlace check (thanks to Wontell)
-* Changing profile bitrate selector to be text field (thanks to Wontell)
+* Adding global disable interlace check (thanks to Hexenhammer)
+* Changing profile bitrate selector to be text field (thanks to Hexenhammer)
 * Fixing #637 saving temp files for seven days to allow for better debug and recovery (thanks to marillat)
 * Fixing #638 switching archived library appdirs to maintained platformdirs (thanks to marillat)
 * Fixing x265 passlog file name was not being applied properly
+* Fixing audio conversion list for rigaya encoders (thanks to Hexenhammer)
 
 ## Version 5.9.0
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 5.10.0
+
+* Adding global disable interlace check (thanks to Wontell)
+
+
 ## Version 5.9.0
 
 * Adding QP mode for FFmpeg Nvenc encoding

--- a/fastflix/conversion_worker.py
+++ b/fastflix/conversion_worker.py
@@ -6,7 +6,7 @@ from typing import Literal
 from datetime import datetime
 
 import reusables
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 from pathvalidate import sanitize_filename
 
 from fastflix.command_runner import BackgroundRunner

--- a/fastflix/encoders/hevc_x265/command_builder.py
+++ b/fastflix/encoders/hevc_x265/command_builder.py
@@ -170,7 +170,7 @@ def build(fastflix: FastFlix):
     if fastflix.current_video.cll:
         pass
 
-    pass_log_file = fastflix.current_video.work_path / f"pass_log_file_{secrets.token_hex(10)}"
+    pass_log_file = f"pass_log_file_{secrets.token_hex(10)}.log"
 
     def get_x265_params(params=()):
         if not isinstance(params, (list, tuple)):
@@ -181,12 +181,12 @@ def build(fastflix: FastFlix):
     if settings.bitrate:
         if settings.bitrate_passes == 2:
             command_1 = (
-                f'{beginning} {get_x265_params(["pass=1", "no-slow-firstpass=1"])} '
-                f'-passlogfile "{pass_log_file}" -b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} '
+                f'{beginning} {get_x265_params(["pass=1", "no-slow-firstpass=1", f"stats={pass_log_file}"])} '
+                f' -b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} '
                 f" -an -sn -dn {output_fps} -f mp4 {null}"
             )
             command_2 = (
-                f'{beginning} {get_x265_params(["pass=2"])} -passlogfile "{pass_log_file}" '
+                f'{beginning} {get_x265_params(["pass=2", f"stats={pass_log_file}"])}  '
                 f"-b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra} {ending}"
             )
             return [

--- a/fastflix/entry.py
+++ b/fastflix/entry.py
@@ -8,7 +8,7 @@ try:
     import coloredlogs
     import requests
     import reusables
-    from appdirs import user_data_dir
+    from platformdirs import user_data_dir
     from box import Box
 
     import fastflix.language  # Have to set language first thing
@@ -53,7 +53,7 @@ def startup_options():
 
     if "--test" in options:
         try:
-            import appdirs
+            import platformdirs
             import box
             import colorama
             import coloredlogs

--- a/fastflix/flix.py
+++ b/fastflix/flix.py
@@ -407,7 +407,6 @@ def get_auto_crop(
 
 def detect_interlaced(app: FastFlixApp, config: Config, source: Path, **_):
     """http://www.aktau.be/2013/09/22/detecting-interlaced-video-with-ffmpeg/"""
-
     # Interlaced
     # [Parsed_idet_0 @ 00000] Repeated Fields: Neither:   815 Top:    88 Bottom:    98
     # [Parsed_idet_0 @ 00000] Single frame detection: TFF:   693 BFF:     0 Progressive:    39 Undetermined:   269

--- a/fastflix/language.py
+++ b/fastflix/language.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 from pathlib import Path
 import importlib.resources
 
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 from box import Box
 
 ref = importlib.resources.files("fastflix") / "data/languages.yaml"

--- a/fastflix/models/config.py
+++ b/fastflix/models/config.py
@@ -127,6 +127,7 @@ class Config(BaseModel):
     custom_after_run_scripts: dict = Field(default_factory=dict)
     profiles: dict[str, Profile] = Field(default_factory=get_preset_defaults)
     priority: Literal["Realtime", "High", "Above Normal", "Normal", "Below Normal", "Idle"] = "Normal"
+    disable_deinterlace_check: bool = False
     stay_on_top: bool = False
     portable_mode: bool = False
     ui_scale: str = "1"

--- a/fastflix/models/config.py
+++ b/fastflix/models/config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Literal
 import json
 
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 from box import Box, BoxError
 from pydantic import BaseModel, Field
 from reusables import win_based

--- a/fastflix/models/fastflix.py
+++ b/fastflix/models/fastflix.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 from typing import Any
 
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 from pydantic import BaseModel, Field
 
 from fastflix.models.config import Config

--- a/fastflix/program_downloads.py
+++ b/fastflix/program_downloads.py
@@ -9,7 +9,7 @@ import re
 
 import requests
 import reusables
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 from PySide6 import QtWidgets
 
 from fastflix.language import t

--- a/fastflix/shared.py
+++ b/fastflix/shared.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from subprocess import run
 import platform
 
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 import importlib.resources
 import requests
 import reusables
@@ -352,3 +352,15 @@ def clear_list(the_list: list, close=False):
         if close:
             the_list[i].close()
         del the_list[i]
+
+
+def get_filesafe_datetime():
+    return datetime.now().strftime("%Y%m%d")
+
+
+def parse_filesafe_datetime(dt: str):
+    return datetime.strptime(dt, "%Y%m%d")
+
+
+def is_date_older_than_7days(dt: datetime):
+    return (datetime.now() - dt) > timedelta(days=7)

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "5.9.0"
+__version__ = "5.10.0"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -42,7 +42,14 @@ from fastflix.resources import (
     onyx_queue_add_icon,
     get_text_color,
 )
-from fastflix.shared import error_message, message, time_to_number, yes_no_message, clean_file_string
+from fastflix.shared import (
+    error_message,
+    message,
+    time_to_number,
+    yes_no_message,
+    clean_file_string,
+    get_filesafe_datetime,
+)
 from fastflix.windows_tools import prevent_sleep_mode, allow_sleep_mode
 from fastflix.widgets.background_tasks import ThumbnailCreator
 from fastflix.widgets.progress_bar import ProgressBar, Task
@@ -415,7 +422,7 @@ class Main(QtWidgets.QWidget):
         self.generate_thumbnail()
 
     def get_temp_work_path(self):
-        new_temp = self.app.fastflix.config.work_path / f"temp_{secrets.token_hex(12)}"
+        new_temp = self.app.fastflix.config.work_path / f"temp_{get_filesafe_datetime()}_{secrets.token_hex(8)}"
         if new_temp.exists():
             return self.get_temp_work_path()
         new_temp.mkdir()

--- a/fastflix/widgets/main.py
+++ b/fastflix/widgets/main.py
@@ -1502,10 +1502,11 @@ class Main(QtWidgets.QWidget):
         tasks = [
             Task(t("Parse Video details"), parse),
             Task(t("Extract covers"), extract_attachments),
-            Task(t("Detecting Interlace"), detect_interlaced, dict(source=self.source_material)),
             Task(t("Determine HDR details"), parse_hdr_details),
             Task(t("Detect HDR10+"), detect_hdr10_plus),
         ]
+        if not self.app.fastflix.config.disable_deinterlace_check:
+            tasks.append(Task(t("Detecting Interlace"), detect_interlaced, dict(source=self.source_material)))
 
         try:
             ProgressBar(self.app, tasks, hidden=hide_progress)

--- a/fastflix/widgets/panels/queue_panel.py
+++ b/fastflix/widgets/panels/queue_panel.py
@@ -10,7 +10,7 @@ from pathlib import Path
 # import tracemalloc
 import gc
 
-from appdirs import user_data_dir
+from platformdirs import user_data_dir
 import reusables
 from box import Box
 from PySide6 import QtCore, QtGui, QtWidgets

--- a/fastflix/widgets/settings.py
+++ b/fastflix/widgets/settings.py
@@ -257,6 +257,9 @@ class Settings(QtWidgets.QWidget):
         )
         self.clean_old_logs_button.setChecked(self.app.fastflix.config.clean_old_logs)
 
+        self.disable_deinterlace_button = QtWidgets.QCheckBox(t("Disable interlace check"))
+        self.disable_deinterlace_button.setChecked(self.app.fastflix.config.disable_deinterlace_check)
+
         # Layouts
 
         layout.addWidget(self.use_sane_audio, 7, 0, 1, 2)
@@ -273,13 +276,14 @@ class Settings(QtWidgets.QWidget):
 
         layout.addWidget(self.clean_old_logs_button, 21, 0, 1, 3)
         layout.addWidget(self.disable_end_message, 22, 0, 1, 3)
+        layout.addWidget(self.disable_deinterlace_button, 23, 0, 1, 3)
 
         button_layout = QtWidgets.QHBoxLayout()
         button_layout.addStretch()
         button_layout.addWidget(cancel)
         button_layout.addWidget(save)
 
-        layout.addLayout(button_layout, 24, 0, 1, 3)
+        layout.addLayout(button_layout, 25, 0, 1, 3)
 
         self.setLayout(layout)
 
@@ -365,6 +369,7 @@ class Settings(QtWidgets.QWidget):
         self.app.fastflix.config.clean_old_logs = self.clean_old_logs_button.isChecked()
         self.app.fastflix.config.sticky_tabs = self.sticky_tabs.isChecked()
         self.app.fastflix.config.disable_complete_message = self.disable_end_message.isChecked()
+        self.app.fastflix.config.disable_deinterlace_check = self.disable_deinterlace_button.isChecked()
 
         self.main.config_update()
         self.app.fastflix.config.save()

--- a/fastflix/widgets/windows/audio_conversion.py
+++ b/fastflix/widgets/windows/audio_conversion.py
@@ -53,6 +53,29 @@ channel_list = {
     "7.1(wide)": 8,
 }
 
+venc_channels = {
+    "mono": 1,
+    "stereo": 2,
+    "2.1": 3,
+    "3.0": 3,
+    "3.0(back)": 3,
+    "3.1": 4,
+    "4.0": 4,
+    "quad": 4,
+    "quad(side)": 4,
+    "5.0": 5,
+    "5.1": 6,
+    "6.0": 6,
+    "6.0(front)": 6,
+    "hexagonal": 6,
+    "6.1": 7,
+    "6.1(front)": 7,
+    "7.0": 7,
+    "7.0(front)": 7,
+    "7.1": 8,
+    "7.1(wide)": 8,
+}
+
 back_channel_list = {
     1: "mono",
     2: "stereo",
@@ -134,7 +157,12 @@ class AudioConversion(QtWidgets.QWidget):
         channel_layout = self.audio_track.raw_info.get("channel_layout")
 
         self.downmix = QtWidgets.QComboBox()
-        self.downmix.addItems([t("None")] + list(channel_list.keys()))
+
+        if "encc" in app.fastflix.current_video.video_settings.video_encoder_settings.name.lower():
+            self.downmix.addItems([t("None")] + list(venc_channels.keys()))
+        else:
+            self.downmix.addItems([t("None")] + list(channel_list.keys()))
+
         try:
             if channel_layout:
                 self.downmix.setCurrentText(channel_layout)

--- a/fastflix/widgets/windows/profile_window.py
+++ b/fastflix/widgets/windows/profile_window.py
@@ -88,9 +88,9 @@ class AudioProfile(QtWidgets.QTabWidget):
         self.convert_to.addItems(["None | Passthrough"] + main.video_options.audio_formats)
 
         self.convert_to.view().setFixedWidth(self.convert_to.minimumSizeHint().width() + 50)
-        self.bitrate = QtWidgets.QComboBox()
-        self.bitrate.addItems([f"{x}k" for x in range(32, 1024, 32)])
-        self.bitrate.view().setFixedWidth(self.bitrate.minimumSizeHint().width() + 50)
+        self.bitrate = QtWidgets.QLineEdit()
+        self.bitrate.setPlaceholderText("128k")
+        self.bitrate.setFixedWidth(self.bitrate.minimumSizeHint().width() + 50)
 
         self.bitrate.setDisabled(True)
         self.downmix.setDisabled(True)
@@ -153,7 +153,7 @@ class AudioProfile(QtWidgets.QTabWidget):
             match_item=match_item_enum,
             match_input=match_input_value,
             conversion=self.convert_to.currentText() if self.convert_to.currentIndex() > 0 else None,
-            bitrate=self.bitrate.currentText(),
+            bitrate=self.bitrate.text(),
             downmix=self.downmix.currentText() if self.downmix.currentIndex() > 0 else None,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-    "appdirs~=1.4",
+    "platformdirs~=4.3",
     "chardet>=5.1.0,<5.2.0",
     "colorama>=0.4,<1.0",
     "coloredlogs>=15.0,<16.0",


### PR DESCRIPTION
## Version 5.10.0

* Adding global disable interlace check (thanks to Hexenhammer)
* Changing profile bitrate selector to be text field (thanks to Hexenhammer)
* Fixing #637 saving temp files for seven days to allow for better debug and recovery (thanks to marillat)
* Fixing #638 switching archived library appdirs to maintained platformdirs (thanks to marillat)
* Fixing x265 passlog file name was not being applied properly
* Fixing audio conversion list for rigaya encoders (thanks to Hexenhammer)