### PR TITLE
Version 5.11.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
   build-nix:
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/CHANGES
+++ b/CHANGES
@@ -3,10 +3,13 @@
 ## Version 5.11.0
 
 * Adding parallel encoding options for rigaya hardware encoders (thanks to Hexenhammer)
+* Adding builds for Ubuntu 22.04 and mac 13 again
 * Changing SVT-AV1 to single pass only due to ffmpeg not allowing passlog files properly
 * Changing SVT-AV1 to CRF quantization mode by default
 * Fixing #642 Possible to create a profile without bitrate specified for audio stream (thanks to Xoanon88)
+* Fixing #644 various typos (thanks to luzpaz)
 * Fixing #646 PydanticSerializationUnexpectedValue warning during startup (thanks to Noelle Leigh)
+* Fixing #647 another typo (thanks to Noelle Leigh)
 * Fixing #649 1-Pass Bitrate stored in x265 profile not honored (thanks to Xoanon88)
 * Fixing how program is centered on multiple monitors
 * Fixing do not pass infer_no_subs to encc encoders

--- a/CHANGES
+++ b/CHANGES
@@ -1,12 +1,15 @@
 # Changelog
 
-## Version 5.10.1
+## Version 5.11.0
 
+* Adding parallel encoding options for rigaya hardware encoders (thanks to Hexenhammer)
 * Changing SVT-AV1 to single pass only due to ffmpeg not allowing passlog files properly
 * Changing SVT-AV1 to CRF quantization mode by default
 * Fixing #642 Possible to create a profile without bitrate specified for audio stream (thanks to Xoanon88)
 * Fixing #646 PydanticSerializationUnexpectedValue warning during startup (thanks to Noelle Leigh)
+* Fixing #649 1-Pass Bitrate stored in x265 profile not honored (thanks to Xoanon88)
 * Fixing how program is centered on multiple monitors
+* Fixing do not pass infer_no_subs to encc encoders
 
 ## Version 5.10.0
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 5.10.1
+
+* Changing SVT-AV1 to single pass only due to ffmpeg not allowing passlog files properly
+* Changing SVT-AV1 to CRF quantization mode by default
+* Fixing #642 Possible to create a profile without bitrate specified for audio stream (thanks to Xoanon88)
+* Fixing #646 PydanticSerializationUnexpectedValue warning during startup (thanks to Noelle Leigh)
+* Fixing how program is centered on multiple monitors
+
 ## Version 5.10.0
 
 * Adding global disable interlace check (thanks to Hexenhammer)

--- a/fastflix/__main__.py
+++ b/fastflix/__main__.py
@@ -23,7 +23,7 @@ def start_fastflix():
         traceback.print_exc()
         input(
             "Error while running FastFlix!\n"
-            "Plese report this issue on https://github.com/cdgriffith/FastFlix/issues (press any key to exit)"
+            "Please report this issue on https://github.com/cdgriffith/FastFlix/issues (press any key to exit)"
         )
     except KeyboardInterrupt:
         pass

