### PR TITLE
Version 6.0.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 6.0.1
+
+* Fixing Dolby Vision copy for Rigaya encoders (NVEncC, QSVEncC, VCEEncC) by adding --dolby-vision-profile copy alongside --dolby-vision-rpu copy
+* Fixing Readme to list AOM-AV1 as having HDR10+ support
+
+
 ## Version 6.0.0
 
 * Adding #709 PGS to SRT OCR subtitle extraction feature (thanks to mikeSGman)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Check out [the FastFlix github wiki](https://github.com/cdgriffith/FastFlix/wiki
 | Encoder   | x265 | x264 | rav1e | AOM AV1 | SVT AV1 | VP9 | VVC |
 |-----------|------|------|-------|---------|---------|-----|-----|
 | HDR10     | ✓    |      | ✓     | ✓       | ✓       | ✓*  | ✓   |
-| HDR10+    | ✓    |      |       |         |         |     |     |
+| HDR10+    | ✓    |      |       | ✓       |         |     |     |
 | Audio     | ✓    | ✓    | ✓     | ✓       | ✓       | ✓   | ✓   |
 | Subtitles | ✓    | ✓    | ✓     | ✓       | ✓       |     | ✓   |
 | Covers    | ✓    | ✓    | ✓     | ✓       | ✓       |     | ✓   |

--- a/fastflix/encoders/nvencc_av1/command_builder.py
+++ b/fastflix/encoders/nvencc_av1/command_builder.py
@@ -146,6 +146,7 @@ def build(fastflix: FastFlix):
         command.extend(["--dhdr10-info", "copy"])
     if settings.copy_dv:
         command.extend(["--dolby-vision-rpu", "copy"])
+        command.extend(["--dolby-vision-profile", "copy"])
 
     command.extend(["--output-depth", bit_depth])
     command.extend(["--multipass", settings.multipass])

--- a/fastflix/encoders/nvencc_hevc/command_builder.py
+++ b/fastflix/encoders/nvencc_hevc/command_builder.py
@@ -146,6 +146,7 @@ def build(fastflix: FastFlix):
         command.extend(["--dhdr10-info", "copy"])
     if settings.copy_dv:
         command.extend(["--dolby-vision-rpu", "copy"])
+        command.extend(["--dolby-vision-profile", "copy"])
 
     command.extend(["--output-depth", bit_depth])
     command.extend(["--multipass", settings.multipass])

--- a/fastflix/encoders/qsvencc_av1/command_builder.py
+++ b/fastflix/encoders/qsvencc_av1/command_builder.py
@@ -141,6 +141,7 @@ def build(fastflix: FastFlix):
         command.extend(["--dhdr10-info", "copy"])
     if settings.copy_dv:
         command.extend(["--dolby-vision-rpu", "copy"])
+        command.extend(["--dolby-vision-profile", "copy"])
 
     command.extend(["--output-depth", bit_depth])
 

--- a/fastflix/encoders/qsvencc_hevc/command_builder.py
+++ b/fastflix/encoders/qsvencc_hevc/command_builder.py
@@ -141,6 +141,7 @@ def build(fastflix: FastFlix):
         command.extend(["--dhdr10-info", "copy"])
     if settings.copy_dv:
         command.extend(["--dolby-vision-rpu", "copy"])
+        command.extend(["--dolby-vision-profile", "copy"])
 
     command.extend(["--output-depth", bit_depth])
 

--- a/fastflix/encoders/vceencc_av1/command_builder.py
+++ b/fastflix/encoders/vceencc_av1/command_builder.py
@@ -116,6 +116,7 @@ def build(fastflix: FastFlix):
         command.extend(["--dhdr10-info", "copy"])
     if settings.copy_dv:
         command.extend(["--dolby-vision-rpu", "copy"])
+        command.extend(["--dolby-vision-profile", "copy"])
 
     command.extend(["--output-depth", output_depth])
     command.extend(["--motion-est", settings.mv_precision])

--- a/fastflix/encoders/vceencc_hevc/command_builder.py
+++ b/fastflix/encoders/vceencc_hevc/command_builder.py
@@ -117,6 +117,7 @@ def build(fastflix: FastFlix):
         command.extend(["--dhdr10-info", "copy"])
     if settings.copy_dv:
         command.extend(["--dolby-vision-rpu", "copy"])
+        command.extend(["--dolby-vision-profile", "copy"])
 
     command.extend(["--output-depth", output_depth])
     command.extend(["--motion-est", settings.mv_precision])

--- a/fastflix/version.py
+++ b/fastflix/version.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "6.0.0"
+__version__ = "6.0.1"
 __author__ = "Chris Griffith"


### PR DESCRIPTION
* Fixing Dolby Vision copy for Rigaya encoders (NVEncC, QSVEncC, VCEEncC) by adding --dolby-vision-profile copy alongside --dolby-vision-rpu copy
* Fixing Readme to list AOM-AV1 as having HDR10+ support