### PR TITLE
AVC: Check for `custom_crf` before access

### DIFF
--- a/fastflix/encoders/avc_x264/settings_panel.py
+++ b/fastflix/encoders/avc_x264/settings_panel.py
@@ -154,7 +154,8 @@ class AVC(SettingPanel):
         return self._add_modes(recommended_bitrates, recommended_crfs, qp_name="crf", show_bitrate_passes=True)
 
     def mode_update(self):
-        self.widgets.custom_crf.setDisabled(self.widgets.crf.currentText() != "Custom")
+        if "custom_crf" in self.widgets:
+            self.widgets.custom_crf.setDisabled(self.widgets.crf.currentText() != "Custom")
         self.widgets.custom_bitrate.setDisabled(self.widgets.bitrate.currentText() != "Custom")
         self.main.build_commands()
 


### PR DESCRIPTION
Fixes this error on startup:

```
2025-05-03 08:31:08 leela fastflix[45905] INFO Running task Initialize Encoders
Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 504, in __getitem__
    return super().__getitem__(item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'custom_crf'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 537, in __getattr__
    value = self.__getitem__(item, _ignore_default=True)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 525, in __getitem__
    raise BoxKeyError(str(err)) from _exception_cause(err)
box.exceptions.BoxKeyError: "'custom_crf'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 539, in __getattr__
    value = object.__getattribute__(self, item)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Box' object has no attribute 'custom_crf'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/fastflix/encoders/common/setting_panel.py", line 378, in <lambda>
    self.widgets.bitrate_passes.currentIndexChanged.connect(lambda: self.mode_update())
                                                                    ^^^^^^^^^^^^^^^^^^
  File "/home/noelle/dev/FastFlix/fastflix/encoders/avc_x264/settings_panel.py", line 157, in mode_update
    self.widgets.custom_crf.setDisabled(self.widgets.crf.currentText() != "Custom")
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 553, in __getattr__
    raise BoxKeyError(str(err)) from _exception_cause(err)
box.exceptions.BoxKeyError: "'Box' object has no attribute 'custom_crf'"
Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 504, in __getitem__
    return super().__getitem__(item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'custom_crf'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 537, in __getattr__
    value = self.__getitem__(item, _ignore_default=True)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 525, in __getitem__
    raise BoxKeyError(str(err)) from _exception_cause(err)
box.exceptions.BoxKeyError: "'custom_crf'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 539, in __getattr__
    value = object.__getattribute__(self, item)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Box' object has no attribute 'custom_crf'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/noelle/dev/FastFlix/fastflix/encoders/common/setting_panel.py", line 378, in <lambda>
    self.widgets.bitrate_passes.currentIndexChanged.connect(lambda: self.mode_update())
                                                                    ^^^^^^^^^^^^^^^^^^
  File "/home/noelle/dev/FastFlix/fastflix/encoders/avc_x264/settings_panel.py", line 157, in mode_update
    self.widgets.custom_crf.setDisabled(self.widgets.crf.currentText() != "Custom")
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/noelle/dev/FastFlix/.venv/lib/python3.12/site-packages/box/box.py", line 553, in __getattr__
    raise BoxKeyError(str(err)) from _exception_cause(err)
box.exceptions.BoxKeyError: "'Box' object has no attribute 'custom_crf'"
```