--- a/fastflix/application.py
+++ b/fastflix/application.py
@@ -196,8 +196,7 @@ def app_setup(
         sys.exit(1)
 
     if app.fastflix.config.theme != "system":
-        QtCore.QDir.addSearchPath(app.fastflix.config.theme, str(breeze_styles_path / app.fastflix.config.theme))
-        file = QtCore.QFile(f"{app.fastflix.config.theme}:stylesheet.qss")
+        file = QtCore.QFile(str(breeze_styles_path / app.fastflix.config.theme / "stylesheet.qss"))
         file.open(QtCore.QFile.OpenModeFlag.ReadOnly | QtCore.QFile.OpenModeFlag.Text)
         stream = QtCore.QTextStream(file)
         data = stream.readAll()
@@ -233,7 +232,9 @@ def app_setup(
     container = Container(app)
     container.show()
 
-    container.move(QtGui.QGuiApplication.primaryScreen().availableGeometry().center() - container.rect().center())
+    # container.move(QtGui.QGuiApplication.primaryScreen().availableGeometry().center() - container.rect().center())
+    screen_geometry = QtGui.QGuiApplication.primaryScreen().availableGeometry()
+    container.move(screen_geometry.center() - container.rect().center())
 
     if not app.fastflix.config.disable_version_check:
         latest_fastflix(app=app, show_new_dialog=False)
@@ -257,7 +258,7 @@ def start_app(worker_queue, status_queue, log_queue, queue_list, queue_lock, por
     )
 
     try:
-        app.exec_()
+        app.exec()
     except Exception:
         logger.exception("Error while running FastFlix")
         raise

--- a/fastflix/data/languages.yaml
+++ b/fastflix/data/languages.yaml
@@ -10757,3 +10757,33 @@ Automatically download FFmpeg?:
   ukr: Автоматично завантажити FFmpeg?
   kor: FFmpeg를 자동으로 다운로드하시겠습니까?
   ron: Descărcați automat FFmpeg?
+Parallel Encoding:
+  eng: Parallel Encoding
+  deu: Parallele Kodierung
+  fra: Encodage parallèle
+  ita: Codifica parallela
+  spa: Codificación paralela
+  jpn: パラレル・エンコーディング
+  rus: Параллельное кодирование
+  por: Codificação paralela
+  swe: Parallell kodning
+  pol: Kodowanie równoległe
+  chs: 并行编码
+  ukr: Паралельне кодування
+  kor: 병렬 인코딩
+  ron: Codificare paralelă
+Enable either auto split or parallel encoding mode.:
+  eng: Enable either auto split or parallel encoding mode.
+  deu: Aktivieren Sie entweder die automatische Aufteilung oder den parallelen Codierungsmodus.
+  fra: Activer le mode d'encodage auto split ou parallèle.
+  ita: Abilitare la modalità di codifica automatica o parallela.
+  spa: Habilita el modo de división automática o de codificación paralela.
+  jpn: 自動分割またはパラレルエンコーディングモードのいずれかを有効にする。
+  rus: Включите режим автоматического разделения или параллельного кодирования.
+  por: Ativar o modo de codificação automática ou paralela.
+  swe: Aktivera antingen auto split eller parallell kodning.
+  pol: Włącz tryb automatycznego podziału lub kodowania równoległego.
+  chs: 启用自动分割或并行编码模式。
+  ukr: Увімкніть режим автоматичного розділення або паралельного кодування.
+  kor: 자동 분할 또는 병렬 인코딩 모드를 활성화합니다.
+  ron: Activați divizarea automată sau modul de codare paralelă.

--- a/fastflix/encoders/common/encc_helpers.py
+++ b/fastflix/encoders/common/encc_helpers.py
@@ -184,5 +184,5 @@ def build_subtitle(subtitle_tracks: list[SubtitleTrack], subtitle_streams, video
 
     commands = f" --sub-copy {','.join(copies)} {' '.join(command_list)}" if copies else f" {' '.join(command_list)}"
     if commands:
-        return f"{commands} -m default_mode:infer_no_subs"
+        return commands
     return ""

--- a/fastflix/encoders/common/setting_panel.py
+++ b/fastflix/encoders/common/setting_panel.py
@@ -375,7 +375,6 @@ class SettingPanel(QtWidgets.QWidget):
             self.widgets.bitrate.addItems(recommended_bitrates)
             self.widgets.bitrate_passes = QtWidgets.QComboBox()
             self.widgets.bitrate_passes.addItems(["1", "2"])
-            self.widgets.bitrate_passes.setCurrentIndex(1)
             self.widgets.bitrate_passes.currentIndexChanged.connect(lambda: self.mode_update())
             config_opt = self.app.fastflix.config.encoder_opt(self.profile_name, "bitrate")
             custom_bitrate = False
@@ -399,6 +398,9 @@ class SettingPanel(QtWidgets.QWidget):
             bitrate_box_layout.addWidget(self.widgets.bitrate, 1)
             bitrate_box_layout.addStretch(1)
             if show_bitrate_passes:
+                self.widgets.bitrate_passes.setCurrentIndex(
+                    int(self.app.fastflix.config.encoder_opt(self.profile_name, "bitrate_passes")) - 1
+                )
                 bitrate_box_layout.addWidget(QtWidgets.QLabel(t("Passes") + ":"))
                 bitrate_box_layout.addWidget(self.widgets.bitrate_passes)
             bitrate_box_layout.addStretch(1)
@@ -655,6 +657,18 @@ class RigayaPanel(SettingPanel):
             opt="copy_hdr10",
         )
         return layout
+
+    def init_parallel_mode(self, add_split=False):
+        options = ["none", "parallel"]
+        if add_split:
+            options.insert(1, "split")
+        return self._add_combo_box(
+            label="Parallel Encoding",
+            widget_name="split_mode",
+            options=options,
+            opt="split_mode",
+            tooltip="Enable either auto split or parallel encoding mode.",
+        )
 
 
 class QSVEncPanel(RigayaPanel):

--- a/fastflix/encoders/common/setting_panel.py
+++ b/fastflix/encoders/common/setting_panel.py
@@ -346,7 +346,10 @@ class SettingPanel(QtWidgets.QWidget):
         disable_custom_qp=False,
         show_bitrate_passes=False,
         disable_bitrate=False,
+        qp_display_name=None,
     ):
+        if not qp_display_name:
+            qp_display_name = qp_name.upper()
         self.recommended_bitrates = recommended_bitrates
         self.recommended_qps = recommended_qps
         self.qp_name = qp_name
@@ -403,7 +406,7 @@ class SettingPanel(QtWidgets.QWidget):
             bitrate_box_layout.addWidget(self.widgets.custom_bitrate)
             bitrate_box_layout.addWidget(QtWidgets.QLabel("k"))
 
-            self.qp_radio = QtWidgets.QRadioButton(qp_name.upper())
+            self.qp_radio = QtWidgets.QRadioButton(qp_display_name)
             self.qp_radio.setChecked(True)
             self.qp_radio.setFixedWidth(80)
             self.qp_radio.setToolTip(qp_help)

--- a/fastflix/encoders/hevc_x265/settings_panel.py
+++ b/fastflix/encoders/hevc_x265/settings_panel.py
@@ -566,7 +566,8 @@ class HEVC(SettingPanel):
         return self._add_modes(recommended_bitrates, recommended_crfs, qp_name="crf", show_bitrate_passes=True)
 
     def mode_update(self):
-        self.widgets.custom_crf.setDisabled(self.widgets.crf.currentText() != "Custom")
+        if "custom_crf" in self.widgets:
+            self.widgets.custom_crf.setDisabled(self.widgets.crf.currentText() != "Custom")
         self.widgets.custom_bitrate.setDisabled(self.widgets.bitrate.currentText() != "Custom")
         self.main.build_commands()
 

--- a/fastflix/encoders/nvencc_av1/command_builder.py
+++ b/fastflix/encoders/nvencc_av1/command_builder.py
@@ -105,6 +105,12 @@ def build(fastflix: FastFlix):
 
     source_fps = f"--fps {video.video_settings.source_fps}" if video.video_settings.source_fps else ""
 
+    split_mode = ""
+    if settings.split_mode == "split":
+        split_mode = f"--split-enc auto_forced"
+    elif settings.split_mode == "parallel":
+        split_mode = f"--parallel auto"
+
     command = [
         f'"{clean_file_string(fastflix.config.nvencc)}"',
         rigaya_avformat_reader(fastflix),
@@ -160,6 +166,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-yadif" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        split_mode,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.audio_tracks, video.streams.audio),
         build_subtitle(video.subtitle_tracks, video.streams.subtitle, video_height=video.height),

--- a/fastflix/encoders/nvencc_av1/settings_panel.py
+++ b/fastflix/encoders/nvencc_av1/settings_panel.py
@@ -128,7 +128,8 @@ class NVENCC(RigayaPanel):
         even_more.addLayout(self.init_metrics())
         grid.addLayout(even_more, 7, 2, 1, 4)
 
-        grid.addLayout(self.init_dhdr10_info(), 8, 2, 1, 4)
+        grid.addLayout(self.init_dhdr10_info(), 8, 2, 1, 2)
+        grid.addLayout(self.init_parallel_mode(add_split=True), 8, 4, 1, 2)
 
         grid.setRowStretch(9, 1)
 
@@ -415,6 +416,7 @@ class NVENCC(RigayaPanel):
             b_ref_mode=self.widgets.b_ref_mode.currentText(),
             device=int(self.widgets.device.currentText().split(":", 1)[0] or 0),
             decoder=self.widgets.decoder.currentText(),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/nvencc_avc/command_builder.py
+++ b/fastflix/encoders/nvencc_avc/command_builder.py
@@ -129,6 +129,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-yadif" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        "--parallel auto" if settings.split_mode == "parallel" else "",
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.audio_tracks, video.streams.audio),
         build_subtitle(video.subtitle_tracks, video.streams.subtitle, video_height=video.height),

--- a/fastflix/encoders/nvencc_avc/settings_panel.py
+++ b/fastflix/encoders/nvencc_avc/settings_panel.py
@@ -125,6 +125,7 @@ class NVENCCAVC(RigayaPanel):
         even_more.addStretch(1)
         even_more.addLayout(self.init_metrics())
         grid.addLayout(even_more, 7, 2, 1, 4)
+        grid.addLayout(self.init_parallel_mode(), 8, 4, 1, 2)
 
         grid.setRowStretch(9, 1)
 
@@ -399,6 +400,7 @@ class NVENCCAVC(RigayaPanel):
             b_ref_mode=self.widgets.b_ref_mode.currentText(),
             device=int(self.widgets.device.currentText().split(":", 1)[0] or 0),
             decoder=self.widgets.decoder.currentText(),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/nvencc_hevc/command_builder.py
+++ b/fastflix/encoders/nvencc_hevc/command_builder.py
@@ -103,6 +103,12 @@ def build(fastflix: FastFlix):
     elif video.video_settings.vsync == "vfr":
         vsync_setting = "vfr"
 
+    split_mode = ""
+    if settings.split_mode == "split":
+        split_mode = f"--split-enc auto_forced"
+    elif settings.split_mode == "parallel":
+        split_mode = f"--parallel auto"
+
     source_fps = f"--fps {video.video_settings.source_fps}" if video.video_settings.source_fps else ""
 
     command = [
@@ -160,6 +166,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-yadif" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        split_mode,
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.audio_tracks, video.streams.audio),
         build_subtitle(video.subtitle_tracks, video.streams.subtitle, video_height=video.height),

--- a/fastflix/encoders/nvencc_hevc/settings_panel.py
+++ b/fastflix/encoders/nvencc_hevc/settings_panel.py
@@ -128,7 +128,8 @@ class NVENCC(RigayaPanel):
         even_more.addLayout(self.init_metrics())
         grid.addLayout(even_more, 7, 2, 1, 4)
 
-        grid.addLayout(self.init_dhdr10_info(), 8, 2, 1, 4)
+        grid.addLayout(self.init_dhdr10_info(), 8, 2, 1, 2)
+        grid.addLayout(self.init_parallel_mode(add_split=True), 8, 4, 1, 2)
 
         grid.setRowStretch(9, 1)
 
@@ -414,6 +415,7 @@ class NVENCC(RigayaPanel):
             b_ref_mode=self.widgets.b_ref_mode.currentText(),
             device=int(self.widgets.device.currentText().split(":", 1)[0] or 0),
             decoder=self.widgets.decoder.currentText(),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/qsvencc_av1/command_builder.py
+++ b/fastflix/encoders/qsvencc_av1/command_builder.py
@@ -138,6 +138,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-yadif" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        "--parallel auto" if settings.split_mode == "parallel" else "",
         ("--adapt-ref" if settings.adapt_ref else ""),
         ("--adapt-ltr" if settings.adapt_ltr else ""),
         ("--adapt-cqm" if settings.adapt_cqm else ""),

--- a/fastflix/encoders/qsvencc_av1/settings_panel.py
+++ b/fastflix/encoders/qsvencc_av1/settings_panel.py
@@ -131,8 +131,8 @@ class QSVAV1Enc(QSVEncPanel):
         # adapt_line.addLayout(self.init_adapt_cqm())
         # grid.addLayout(adapt_line, 7, 2, 1, 4)
         #
-        grid.addLayout(self.init_dhdr10_info(), 7, 2, 1, 4)
-
+        grid.addLayout(self.init_dhdr10_info(), 7, 2, 1, 2)
+        grid.addLayout(self.init_parallel_mode(), 7, 4, 1, 2)
         self.ffmpeg_level = QtWidgets.QLabel()
         grid.addWidget(self.ffmpeg_level, 8, 2, 1, 4)
 
@@ -340,6 +340,7 @@ class QSVAV1Enc(QSVEncPanel):
             adapt_ltr=self.widgets.adapt_ltr.isChecked(),
             adapt_cqm=self.widgets.adapt_cqm.isChecked(),
             adapt_ref=self.widgets.adapt_ref.isChecked(),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/qsvencc_avc/command_builder.py
+++ b/fastflix/encoders/qsvencc_avc/command_builder.py
@@ -119,6 +119,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-yadif" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        "--parallel auto" if settings.split_mode == "parallel" else "",
         ("--adapt-ref" if settings.adapt_ref else ""),
         ("--adapt-ltr" if settings.adapt_ltr else ""),
         ("--adapt-cqm" if settings.adapt_cqm else ""),

--- a/fastflix/encoders/qsvencc_avc/settings_panel.py
+++ b/fastflix/encoders/qsvencc_avc/settings_panel.py
@@ -124,6 +124,7 @@ class QSVEncH264(QSVEncPanel):
 
         self.ffmpeg_level = QtWidgets.QLabel()
         grid.addWidget(self.ffmpeg_level, 8, 2, 1, 4)
+        grid.addLayout(self.init_parallel_mode(), 7, 4, 1, 2)
 
         grid.setRowStretch(9, 1)
 
@@ -333,6 +334,7 @@ class QSVEncH264(QSVEncPanel):
             adapt_ltr=self.widgets.adapt_ltr.isChecked(),
             adapt_cqm=self.widgets.adapt_cqm.isChecked(),
             adapt_ref=self.widgets.adapt_ref.isChecked(),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/qsvencc_hevc/command_builder.py
+++ b/fastflix/encoders/qsvencc_hevc/command_builder.py
@@ -138,6 +138,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-yadif" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        "--parallel auto" if settings.split_mode == "parallel" else "",
         ("--adapt-ref" if settings.adapt_ref else ""),
         ("--adapt-ltr" if settings.adapt_ltr else ""),
         ("--adapt-cqm" if settings.adapt_cqm else ""),

--- a/fastflix/encoders/qsvencc_hevc/settings_panel.py
+++ b/fastflix/encoders/qsvencc_hevc/settings_panel.py
@@ -123,8 +123,8 @@ class QSVEnc(QSVEncPanel):
         advanced.addLayout(self.init_metrics())
         grid.addLayout(advanced, 6, 2, 1, 4)
 
-        grid.addLayout(self.init_dhdr10_info(), 7, 2, 1, 4)
-
+        grid.addLayout(self.init_dhdr10_info(), 7, 2, 1, 2)
+        grid.addLayout(self.init_parallel_mode(), 7, 4, 1, 2)
         self.ffmpeg_level = QtWidgets.QLabel()
         grid.addWidget(self.ffmpeg_level, 8, 2, 1, 4)
 
@@ -333,6 +333,7 @@ class QSVEnc(QSVEncPanel):
             adapt_ltr=self.widgets.adapt_ltr.isChecked(),
             adapt_cqm=self.widgets.adapt_cqm.isChecked(),
             adapt_ref=self.widgets.adapt_ref.isChecked(),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/svt_av1/command_builder.py
+++ b/fastflix/encoders/svt_av1/command_builder.py
@@ -77,7 +77,7 @@ def build(fastflix: FastFlix):
         beginning += f" -svtav1-params \"{':'.join(svtav1_params)}\" "
 
     if not settings.single_pass:
-        pass_log_file = fastflix.current_video.work_path / f"pass_log_file_{secrets.token_hex(10)}"
+        pass_log_file = f"pass_log_file_{secrets.token_hex(10)}"
         beginning += f'-passlogfile "{pass_log_file}" '
 
     pass_type = "bitrate" if settings.bitrate else "QP"

--- a/fastflix/encoders/svt_av1/settings_panel.py
+++ b/fastflix/encoders/svt_av1/settings_panel.py
@@ -70,7 +70,7 @@ class SVT_AV1(SettingPanel):
 
         self.widgets = Box(fps=None, mode=None, segment_size=None)
 
-        self.mode = "QP"
+        self.mode = "CRF"
 
         grid.addLayout(self.init_preset(), 0, 0, 1, 2)
         grid.addLayout(self.init_pix_fmt(), 1, 0, 1, 2)
@@ -80,7 +80,7 @@ class SVT_AV1(SettingPanel):
         grid.addLayout(self.init_sc_detection(), 4, 0, 1, 2)
         grid.addLayout(self.init_max_mux(), 5, 0, 1, 2)
         grid.addLayout(self.init_modes(), 0, 2, 5, 4)
-        grid.addLayout(self.init_single_pass(), 6, 2, 1, 1)
+        # grid.addLayout(self.init_single_pass(), 6, 2, 1, 1)
         grid.addLayout(self.init_svtav1_params(), 5, 2, 1, 4)
 
         grid.setRowStretch(8, 1)
@@ -130,13 +130,13 @@ class SVT_AV1(SettingPanel):
             label="Scene Detection", options=["false", "true"], widget_name="sc_detection", opt="scene_detection"
         )
 
