### PR TITLE
Fix PyInstaller `LD_LIBRARY_PATH` contamination breaking FFmpeg on Linux

### DIFF
--- a/fastflix/command_runner.py
+++ b/fastflix/command_runner.py
@@ -14,6 +14,8 @@ import sys
 
 from psutil import Popen
 
+from fastflix.shared import clean_env
+
 try:
     from psutil import (
         HIGH_PRIORITY_CLASS,
@@ -93,6 +95,7 @@ class BackgroundRunner:
                 stderr=stderr_handle,
                 stdin=PIPE,  # FFmpeg can try to read stdin and wrecks havoc on linux
                 encoding="utf-8",
+                env=clean_env(),
             )
         except PermissionError:
             logger.error(

--- a/fastflix/flix.py
+++ b/fastflix/flix.py
@@ -16,6 +16,7 @@ from fastflix.exceptions import FlixError
 from fastflix.language import t
 from fastflix.models.config import Config
 from fastflix.models.fastflix_app import FastFlixApp
+from fastflix.shared import clean_env
 
 here = os.path.abspath(os.path.dirname(__file__))
 re_tff = re.compile(r"TFF:\s+(\d+)")
@@ -151,6 +152,7 @@ def execute(command: List, work_dir: Union[Path, str] = None, timeout: int = Non
         cwd=work_dir,
         timeout=timeout,
         encoding="utf-8",
+        env=clean_env(),
     )
 
 
@@ -361,6 +363,7 @@ def extract_attachment(ffmpeg: Path, source: Path, stream: int, work_dir: Path, 
             stderr=PIPE,
             stdin=PIPE,
             cwd=work_dir,
+            env=clean_env(),
         )
         try:
             stdout, _ = proc.communicate(timeout=3)
@@ -732,6 +735,7 @@ def _detect_hdr10_plus_tool(app: FastFlixApp, config: Config, stream) -> bool:
         stdout=PIPE,
         stderr=PIPE,
         stdin=PIPE,  # FFmpeg can try to read stdin and wrecks havoc
+        env=clean_env(),
     )
 
     parser_version = get_hdr10_parser_version(config)

--- a/fastflix/rigaya_helpers.py
+++ b/fastflix/rigaya_helpers.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass, field
 from subprocess import run, PIPE
 
+from fastflix.shared import clean_env
 
 @dataclass
 class Encoder:
@@ -72,11 +73,11 @@ def parse_qsv_devices(split_text: list[str]) -> QSVEncoder:
 def run_check_features(executable, is_qsv=False):
     outputs = []
     if is_qsv:
-        result = run([executable, "--check-features"], stdout=PIPE, stderr=PIPE, encoding="utf-8")
+        result = run([executable, "--check-features"], stdout=PIPE, stderr=PIPE, encoding="utf-8", env=clean_env())
         outputs.append(result.stdout.splitlines())
     else:
         for i in range(10):
-            result = run([executable, "--check-features", str(i)], stdout=PIPE, stderr=PIPE, encoding="utf-8")
+            result = run([executable, "--check-features", str(i)], stdout=PIPE, stderr=PIPE, encoding="utf-8", env=clean_env())
             if result.stderr:
                 break
             outputs.append(result.stdout.splitlines())

--- a/fastflix/shared.py
+++ b/fastflix/shared.py
@@ -25,6 +25,17 @@ except AttributeError:
     base_path = os.path.abspath(".")
     pyinstaller = False
 
+def clean_env():
+    """Return a copy of os.environ with PyInstaller's LD_LIBRARY_PATH removed.
+
+    PyInstaller sets LD_LIBRARY_PATH to its bundled lib dir, which causes
+    system tools like ffmpeg to load incompatible shared libraries.
+    """
+    env = os.environ.copy()
+    if pyinstaller:
+        env.pop("LD_LIBRARY_PATH", None)
+    return env
+
 from PySide6 import QtGui, QtWidgets
 
 from fastflix.language import t

--- a/fastflix/widgets/background_tasks.py
+++ b/fastflix/widgets/background_tasks.py
@@ -11,6 +11,7 @@ from PySide6 import QtCore
 from ffmpeg_normalize import FFmpegNormalize
 
 from fastflix.flix import extract_attachments
+from fastflix.shared import clean_env
 from fastflix.language import t
 from fastflix.models.fastflix_app import FastFlixApp
 from fastflix.shared import clean_file_string
@@ -42,7 +43,7 @@ class ThumbnailCreator(QtCore.QThread):
 
     def run(self):
         self.main.thread_logging_signal.emit(f"DEBUG:{t('Generating thumbnail')}: {_format_command(self.command)}")
-        result = run(self.command, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+        result = run(self.command, stdin=PIPE, stdout=PIPE, stderr=STDOUT, env=clean_env())
         if result.returncode > 0:
             if "No such filter: 'zscale'" in result.stdout.decode(encoding="utf-8", errors="ignore"):
                 self.main.thread_logging_signal.emit(
@@ -156,6 +157,7 @@ class ExtractSubtitleSRT(QtCore.QThread):
                 command,
                 stdout=PIPE,
                 stderr=STDOUT,
+                env=clean_env(),
             )
             stdout, _ = self._process.communicate()
             returncode = self._process.returncode
@@ -224,6 +226,7 @@ class ExtractSubtitleSRT(QtCore.QThread):
                 stdout=PIPE,
                 stderr=STDOUT,
                 text=True,
+                env=clean_env(),
             )
 
             if result.returncode != 0:
@@ -530,6 +533,7 @@ class ExtractHDR10(QtCore.QThread):
             stdout=PIPE,
             stderr=open(self.app.fastflix.current_video.work_path / "hdr10extract_out.txt", "wb"),
             # stdin=PIPE,  # FFmpeg can try to read stdin and wrecks havoc
+            env=clean_env(),
         )
 
         process_two = Popen(
@@ -539,6 +543,7 @@ class ExtractHDR10(QtCore.QThread):
             stdin=process.stdout,
             encoding="utf-8",
             cwd=str(self.app.fastflix.current_video.work_path),
+            env=clean_env(),
         )
 
         with open(self.app.fastflix.current_video.work_path / "hdr10extract_out.txt", "r", encoding="utf-8") as f:

--- a/fastflix/widgets/main_post_encode.py
+++ b/fastflix/widgets/main_post_encode.py
@@ -141,7 +141,8 @@ class PostEncodeMixin:
             from subprocess import run as subprocess_run
 
             from fastflix.flix import generate_thumbnail_command
-
+            from fastflix.shared import clean_env
+            
             thumb_command = generate_thumbnail_command(
                 config=self.app.fastflix.config,
                 source=video.source,
@@ -150,7 +151,7 @@ class PostEncodeMixin:
                 start_time=video.video_settings.start_time or 0,
                 input_track=video.video_settings.selected_track,
             )
-            result = subprocess_run(thumb_command, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+            result = subprocess_run(thumb_command, stdin=PIPE, stdout=PIPE, stderr=STDOUT, env=clean_env())
             if result.returncode != 0 or not thumb_output.exists():
                 logger.warning("Failed to generate thumbnail for history entry")
                 entry.thumbnail_filename = ""

--- a/fastflix/widgets/windows/crop_window.py
+++ b/fastflix/widgets/windows/crop_window.py
@@ -9,6 +9,7 @@ from PySide6 import QtWidgets, QtCore, QtGui
 
 from fastflix.encoders.common import helpers
 from fastflix.flix import generate_thumbnail_command
+from fastflix.shared import clean_env
 from fastflix.language import t
 from fastflix.shared import time_to_number
 from fastflix.ui_scale import scaler
@@ -690,7 +691,7 @@ class CropPreviewWindow(QtWidgets.QWidget):
 
         logger.info(f"Generating crop preview: {thumb_command}")
 
-        thumb_run = run(thumb_command, shell=True, stderr=PIPE, stdout=PIPE)
+        thumb_run = run(thumb_command, shell=True, stderr=PIPE, stdout=PIPE, env=clean_env())
         if thumb_run.returncode > 0:
             logger.warning(f"Could not generate crop preview: {thumb_run.stdout} |----| {thumb_run.stderr}")
             return

--- a/fastflix/widgets/windows/large_preview.py
+++ b/fastflix/widgets/windows/large_preview.py
@@ -10,6 +10,7 @@ from PySide6 import QtWidgets, QtCore, QtGui
 from fastflix.flix import (
     generate_thumbnail_command,
 )
+from fastflix.shared import clean_env
 from fastflix.encoders.common import helpers
 from fastflix.resources import get_icon
 from fastflix.language import t
@@ -93,7 +94,7 @@ class LargePreview(QtWidgets.QWidget):
 
         logger.info(f"Generating large thumbnail: {thumb_command}")
 
-        thumb_run = run(thumb_command, shell=True, stderr=PIPE, stdout=PIPE)
+        thumb_run = run(thumb_command, shell=True, stderr=PIPE, stdout=PIPE, env=clean_env())
         if thumb_run.returncode > 0:
             logger.warning(f"Could not generate large thumbnail: {thumb_run.stdout} |----| {thumb_run.stderr}")
             return


### PR DESCRIPTION
When running from a PyInstaller-built binary (e.g. the `fastflix-bin` AUR package), FFmpeg fails to launch with:
`/usr/bin/ffmpeg: symbol lookup error: /usr/lib/libass.so.9: undefined symbol: FcConfigSetDefaultSubstitute`

PyInstaller sets  `LD_LIBRARY_PATH` to its bundled library directory at startup. 

When FastFlix spawns `/usr/bin/ffmpeg` as a subprocess, FFmpeg inherits this contaminated path and loads the bundled `libass.so` (built for Ubuntu 24.04) instead of the system one, causing a symbol mismatch with the system `fontconfig`.

This affects any Linux distribution where the system library versions differ from those bundled in the PyInstaller binary.

---

Added a `clean_env()` helper in `fastflix/shared.py` that strips `LD_LIBRARY_PATH` from the environment when running in a frozen PyInstaller app.

This is applied to all subprocess calls (run, Popen) that invoke FFmpeg, FFprobe, or related tools