-    def init_single_pass(self):
-        return self._add_check_box(
-            label="Single Pass",
-            widget_name="single_pass",
-            tooltip="Single Pass Encoding",
-            opt="single_pass",
-        )
+    # def init_single_pass(self):
+    #     return self._add_check_box(
+    #         label="Single Pass",
+    #         widget_name="single_pass",
+    #         tooltip="Single Pass Encoding",
+    #         opt="single_pass",
+    #     )
 
     def init_preset(self):
         return self._add_combo_box(
@@ -151,7 +151,7 @@ class SVT_AV1(SettingPanel):
         return self._add_combo_box(
             label="Quantization Mode",
             widget_name="qp_mode",
-            options=["qp", "crf"],
+            options=["crf", "qp"],
             tooltip="Use CRF or QP",
             opt="qp_mode",
         )
@@ -174,7 +174,7 @@ class SVT_AV1(SettingPanel):
         return layout
 
     def init_modes(self):
-        return self._add_modes(recommended_bitrates, recommended_qp, qp_name="qp")
+        return self._add_modes(recommended_bitrates, recommended_qp, qp_name="qp", qp_display_name="CRF/QP")
 
     def mode_update(self):
         self.widgets.custom_qp.setDisabled(self.widgets.qp.currentText() != "Custom")
@@ -188,7 +188,8 @@ class SVT_AV1(SettingPanel):
             speed=self.widgets.speed.currentText(),
             tile_columns=self.widgets.tile_columns.currentText(),
             tile_rows=self.widgets.tile_rows.currentText(),
-            single_pass=self.widgets.single_pass.isChecked(),
+            # single_pass=self.widgets.single_pass.isChecked(),
+            single_pass=True,
             scene_detection=bool(self.widgets.sc_detection.currentIndex()),
             qp_mode=self.widgets.qp_mode.currentText(),
             pix_fmt=self.widgets.pix_fmt.currentText().split(":")[1].strip(),

--- a/fastflix/encoders/vceencc_av1/command_builder.py
+++ b/fastflix/encoders/vceencc_av1/command_builder.py
@@ -139,6 +139,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-nnedi" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        "--parallel auto" if settings.split_mode == "parallel" else "",
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.audio_tracks, video.streams.audio),
         build_subtitle(video.subtitle_tracks, video.streams.subtitle, video_height=video.height),

--- a/fastflix/encoders/vceencc_av1/settings_panel.py
+++ b/fastflix/encoders/vceencc_av1/settings_panel.py
@@ -109,6 +109,7 @@ class VCEENCC(VCEPanel):
 
         self.init_pa_row()
         grid.addLayout(self.pa_area, 7, 0, 2, 6)
+        grid.addLayout(self.init_parallel_mode(), 8, 4, 1, 2)
         # grid.addLayout(self.pa_row_2, 8, 0, 1, 6)
 
         grid.addLayout(self.init_devices(), 9, 0, 1, 2)
@@ -304,6 +305,7 @@ class VCEENCC(VCEPanel):
             output_depth=(
                 None if self.widgets.output_depth.currentIndex() == 0 else self.widgets.output_depth.currentText()
             ),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/vceencc_avc/command_builder.py
+++ b/fastflix/encoders/vceencc_avc/command_builder.py
@@ -124,6 +124,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-nnedi" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        "--parallel auto" if settings.split_mode == "parallel" else "",
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.audio_tracks, video.streams.audio),
         build_subtitle(video.subtitle_tracks, video.streams.subtitle, video_height=video.height),

--- a/fastflix/encoders/vceencc_avc/settings_panel.py
+++ b/fastflix/encoders/vceencc_avc/settings_panel.py
@@ -110,7 +110,8 @@ class VCEENCCAVC(VCEPanel):
         grid.addLayout(qp_line, 6, 0, 1, 6)
 
         self.init_pa_row()
-        grid.addLayout(self.pa_area, 8, 0, 2, 6)
+        grid.addLayout(self.pa_area, 8, 0, 2, 4)
+        grid.addLayout(self.init_parallel_mode(), 8, 4, 1, 2)
 
         grid.setRowStretch(11, 1)
 
@@ -304,6 +305,7 @@ class VCEENCCAVC(VCEPanel):
             output_depth=(
                 None if self.widgets.output_depth.currentIndex() == 0 else self.widgets.output_depth.currentText()
             ),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/encoders/vceencc_hevc/command_builder.py
+++ b/fastflix/encoders/vceencc_hevc/command_builder.py
@@ -141,6 +141,7 @@ def build(fastflix: FastFlix):
         (f"--interlace {video.interlaced}" if video.interlaced and video.interlaced != "False" else ""),
         ("--vpp-nnedi" if video.video_settings.deinterlace else ""),
         remove_hdr,
+        "--parallel auto" if settings.split_mode == "parallel" else "",
         "--psnr --ssim" if settings.metrics else "",
         build_audio(video.audio_tracks, video.streams.audio),
         build_subtitle(video.subtitle_tracks, video.streams.subtitle, video_height=video.height),

--- a/fastflix/encoders/vceencc_hevc/settings_panel.py
+++ b/fastflix/encoders/vceencc_hevc/settings_panel.py
@@ -110,7 +110,7 @@ class VCEENCC(VCEPanel):
 
         self.init_pa_row()
         grid.addLayout(self.pa_area, 7, 0, 2, 6)
-
+        grid.addLayout(self.init_parallel_mode(), 8, 4, 1, 2)
         grid.addLayout(self.init_dhdr10_info(), 9, 2, 1, 4)
 
         self.ffmpeg_level = QtWidgets.QLabel()
@@ -298,6 +298,7 @@ class VCEENCC(VCEPanel):
             output_depth=(
                 None if self.widgets.output_depth.currentIndex() == 0 else self.widgets.output_depth.currentText()
             ),
+            split_mode=self.widgets.split_mode.currentText(),
         )
 
         encode_type, q_value = self.get_mode_settings()

--- a/fastflix/models/config.py
+++ b/fastflix/models/config.py
@@ -24,7 +24,6 @@ from fastflix.version import __version__
 from fastflix.rigaya_helpers import get_all_encoder_formats_and_devices
 
 logger = logging.getLogger("fastflix")
-
 ffmpeg_folder = Path(user_data_dir("FFmpeg", appauthor=False, roaming=True))
 
 NO_OPT = object()
@@ -109,8 +108,8 @@ class Config(BaseModel):
     nvencc: Path | None = Field(default_factory=lambda: where("NVEncC64") or where("NVEncC"))
     vceencc: Path | None = Field(default_factory=lambda: where("VCEEncC64") or where("VCEEncC"))
     qsvencc: Path | None = Field(default_factory=lambda: where("QSVEncC64") or where("QSVEncC"))
-    output_directory: Path | None = False
-    source_directory: Path | None = False
+    output_directory: Path | None = None
+    source_directory: Path | None = None
     output_name_format: str = "{source}-fastflix-{rand_4}"
     flat_ui: bool = True
     language: str = "eng"
@@ -287,6 +286,12 @@ class Config(BaseModel):
                 continue
             if key in self and key not in ("config_path", "version"):
                 setattr(self, key, Path(value) if key in paths and value else value)
+
+        if self.output_directory is False:
+            self.output_directory = None
+
+        if self.source_directory is False:
+            self.source_directory = None
 
         if not self.ffmpeg or not self.ffmpeg.exists():
             self.ffmpeg = find_ffmpeg_file("ffmpeg", raise_on_missing=True)

--- a/fastflix/models/config.py
+++ b/fastflix/models/config.py
@@ -323,7 +323,7 @@ class Config(BaseModel):
         # 5.2.0 remove ext
         self.output_name_format = self.output_name_format.replace(".{ext}", "").replace("{ext}", "")
         # if version.parse(__version__) > version.parse(data.version):
-        #     logger.info(f"Clearing possible old config values from fastflix {data.verion}")
+        #     logger.info(f"Clearing possible old config values from fastflix {data.version}")
         #     self.vceencc_encoders = []
         #     self.nvencc_encoders = []
         #     self.qsvencc_encoders = []

--- a/fastflix/models/encode.py
+++ b/fastflix/models/encode.py
@@ -497,7 +497,7 @@ class SVTAV1Settings(EncoderSettings):
     single_pass: bool = False
     speed: str = "7"  # Renamed preset in svtav1 encoder
     qp: Optional[Union[int, float]] = 24
-    qp_mode: str = "qp"
+    qp_mode: str = "crf"
     bitrate: Optional[str] = None
     svtav1_params: list[str] = Field(default_factory=list)
 

--- a/fastflix/models/encode.py
+++ b/fastflix/models/encode.py
@@ -166,6 +166,7 @@ class NVEncCSettings(EncoderSettings):
     device: int = 0
     decoder: str = "Auto"
     copy_hdr10: bool = False
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -207,6 +208,7 @@ class NVEncCAV1Settings(EncoderSettings):
     device: int = 0
     decoder: str = "Auto"
     copy_hdr10: bool = False
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -240,6 +242,7 @@ class QSVEncCSettings(EncoderSettings):
     adapt_cqm: bool = False
     adapt_ltr: bool = False
     copy_hdr10: bool = False
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -273,6 +276,7 @@ class QSVEncCAV1Settings(EncoderSettings):
     adapt_cqm: bool = False
     adapt_ltr: bool = False
     copy_hdr10: bool = False
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -305,6 +309,7 @@ class QSVEncCH264Settings(EncoderSettings):
     adapt_ref: bool = False
     adapt_cqm: bool = False
     adapt_ltr: bool = False
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -344,6 +349,7 @@ class NVEncCAVCSettings(EncoderSettings):
     b_ref_mode: str = "disabled"
     device: int = 0
     decoder: str = "Auto"
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -386,6 +392,7 @@ class VCEEncCSettings(EncoderSettings):
     pa_motion_quality: str | None = None
     output_depth: str | None = None
     copy_hdr10: bool = False
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -428,6 +435,7 @@ class VCEEncCAV1Settings(EncoderSettings):
     pa_motion_quality: str | None = None
     output_depth: str | None = None
     copy_hdr10: bool = False
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod
@@ -469,6 +477,7 @@ class VCEEncCAVCSettings(EncoderSettings):
     pa_taq: int | None = None
     pa_motion_quality: str | None = None
     output_depth: str | None = None
+    split_mode: str = "none"
 
     @field_validator("cqp", mode="before")
     @classmethod

--- a/fastflix/shared.py
+++ b/fastflix/shared.py
@@ -199,7 +199,7 @@ def latest_fastflix(app, show_new_dialog=False):
             title=t("New Version"),
         )
         return
-    logger.debug("FastFlix is up tp date")
+    logger.debug("FastFlix is up to date")
     if show_new_dialog:
         message(t(f"You are using the latest version of FastFlix") + f" <br>")  # <br> {contrib} 💓 <br>
 

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "5.10.0"
+__version__ = "5.10.1"
 __author__ = "Chris Griffith"

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "5.10.1"
+__version__ = "5.11.0"
 __author__ = "Chris Griffith"

--- a/fastflix/widgets/changes.py
+++ b/fastflix/widgets/changes.py
@@ -31,7 +31,7 @@ class Changes(QtWidgets.QScrollArea):
             content = local_package_changes_file.read_text(encoding="utf-8", errors="ignore")
         else:
             if not local_changes_file.exists():
-                raise Exception("Could not locate changlog file")
+                raise Exception("Could not locate changelog file")
             content = local_changes_file.read_text(encoding="utf-8", errors="ignore")
 
         linked_content = issues.sub(

--- a/fastflix/widgets/settings.py
+++ b/fastflix/widgets/settings.py
@@ -351,12 +351,12 @@ class Settings(QtWidgets.QWidget):
             restart_needed = True
         self.app.fastflix.config.hdr10plus_parser = new_hdr10_parser
 
-        new_output_path = False
+        new_output_path = None
         if self.output_path_line_edit.text().strip() and not self.default_output_dir.isChecked():
             new_output_path = Path(self.output_path_line_edit.text())
         self.app.fastflix.config.output_directory = new_output_path
 
-        new_source_path = False
+        new_source_path = None
         if self.source_path_line_edit.text().strip() and not self.default_source_dir.isChecked():
             new_source_path = Path(self.source_path_line_edit.text())
         self.app.fastflix.config.source_directory = new_source_path

--- a/fastflix/widgets/windows/audio_conversion.py
+++ b/fastflix/widgets/windows/audio_conversion.py
@@ -3,10 +3,10 @@ import logging
 
 from PySide6 import QtWidgets, QtGui
 
+from fastflix.exceptions import FastFlixError
 from fastflix.models.fastflix_app import FastFlixApp
 from fastflix.models.encode import AudioTrack
-
-
+from fastflix.shared import error_message
 from fastflix.language import t
 
 __all__ = ["AudioConversion"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pathvalidate>=2.4,<3.0",
     "psutil>=5.9,<6.0",
     "pydantic>=2.0,<3.0",
-    "pyside6==6.7.2",
+    "pyside6==6.9.0",
     "python-box[all]>=6.0,<7.0",
     "requests>=2.28,<3.0",
     "reusables>=0.9.6,<0.10.0",


### PR DESCRIPTION
* Adding parallel encoding options for rigaya hardware encoders (thanks to Hexenhammer)
* Adding builds for Ubuntu 22.04 and mac 13 again
* Changing SVT-AV1 to single pass only due to ffmpeg not allowing passlog files properly
* Changing SVT-AV1 to CRF quantization mode by default
* Fixing #642 Possible to create a profile without bitrate specified for audio stream (thanks to Xoanon88)
* Fixing #644 various typos (thanks to luzpaz)
* Fixing #646 PydanticSerializationUnexpectedValue warning during startup (thanks to Noelle Leigh)
* Fixing #647 another typo (thanks to Noelle Leigh)
* Fixing #649 1-Pass Bitrate stored in x265 profile not honored (thanks to Xoanon88)
* Fixing how program is centered on multiple monitors
* Fixing do not pass infer_no_subs to encc encoders